### PR TITLE
Use datajoint-python pre/v2.0 branch for documentation

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: datajoint/datajoint-python
+          ref: pre/v2.0
           path: datajoint-python
       - name: Compile docs static artifacts
         run: |

--- a/README.md
+++ b/README.md
@@ -154,8 +154,13 @@ dependencies needed to build documentation and execute tutorial notebooks.
 ### Start the Environment
 
 ```bash
-# Clone the repository
+# Clone the documentation repository
 git clone https://github.com/datajoint/datajoint-docs.git
+cd datajoint-docs
+
+# Clone datajoint-python pre-release branch (required for API docs)
+cd ..
+git clone -b pre/v2.0 https://github.com/datajoint/datajoint-python.git
 cd datajoint-docs
 
 # Start all services (MySQL, MinIO, docs server)


### PR DESCRIPTION
## Problem

The documentation is currently being built against the default branch of datajoint-python (likely main), but it should be built against the pre-release 2.0 features on the `pre/v2.0` branch.

## Solution

**CI workflow:**
- Added `ref: pre/v2.0` to the datajoint-python checkout step
- Ensures API documentation matches pre-release 2.0 features

**README:**
- Updated local development instructions
- Now explicitly shows cloning the `pre/v2.0` branch
- Ensures local dev environment matches CI

## Changes

- `.github/workflows/development.yml`: Added `ref: pre/v2.0` to checkout
- `README.md`: Updated setup instructions to clone pre/v2.0 branch

## Impact

- API documentation will now reflect pre-release 2.0 features
- Local development environment will match CI configuration
- Ensures consistency between docs and the version being documented

## Testing

CI build should succeed with the pre/v2.0 branch.