### PR TITLE
docs: fix broken migration guide URLs

### DIFF
--- a/src/explanation/whats-new-2.md
+++ b/src/explanation/whats-new-2.md
@@ -4,7 +4,7 @@ DataJoint 2.0 is a major release that establishes DataJoint as a mature framewor
 
 > **📘 Upgrading from legacy DataJoint (pre-2.0)?**
 >
-> This page summarizes new features and concepts. For step-by-step migration instructions, see the **[Migration Guide](../how-to/migrate-from-0x.md)**.
+> This page summarizes new features and concepts. For step-by-step migration instructions, see the **[Migration Guide](../how-to/migrate-to-v20.md)**.
 
 ## Overview
 
@@ -27,7 +27,7 @@ If you're upgrading from legacy DataJoint, these changes require code updates:
 | **Type syntax** | `longblob`, `int unsigned` | `<blob>`, `uint32` |
 | **Jobs** | `~jobs` table | Per-table `~~table_name` |
 
-See the [Migration Guide](../how-to/migrate-from-0x.md) for complete upgrade steps.
+See the [Migration Guide](../how-to/migrate-to-v20.md) for complete upgrade steps.
 
 ## Object-Augmented Schema (OAS)
 
@@ -228,7 +228,7 @@ DataJoint 2.0 is licensed under the **Apache License 2.0** (previously LGPL-2.1)
 
 ## Migration Path
 
-→ **[Complete Migration Guide](../how-to/migrate-from-0x.md)**
+→ **[Complete Migration Guide](../how-to/migrate-to-v20.md)**
 
 Upgrading from DataJoint 0.x is a **phased process** designed to minimize risk:
 
@@ -272,7 +272,7 @@ Most users complete Phases 1-2 in a single session. Phases 3-4 only apply if you
 ## See Also
 
 ### Migration
-- **[Migration Guide](../how-to/migrate-from-0x.md)** — Complete upgrade instructions
+- **[Migration Guide](../how-to/migrate-to-v20.md)** — Complete upgrade instructions
 - [Configuration](../how-to/configure-database.md) — Setup new configuration system
 
 ### Core Concepts

--- a/src/how-to/alter-tables.md
+++ b/src/how-to/alter-tables.md
@@ -237,4 +237,4 @@ test_schema = dj.Schema('test_' + schema.database)
 ## See Also
 
 - [Define Tables](define-tables.md) — Table definition syntax
-- [Migrate from 0.x](migrate-from-0x.md) — Version migration
+- [Migrate to v2.0](migrate-to-v20.md) — Version migration

--- a/src/how-to/index.md
+++ b/src/how-to/index.md
@@ -45,6 +45,6 @@ they assume you understand the basics and focus on getting things done.
 
 ## Maintenance
 
-- [Migrate from 0.x](migrate-from-0x.md) — Upgrading existing pipelines
+- [Migrate to v2.0](migrate-to-v20.md) — Upgrading existing pipelines
 - [Alter Tables](alter-tables.md) — Schema evolution
 - [Backup and Restore](backup-restore.md) — Data protection

--- a/src/reference/specs/autopopulate.md
+++ b/src/reference/specs/autopopulate.md
@@ -921,7 +921,7 @@ slow = Analysis & '_job_duration > 3600'
 
 ## 15. Migration from Legacy DataJoint
 
-DataJoint 2.0 replaces the schema-level `~jobs` table with per-table `~~table_name` jobs tables. See the [Migration Guide](../../how-to/migrate-from-0x.md#autopopulate-20) for details.
+DataJoint 2.0 replaces the schema-level `~jobs` table with per-table `~~table_name` jobs tables. See the [Migration Guide](../../how-to/migrate-to-v20.md) for details.
 
 ---
 


### PR DESCRIPTION
Update 7 references from `migrate-from-0x.md` to `migrate-to-v20.md`:
- src/explanation/whats-new-2.md (4 links)
- src/how-to/alter-tables.md (1 link)
- src/how-to/index.md (1 link)
- src/reference/specs/autopopulate.md (1 link)

Also updated link text from "Migrate from 0.x" to "Migrate to v2.0" for consistency.