### PR TITLE
feat: ✨ update url reference from datajoint.com/docs/ to docs.datajoint.com | fix: element user guild mermaid chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # DataJoint Documentation
 
-This is the home for DataJoint software documentation as hosted at https://datajoint.com/docs
-
+This is the home for DataJoint software documentation as hosted at https://docs.datajoint.com
 ## VSCode Linter Extensions and Settings
 
 The following extensions were used in developing these docs, with the corresponding
@@ -39,7 +38,7 @@ Then install the required packages:
 pip install -r pip_requirements.txt
 ```
 
-Run mkdocs at: http://127.0.0.1:8000/docs/
+Run mkdocs at: http://127.0.0.1:8000/
 ```bash
 # It will automatically reload the docs when changes are made
 mkdocs serve --config-file ./mkdocs.yaml
@@ -57,7 +56,7 @@ Then run the following:
 MODE="LIVE" docker compose up --build
 ```
 
-Navigate to http://127.0.0.1:8000/docs/ to preview the changes.
+Navigate to http://127.0.0.1:8000/ to preview the changes.
 
 This setup supports live-reloading so all that is needed is to save the markdown files
 and/or `mkdocs.yaml` file to trigger a reload.
@@ -77,10 +76,9 @@ INFO    -  Doc file 'index.md' contains an unrecognized relative link './core/da
   - You hit `datajoint.com/*` on your browser
   - It'll bring you to the reverse proxy server first, that you wouldn't notice
   - when your URL ends with:
-    - `/` is the company page
-    - `/docs/` is the landing/navigation page hosted by datajoint/datajoint-docs's github pages
-    - `/docs/core/datajoint-python/` is the actual docs site hosted by datajoint/datajoint-python's github pages
-    - `/docs/elements/element-*/` is the actual docs site hosted by each element's github pages
+    - `/` is the landing/navigation page hosted by datajoint/datajoint-docs's github pages
+    - `/core/datajoint-python/` is the actual docs site hosted by datajoint/datajoint-python's github pages
+    - `/elements/element-*/` is the actual docs site hosted by each element's github pages
 
 
 ```log

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 # MODE="LIVE|BUILD" docker compose up --build
 #
-# Navigate to http://localhost/docs/
+# Navigate to http://localhost:8000/
 services:
   docs:
     # image: datajoint/datajoint-docs

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -71,6 +71,7 @@ theme:
         name: Switch to light mode
 plugins:
   - search
+  - mermaid2
   - section-index
   # There is no welcome.md anymore
   # - redirects:
@@ -96,7 +97,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
+          format: !!python/name:mermaid2.fence_mermaid_custom
   - pymdownx.tabbed:
       alternate_style: true
   - footnotes

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -5,3 +5,4 @@ mdx_truly_sane_lists
 mkdocs-pymdownx-material-extras
 pymdown-extensions
 mkdocs-section-index
+mkdocs-mermaid2-plugin

--- a/src/additional-resources.md
+++ b/src/additional-resources.md
@@ -12,7 +12,7 @@ A collection of additional open-source tools for building and operating scientif
 
     A MATLAB client for defining, operating, and querying data pipelines.
 
