### PR TITLE
Fix CI: skip datajoint-python install in BUILD mode

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -12,9 +12,14 @@ jobs:
       DJBOT_GH_TOKEN: ${{secrets.djbot_gh_token}}
     steps:
       - uses: actions/checkout@v2
+      - name: Checkout datajoint-python
+        uses: actions/checkout@v2
+        with:
+          repository: datajoint/datajoint-python
+          path: datajoint-python
       - name: Compile docs static artifacts
         run: |
-          BOT_PAT=$DJBOT_GH_TOKEN MODE=BUILD HOST_UID=$(id -u) docker compose up --exit-code-from docs --build
+          BOT_PAT=$DJBOT_GH_TOKEN MODE=BUILD DJ_PYTHON_PATH=./datajoint-python HOST_UID=$(id -u) docker compose up --exit-code-from docs --build
       - name: Commit documentation changes
         run: |
           git clone https://github.com/${GITHUB_REPOSITORY}.git \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
       - DJ_PASS=tutorial
     volumes:
       - .:/main
-      - ../datajoint-python:/datajoint-python
+      - ${DJ_PYTHON_PATH:-../datajoint-python}:/datajoint-python
     ports:
       - 8000:8000
     depends_on:
@@ -58,11 +58,14 @@ services:
       - -c
       - |
         set -e
-        pip install -e /datajoint-python
-        pip install scikit-image pooch
         if echo "$${MODE}" | grep -i live &>/dev/null; then
+            # LIVE mode: install datajoint and notebook dependencies for interactive development
+            pip install -e /datajoint-python
+            pip install scikit-image pooch
             mkdocs serve --config-file ./mkdocs.yaml -a 0.0.0.0:8000
         elif echo "$${MODE}" | grep -i build &>/dev/null; then
+            # BUILD mode: just build static site from pre-executed notebooks
+            # datajoint-python source is mounted for mkdocstrings API doc generation
             mkdocs build --config-file ./mkdocs.yaml
         else
             echo "Unexpected mode..."


### PR DESCRIPTION
## Problem

The Development workflow was failing with:
```
ERROR: file:///datajoint-python does not appear to be a Python project: 
neither 'setup.py' nor 'pyproject.toml' found.
```

The build was trying to `pip install -e /datajoint-python` but:
1. Notebooks are **pre-executed** - no need to install datajoint during build
2. CI hadn't checked out datajoint-python repository

## Solution

**Separated LIVE vs BUILD modes in docker-compose:**
- **LIVE mode** (local dev): Installs datajoint-python for interactive notebook development
- **BUILD mode** (CI): Skips install, just needs source code mounted for mkdocstrings API doc generation

**Added datajoint-python checkout in CI:**
- Checks out datajoint/datajoint-python as subdirectory
- Mounts at `./datajoint-python` (configurable via `DJ_PYTHON_PATH`)

## Why We Still Need datajoint-python Source

mkdocstrings parses docstrings from source files to generate API documentation. It doesn't need datajoint *installed*, just the source files present.

## Changes

- `.github/workflows/development.yml`: Added datajoint-python checkout, set DJ_PYTHON_PATH
- `docker-compose.yaml`: 
  - Separated LIVE/BUILD logic
  - BUILD mode skips pip install
  - Made mount path configurable

## Testing

This should fix the failing Development workflow.