### PR TITLE
Fix: install datajoint-python in BUILD mode for mkdocstrings

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,8 +64,9 @@ services:
             pip install scikit-image pooch
             mkdocs serve --config-file ./mkdocs.yaml -a 0.0.0.0:8000
         elif echo "$${MODE}" | grep -i build &>/dev/null; then
-            # BUILD mode: just build static site from pre-executed notebooks
-            # datajoint-python source is mounted for mkdocstrings API doc generation
+            # BUILD mode: build static site from pre-executed notebooks
+            # Install datajoint-python for mkdocstrings (needs to import for API docs)
+            pip install -e /datajoint-python
             mkdocs build --config-file ./mkdocs.yaml
         else
             echo "Unexpected mode..."


### PR DESCRIPTION
## Problem

After PR #102 was merged, the build is still failing with:
```
ERROR - mkdocstrings: ModuleNotFoundError: No module named 'datajoint'
ERROR - Could not collect 'datajoint'
```

**Root cause:** mkdocstrings uses Python introspection to generate API documentation - it needs to **import** the module to read docstrings. Simply mounting the source files isn't sufficient.

## Solution

Install datajoint-python in BUILD mode with `pip install -e /datajoint-python`.

**Why this is safe:**
- Notebooks are pre-executed (don't need datajoint installed to display them)
- mkdocstrings only needs the package *installed* to import and introspect
- No database connectivity required during build
- No need to install notebook dependencies (scikit-image, pooch) in BUILD mode

## Changes

- `docker-compose.yaml`: Added `pip install -e /datajoint-python` to BUILD mode

## Relation to PR #102

PR #102 correctly:
✅ Checked out datajoint-python in CI
✅ Mounted it in docker-compose
✅ Made path configurable

This PR completes the fix by:
✅ Actually installing the package so mkdocstrings can import it

## Testing

This should fix the failing Development workflow on main branch.