-    :octicons-arrow-right-24: [Legacy docs](https://docs.datajoint.org/matlab/) | 
+    :octicons-arrow-right-24: [Legacy docs](https://datajoint.github.io/datajoint-docs-original/matlab/) | 
     [Source code](https://github.com/datajoint/datajoint-matlab)
 
 -   :fontawesome-solid-flask:{ .lg .middle } **DataJoint Pharus**
@@ -21,7 +21,7 @@ A collection of additional open-source tools for building and operating scientif
 
     A REST API server for interacting with DataJoint pipelines.
 
-    :octicons-arrow-right-24: [Docs](https://datajoint.com/docs/core/pharus) | 
+    :octicons-arrow-right-24: [Docs](https://docs.datajoint.com/core/pharus) | 
     [Source code](https://github.com/datajoint/pharus/)
  
 </div>
@@ -36,8 +36,7 @@ A collection of additional open-source tools for building and operating scientif
 
     A browser-based graphical user interface for data entry and navigation. 
 
-    :octicons-arrow-right-24: [Legacy 
-    docs](https://datajoint.com/docs/core/datajoint-labbook/) | 
+    :octicons-arrow-right-24: [Legacy docs](https://datajoint.github.io/datajoint-labbook/) | 
     [Source code](https://github.com/datajoint/datajoint-labbook/)
 
 -   :fontawesome-brands-chrome:{ .lg .middle } **DataJoint SciViz**
@@ -46,7 +45,7 @@ A collection of additional open-source tools for building and operating scientif
 
     A framework for making low-code web apps for data visualization.
 
-    :octicons-arrow-right-24: [Legacy docs](https://datajoint.com/docs/core/sci-viz/) | 
+    :octicons-arrow-right-24: [Docs](https://docs.datajoint.com/core/sci-viz/) | 
     [Source code](https://github.com/datajoint/sci-viz)
 
 </div>
@@ -78,8 +77,7 @@ graph
     ---
     MySQL server configured to work with DataJoint.
 
-    :octicons-arrow-right-24: [Docker 
-    image](https://hub.docker.com/r/datajoint/mysql) | 
+    :octicons-arrow-right-24: [Docker image](https://hub.docker.com/r/datajoint/mysql) | 
     [Source code](https://github.com/datajoint/mysql-docker)
 
 -   :fontawesome-brands-docker:{ .lg .middle } **datajoint/miniconda3**
@@ -88,8 +86,7 @@ graph
 
     Minimal Python Docker image with [conda](https://docs.conda.io/en/latest/).
 
-    :octicons-arrow-right-24: [Docker
-    image](https://hub.docker.com/r/datajoint/miniconda3) | 
+    :octicons-arrow-right-24: [Docker image](https://hub.docker.com/r/datajoint/miniconda3) | 
     [Legacy docs](https://datajoint.github.io/miniconda3-docker/) | 
     [Source code](https://github.com/datajoint/miniconda3-docker)
 
@@ -99,8 +96,7 @@ graph
 
     Minimal base Docker image with DataJoint Python dependencies installed. 
 
-    :octicons-arrow-right-24: [Docker 
-    image](https://hub.docker.com/r/datajoint/djbase) | 
+    :octicons-arrow-right-24: [Docker image](https://hub.docker.com/r/datajoint/djbase) | 
     [Legacy docs](https://datajoint.github.io/djbase-docker/) | 
     [Source code](https://github.com/datajoint/djbase-docker)
 
@@ -110,8 +106,7 @@ graph
 
     Docker image for running tests related to DataJoint Python. 
 
-    :octicons-arrow-right-24: [Docker 
-    image](https://hub.docker.com/r/datajoint/djtest) | 
+    :octicons-arrow-right-24: [Docker image](https://hub.docker.com/r/datajoint/djtest) | 
     [Legacy docs](https://datajoint.github.io/djtest-docker/) | 
     [Source code](https://github.com/datajoint/djtest-docker)
 
@@ -121,8 +116,7 @@ graph
 
     Official DataJoint Docker image.
 
-    :octicons-arrow-right-24: [Docker
-    image](https://hub.docker.com/r/datajoint/datajoint) | 
+    :octicons-arrow-right-24: [Docker image](https://hub.docker.com/r/datajoint/datajoint) | 
     [Source code](https://github.com/datajoint/datajoint-python)
 
 -   :fontawesome-brands-docker:{ .lg .middle } **datajoint/djlab**
@@ -131,9 +125,7 @@ graph
 
     Docker image optimized for running a JupyterLab environment with DataJoint Python. 
 
-    :octicons-arrow-right-24: [Docker 
-    image](https://hub.docker.com/r/datajoint/djlab) | 
-    [Legacy docs](https://datajoint.github.io/djlab-docker/) | 
+    :octicons-arrow-right-24: [Docker image](https://hub.docker.com/r/datajoint/djlab) | 
     [Source code](https://github.com/datajoint/djlab-docker)
 
 -   :fontawesome-brands-docker:{ .lg .middle } **datajoint/djlabhub**
@@ -143,9 +135,7 @@ graph
     Docker image optimized for deploying to JupyterHub a JupyterLab environment with 
     DataJoint Python. 
 
-    :octicons-arrow-right-24: [Docker 
-    image](https://hub.docker.com/r/datajoint/djlabhub) | 
-    [Legacy docs](https://datajoint.github.io/djlabhub-docker/) | 
+    :octicons-arrow-right-24: [Docker image](https://hub.docker.com/r/datajoint/djlabhub) | 
     [Source code](https://github.com/datajoint/djlabhub-docker)
 
 </div>

--- a/src/elements/management/dissemination.md
+++ b/src/elements/management/dissemination.md
@@ -5,7 +5,7 @@
 We conduct activities to disseminate Resource components for adoption in diverse
 neuroscience labs. These activities include
 
-- A central [website](https://datajoint.com/docs/elements/) for the Resource.
+- A central [website](https://docs.datajoint.com/elements/) for the Resource.
 - [Conference talks, presentations, and workshops](../../support-events.md)
 - Publications in peer-reviewed journals
 - White papers posted on internet resources and websites

--- a/src/elements/user-guide.md
+++ b/src/elements/user-guide.md
@@ -42,27 +42,20 @@ This diagram describes the general components for a local DataJoint environment.
 
 ```mermaid
 flowchart LR
-  py_interp  -->|DataJoint| db_server[("Database Server\n(e.g., MySQL)")]
-  subgraph conda["Conda environment"]
-    direction TB
-    py_interp[Python Interpreter]
-  end
-  subgraph empty1[" "] %% Empty subgraphs prevent overlapping titles
-    direction TB
-    style empty1 fill:none, stroke-dasharray: 0 1
-    conda
-  end
-  subgraph term["Terminal or Jupyter Notebook"]
-    direction TB
-    empty1
-  end
-  subgraph empty2[" "] %% Empty subgraphs prevent overlapping titles
-    direction TB
-    style empty2 fill:none, stroke-dasharray: 0 1
-    term
-  end
-  class py_interp,conda,term,ide,db_server,DataJoint boxes;
-  classDef boxes fill:#ddd, stroke:#333;
+  %% Nodes
+  py_interp["Python Interpreter"]
+  db_server["Database Server<br>(e.g., MySQL)"]
+  conda_env["Conda Environment"]
+  terminal["Terminal or Jupyter Notebook"]
+
+  %% Edges
+  py_interp -->|DataJoint| db_server
+  terminal --> conda_env
+  conda_env --> py_interp
+
+  %% Styling
+  classDef boxes fill:#ddd,stroke:#333;
+  class py_interp,db_server,conda_env,terminal boxes;
 ```
 
 ### Python

--- a/src/partnerships/dandi.md
+++ b/src/partnerships/dandi.md
@@ -20,9 +20,9 @@ integration and interoperability across the two ecosystems.
 
 ### DataJoint
 
-**DataJoint Elements** — https://datajoint.com/docs/elements/ — is a collection of
+**DataJoint Elements** — https://docs.datajoint.com/elements/ — is a collection of
   open-source reference database schemas and analysis workflows for neurophysiology
-  experiments, supported by **DataJoint** — https://datajoint.com/docs/core/ — an
+  experiments, supported by **DataJoint** — https://docs.datajoint.com/core/ — an
   open-source software framework. The project is funded by the NIH grant U24 NS116470
   and led by Dr. Dimitri Yatsenko.
   

--- a/src/partnerships/facemap.md
+++ b/src/partnerships/facemap.md
@@ -20,9 +20,9 @@ across the two ecosystems.
 
 ### DataJoint
 
-**DataJoint Elements** — https://datajoint.com/docs/elements/ — is a collection of
+**DataJoint Elements** — https://docs.datajoint.com/elements/ — is a collection of
   open-source reference database schemas and analysis workflows for neurophysiology
-  experiments, supported by **DataJoint** — https://datajoint.com/docs/core/ — an
+  experiments, supported by **DataJoint** — https://docs.datajoint.com/core/ — an
   open-source software framework. The project is funded by the NIH grant U24 NS116470
   and led by Dr. Dimitri Yatsenko.
   

--- a/src/partnerships/nwb.md
+++ b/src/partnerships/nwb.md
@@ -20,9 +20,9 @@
 
 ### DataJoint
 
-**DataJoint Elements** — https://datajoint.com/docs/elements/ — is a collection of
+**DataJoint Elements** — https://docs.datajoint.com/elements/ — is a collection of
   open-source reference database schemas and analysis workflows for neurophysiology
-  experiments, supported by **DataJoint** — https://datajoint.com/docs/core/ — an
+  experiments, supported by **DataJoint** — https://docs.datajoint.com/core/ — an
   open-source software framework. The project is funded by the NIH grant U24 NS116470
   and led by Dr. Dimitri Yatsenko.
   

--- a/src/partnerships/openephysgui.md
+++ b/src/partnerships/openephysgui.md
@@ -16,7 +16,7 @@
 
 ### DataJoint
 
-**DataJoint Elements** — https://datajoint.com/docs/elements/ — is a collection of open-source reference database schemas and analysis workflows for neurophysiology experiments, supported by **DataJoint Core** — https://datajoint.com/docs/core/ — an open-source software framework. The project is funded by the NIH grant U24 NS116470 and led by Dr. Dimitri Yatsenko.
+**DataJoint Elements** — https://docs.datajoint.com/elements/ — is a collection of open-source reference database schemas and analysis workflows for neurophysiology experiments, supported by **DataJoint Core** — https://docs.datajoint.com/core/ — an open-source software framework. The project is funded by the NIH grant U24 NS116470 and led by Dr. Dimitri Yatsenko.
 
 The principal developer of DataJoint Elements and DataJoint Core is the company
 DataJoint — https://datajoint.com.

--- a/src/partnerships/suite2p.md
+++ b/src/partnerships/suite2p.md
@@ -20,9 +20,9 @@
 
 ### DataJoint
 
-**DataJoint Elements** — https://datajoint.com/docs/elements/ — is a collection of
+**DataJoint Elements** — https://docs.datajoint.com/elements/ — is a collection of
   open-source reference database schemas and analysis workflows for neurophysiology
-  experiments, supported by **DataJoint** — https://datajoint.com/docs/core/ — an
+  experiments, supported by **DataJoint** — https://docs.datajoint.com/core/ — an
   open-source software framework. The project is funded by the NIH grant U24 NS116470
   and led by Dr. Dimitri Yatsenko.
   


### PR DESCRIPTION
- Mostly modified `additional_resources.md`, removed a few broken legacy docs. Now if the docs is a legacy doc, it'll be a redirect link to the github pages to `https://datajoint.github.io` instead of proxy from `https://docs.datajoint.com`
- Other docs that has datajoint.com/docs/ have been changed to docs.datajoint.com
- fix mermaid chart