### PR TITLE
Fix broken migration guide links in LLM documentation files

### DIFF
--- a/src/llms-full.txt
+++ b/src/llms-full.txt
@@ -679,6 +679,189 @@ modifying the core framework.
 
 
 ---
+## File: explanation/data-pipelines.md
+
+# Scientific Data Pipelines
+
+A **scientific data pipeline** extends beyond a database with computations. It is a comprehensive system that:
+
+- Manages the complete lifecycle of scientific data from acquisition to delivery
+- Integrates diverse tools for data entry, visualization, and analysis
+- Provides infrastructure for secure, scalable computation
+- Enables collaboration across teams and institutions
+- Supports reproducibility and provenance tracking throughout
+
+## Pipeline Architecture
+
+A DataJoint pipeline integrates three core components:
+
+![DataJoint Platform Architecture](../images/dj-platform.png)
+
+| Component | Purpose |
+|-----------|---------|
+| **Code Repository** | Version-controlled pipeline definitions, `make` methods, configuration |
+| **Relational Database** | System of record for metadata, relationships, and integrity enforcement |
+| **Object Store** | Scalable storage for large scientific data (images, recordings, signals) |
+
+These components work together: code defines the schema and computations, the database tracks all metadata and relationships, and object storage holds the large scientific data files.
+
+## Pipeline as a DAG
+
+A DataJoint pipeline forms a **Directed Acyclic Graph (DAG)** at two levels:
+
+![Pipeline DAG Structure](../images/pipeline-illustration.png)
+
+**Nodes** represent Python modules, which correspond to database schemas.
+
+**Edges** represent:
+
+- Python import dependencies between modules
+- Bundles of foreign key references between schemas
+
+This dual structure ensures that both code dependencies and data dependencies flow in the same direction.
+
+### DAG Constraints
+
+> **All foreign key relationships within a schema MUST form a DAG.**
+>
+> **Dependencies between schemas (foreign keys + imports) MUST also form a DAG.**
+
+This constraint is fundamental to DataJoint's design. It ensures:
+
+- **Unidirectional data flow** — Data enters at the top and flows downstream
+- **Clear provenance** — Every result traces back to its inputs
+- **Safe deletion** — Cascading deletes follow the DAG without cycles
+- **Predictable computation** — `populate()` can determine correct execution order
+
+## The Relational Workflow Model
+
+DataJoint pipelines are built on the [Relational Workflow Model](relational-workflow-model.md)—a paradigm that extends relational databases with native support for computational workflows. In this model:
+
+- **Tables represent workflow steps**, not just data storage
+- **Foreign keys encode dependencies**, prescribing the order of operations
+- **Table tiers** (Lookup, Manual, Imported, Computed) classify how data enters the pipeline
+- **The schema forms a DAG** that defines valid execution sequences
+
+This model treats the database schema as an **executable workflow specification**—defining not just what data exists but when and how it comes into existence.
+
+## Schema Organization
+
+Each schema corresponds to a dedicated Python module. The module import structure mirrors the foreign key dependencies between schemas:
+
+![Schema Structure](../images/schema-illustration.png)
+
+```
+my_pipeline/
+├── src/
+│   └── my_pipeline/
+│       ├── __init__.py
+│       ├── subject.py      # subject schema (no dependencies)
+│       ├── session.py      # session schema (depends on subject)
+│       ├── acquisition.py  # acquisition schema (depends on session)
+│       └── analysis.py     # analysis schema (depends on acquisition)
+```
+
+For practical guidance on organizing multi-schema pipelines, configuring repositories, and managing team access, see [Manage a Pipeline Project](../how-to/manage-pipeline-project.md).
+
+## Object-Augmented Schemas
+
+Scientific data often includes large objects—images, recordings, time series, instrument outputs—that don't fit efficiently in relational tables. DataJoint addresses this through **Object-Augmented Schemas (OAS)**, a hybrid storage architecture that preserves relational semantics while handling arbitrarily large data.
+
+### The OAS Philosophy
+
+**1. The database remains the system of record.**
+
+All metadata, relationships, and query logic live in the relational database. The schema defines what data exists, how entities relate, and what computations produce them. Queries operate on the relational structure; results are consistent and reproducible.
+
+**2. Large objects live in external stores.**
+
+Object storage (filesystems, S3, GCS, Azure Blob, MinIO) holds the actual bytes—arrays, images, files. The database stores only lightweight references (paths, checksums, metadata). This separation lets the database stay fast while data scales to terabytes.
+
+**3. Transparent access through codecs.**
+
+DataJoint's [type system](type-system.md) provides codec types that bridge Python objects and storage:
+
+| Codec | Purpose |
+|-------|---------|
+| `<blob>` | Serialize Python objects (NumPy arrays, dicts) |
+| `<blob@store>` | Same, but stored externally |
+| `<attach>` | Store files with preserved filenames |
+| `<object@store>` | Path-addressed storage for complex structures (Zarr, HDF5) |
+| `<filepath@store>` | References to externally-managed files |
+
+Users work with native Python objects; serialization and storage routing are invisible.
+
+**4. Referential integrity extends to objects.**
+
+When a database row is deleted, its associated external objects are garbage-collected. Foreign key cascades work correctly—delete upstream data and downstream results (including their objects) disappear. The database and object store remain synchronized without manual cleanup.
+
+**5. Multiple storage tiers support diverse access patterns.**
+
+Different attributes can route to different stores:
+
+```python
+class Recording(dj.Imported):
+    definition = """
+    -> Session
+    ---
+    raw_data : <blob@fast>       # Hot storage for active analysis
+    archive : <blob@cold>        # Cold storage for long-term retention
+    """
+```
+
+This architecture lets teams work with terabyte-scale datasets while retaining the query power, integrity guarantees, and reproducibility of the relational model.
+
+## Pipeline Workflow
+
+A typical data pipeline workflow:
+
+1. **Acquisition** — Data is collected from instruments, experiments, or external sources. Raw files land in object storage; metadata populates Manual tables.
+
+2. **Import** — Automated processes parse raw data, extract signals, and populate Imported tables with structured results.
+
+3. **Computation** — The `populate()` mechanism identifies new data and triggers downstream processing. Compute resources execute transformations and populate Computed tables.
+
+4. **Query & Analysis** — Users query results across the pipeline, combining data from multiple stages to generate insights, reports, or visualizations.
+
+5. **Collaboration** — Team members access the same database concurrently, building on shared results. Foreign key constraints maintain consistency.
+
+6. **Delivery** — Processed results are exported, integrated into downstream systems, or archived according to project requirements.
+
+Throughout this process, the schema definition remains the single source of truth.
+
+## Comparing Approaches
+
+| Aspect | File-Based Approach | DataJoint Pipeline |
+|--------|--------------------|--------------------|
+| **Data Structure** | Implicit in filenames/folders | Explicit in schema definition |
+| **Dependencies** | Encoded in scripts | Declared through foreign keys |
+| **Provenance** | Manual tracking | Automatic through referential integrity |
+| **Reproducibility** | Requires careful discipline | Built into the model |
+| **Collaboration** | File sharing/conflicts | Concurrent database access |
+| **Queries** | Custom scripts per question | Composable query algebra |
+| **Scalability** | Limited by filesystem | Database + object-augmented storage |
+
+The pipeline approach requires upfront investment in schema design. This investment pays dividends through reduced errors, improved reproducibility, and efficient collaboration as projects scale.
+
+## Summary
+
+Scientific data pipelines extend the Relational Workflow Model into complete data operations systems:
+
+- **Pipeline Architecture** — Code repository, relational database, and object store working together
+- **DAG Structure** — Unidirectional flow of data and dependencies
+- **Object-Augmented Schemas** — Scalable storage with relational semantics
+
+The schema remains central—defining data structures, dependencies, and computational flow. This pipeline-centric approach lets teams focus on their science while the system handles data integrity, provenance, and reproducibility automatically.
+
+## See Also
+
+- [Relational Workflow Model](relational-workflow-model.md) — The conceptual foundation
+- [Entity Integrity](entity-integrity.md) — Primary keys and dimensions
+- [Type System](type-system.md) — Codec types and storage modes
+- [Manage a Pipeline Project](../how-to/manage-pipeline-project.md) — Practical project organization
+
+
+---
 ## File: explanation/entity-integrity.md
 
 # Entity Integrity
@@ -855,15 +1038,161 @@ referential integrity and workflow dependency.
 
 ## Schema Dimensions
 
-Primary keys across tables define **schema dimensions**—the axes along which
-your data varies. Common dimensions in neuroscience:
+A **dimension** is an independent axis of variation in your data, introduced by
+a table that defines new primary key attributes. Dimensions are the fundamental
+building blocks of schema design.
+
+### Dimension-Introducing Tables
+
+A table **introduces a dimension** when it defines primary key attributes that
+don't come from a foreign key. In schema diagrams, these tables have
+**underlined names**.
+
+```python
+@schema
+class Subject(dj.Manual):
+    definition = """
+    subject_id : varchar(16)   # NEW dimension: subject_id
+    ---
+    species : varchar(50)
+    """
+
+@schema
+class Modality(dj.Lookup):
+    definition = """
+    modality : varchar(32)     # NEW dimension: modality
+    ---
+    description : varchar(255)
+    """
+```
+
+Both `Subject` and `Modality` are dimension-introducing tables—they create new
+axes along which data varies.
+
+### Dimension-Inheriting Tables
+
+A table **inherits dimensions** when its entire primary key comes from foreign
+keys. In schema diagrams, these tables have **non-underlined names**.
+
+```python
+@schema
+class SubjectProfile(dj.Manual):
+    definition = """
+    -> Subject                 # Inherits subject_id dimension
+    ---
+    weight : float32
+    """
+```
+
+`SubjectProfile` doesn't introduce a new dimension—it extends the `Subject`
+dimension with additional attributes. There's exactly one profile per subject.
+
+### Mixed Tables
+
+Most tables both inherit and introduce dimensions:
+
+```python
+@schema
+class Session(dj.Manual):
+    definition = """
+    -> Subject                 # Inherits subject_id dimension
+    session_idx : uint16       # NEW dimension within subject
+    ---
+    session_date : date
+    """
+```
+
+`Session` inherits the subject dimension but introduces a new dimension
+(`session_idx`) within each subject. This creates a hierarchical structure.
+
+### Computed Tables and Dimensions
+
+**Computed tables never introduce dimensions.** Their primary key is entirely
+inherited from their dependencies:
+
+```python
+@schema
+class SessionSummary(dj.Computed):
+    definition = """
+    -> Session                 # PK = (subject_id, session_idx)
+    ---
+    num_trials : uint32
+    accuracy : float32
+    """
+```
+
+This makes sense—computed tables derive data from existing entities rather
+than introducing new ones.
+
+### Part Tables CAN Introduce Dimensions
+
+Unlike computed tables, **part tables can introduce new dimensions**:
+
+```python
+@schema
+class Detection(dj.Computed):
+    definition = """
+    -> Image                   # Inherits image_id
+    -> DetectionParams         # Inherits params_id
+    ---
+    num_blobs : uint32
+    """
+
+    class Blob(dj.Part):
+        definition = """
+        -> master              # Inherits (image_id, params_id)
+        blob_idx : uint16      # NEW dimension within detection
+        ---
+        x : float32
+        y : float32
+        """
+```
+
+`Detection` inherits dimensions (no underline in diagram), but `Detection.Blob`
+introduces a new dimension (`blob_idx`) for individual blobs within each
+detection.
+
+### Dimensions and Attribute Lineage
+
+Every primary key attribute traces back to the dimension where it was first
+defined. This is called **attribute lineage**:
+
+```
+Subject.subject_id      → myschema.subject.subject_id (origin)
+Session.subject_id      → myschema.subject.subject_id (inherited)
+Session.session_idx     → myschema.session.session_idx (origin)
+Trial.subject_id        → myschema.subject.subject_id (inherited)
+Trial.session_idx       → myschema.session.session_idx (inherited)
+Trial.trial_idx         → myschema.trial.trial_idx (origin)
+```
+
+Lineage enables **semantic matching**—DataJoint only joins attributes that
+trace back to the same dimension. Two attributes named `id` from different
+dimensions cannot be accidentally joined.
+
+See [Semantic Matching](../reference/specs/semantic-matching.md) for details.
+
+### Recognizing Dimensions in Diagrams
+
+In schema diagrams:
+
+| Visual | Meaning |
+|--------|---------|
+| **Underlined name** | Introduces at least one new dimension |
+| Non-underlined name | All PK attributes inherited (no new dimensions) |
+| **Thick solid line** | One-to-one extension (no new dimension) |
+| **Thin solid line** | Containment (may introduce dimension) |
+
+Common dimensions in neuroscience:
 
 - **Subject** — Who/what is being studied
 - **Session** — When data was collected
-- **Modality** — What type of data (ephys, imaging, behavior)
+- **Trial** — Individual experimental unit
+- **Modality** — Type of data (ephys, imaging, behavior)
+- **Parameter set** — Configuration for analysis
 
 Understanding dimensions helps design schemas that naturally express your
-experimental structure.
+experimental structure and ensures correct joins through semantic matching.
 
 ## Best Practices
 
@@ -926,6 +1255,238 @@ stable identification for your domain entities.
 
 
 ---
+## File: explanation/faq.md
+
+# Frequently Asked Questions
+
+## Why Does DataJoint Have Its Own Definition and Query Language?
+
+DataJoint provides a custom data definition language and [query algebra](query-algebra.md) rather than using raw SQL or Object-Relational Mapping (ORM) patterns. This design reflects DataJoint's purpose: enabling research teams to build **[relational workflows](relational-workflow-model.md) with embedded computations** with maximum clarity. These concepts were first formalized in [Yatsenko et al., 2018](https://doi.org/10.48550/arXiv.1807.11104).
+
+### The Definition Language
+
+DataJoint's [definition language](../reference/specs/table-declaration.md) is a standalone scripting language for declaring table schemas — not Python syntax embedded in strings. It is designed for uniform support across multiple host languages (Python, MATLAB, and potentially others). The same definition works identically regardless of which language you use.
+
+### Composite Primary Keys: A Clarity Comparison
+
+Scientific workflows frequently use composite primary keys built from foreign keys. Compare how different approaches handle this common pattern:
+
+```python
+# DataJoint - two characters declare dependency, foreign key, and inherit primary key
+class Scan(dj.Manual):
+    definition = """
+    -> Session
+    scan_idx : int16
+    ---
+    depth : float32
+    """
+```
+
+```python
+# SQLAlchemy - verbose, scattered, error-prone
+class Scan(Base):
+    subject_id = Column(Integer, primary_key=True)
+    session_date = Column(Date, primary_key=True)
+    scan_idx = Column(SmallInteger, primary_key=True)
+    depth = Column(Float)
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ['subject_id', 'session_date'],
+            ['session.subject_id', 'session.session_date']
+        ),
+    )
+```
+
+```sql
+-- Raw SQL - maximum verbosity
+CREATE TABLE scan (
+    subject_id INT NOT NULL,
+    session_date DATE NOT NULL,
+    scan_idx SMALLINT NOT NULL,
+    depth FLOAT,
+    PRIMARY KEY (subject_id, session_date, scan_idx),
+    FOREIGN KEY (subject_id, session_date)
+        REFERENCES session(subject_id, session_date)
+);
+```
+
+The `-> Session` syntax in DataJoint:
+
+- Inherits all primary key attributes from Session
+- Declares the foreign key constraint
+- Establishes the computational dependency (for `populate()`)
+- Documents the data lineage
+
+All in two characters. As pipelines grow to dozens of tables with deep dependency chains, this clarity compounds.
+
+### Why Multiline Strings?
+
+| Aspect | Benefit |
+|--------|---------|
+| **Readable** | Looks like a specification: `---` separates primary from secondary attributes, `#` for comments |
+| **Concise** | `mouse_id : int32` vs `mouse_id = Column(Integer, primary_key=True)` |
+| **Database-first** | `table.describe()` shows the same format; virtual schemas reconstruct definitions from database metadata |
+| **Language-agnostic** | Same syntax for Python, MATLAB, future implementations |
+| **Separation of concerns** | Definition string = structure (what); class = behavior (how: `make()` methods) |
+
+The definition string **is** the specification — a declarative language that describes entities and their relationships, independent of any host language's syntax.
+
+### Why Custom Query Algebra?
+
+DataJoint's operators implement **[semantic matching](../reference/specs/semantic-matching.md)** — joins and restrictions match only on attributes connected through the foreign key graph, not arbitrary columns that happen to share a name. This prevents:
+- Accidental Cartesian products
+- Joins on unrelated columns
+- Silent incorrect results
+
+Every query result has a defined **[entity type](entity-integrity.md)** with a specific [primary key](../reference/specs/primary-keys.md) (algebraic closure). SQL results are untyped bags of rows; DataJoint results are entity sets you can continue to query and compose.
+
+### Object-Augmented Schemas
+
+Object-Relational Mappers treat large objects as opaque binary blobs or leave file management to the application. DataJoint's object store **extends the relational schema** (see [Type System](type-system.md)):
+
+- Relational semantics apply: referential integrity, cascading deletes, query filtering
+- Multiple access patterns: lazy `ObjectRef`, streaming via fsspec, explicit download
+- Two addressing modes: path-addressed (by primary key) and hash-addressed (deduplicated)
+
+The object store is part of the relational model — queryable and integrity-protected like any other attribute.
+
+### Summary
+
+| Aspect | Raw SQL | Object-Relational Mappers | DataJoint |
+|--------|---------|---------------------------|-----------|
+| Schema definition | SQL Data Definition Language | Host language classes | Standalone definition language |
+| Composite foreign keys | Verbose, repetitive | Verbose, scattered | `-> TableName` |
+| Query model | SQL strings | Object navigation | Relational algebra operators |
+| Dependencies | Implicit in application | Implicit in application | Explicit in schema |
+| Large objects | Binary blobs / manual | Binary blobs / manual | Object-Augmented Schema |
+| Computation | External to database | External to database | First-class ([Computed tables](computation-model.md)) |
+| Target audience | Database administrators | Web developers | Research teams |
+
+---
+
+## Is DataJoint an ORM?
+
+**Object-Relational Mapping (ORM)** is a technique for interacting with relational databases through object-oriented programming, abstracting direct SQL queries. Popular Python ORMs include SQLAlchemy, Django ORM, and Peewee, often used in web development.
+
+DataJoint shares certain ORM characteristics—tables are defined as Python classes, and queries return Python objects. However, DataJoint is fundamentally a **computational database framework** designed for scientific workflows:
+
+| Aspect | Traditional ORMs | DataJoint |
+|--------|-----------------|-----------|
+| Primary use case | Web applications | Scientific data pipelines |
+| Focus | Simplify database CRUD | Data integrity + computation |
+| Dependencies | Implicit (application logic) | Explicit (foreign keys define data flow) |
+| Computation | External to database | First-class citizen in schema |
+| Query model | Object navigation | Relational algebra |
+
+DataJoint can be considered an **ORM specialized for scientific databases**—purpose-built for structured experimental data and computational workflows where reproducibility and [data integrity](entity-integrity.md) are paramount.
+
+## Is DataJoint a Workflow Management System?
+
+Not exactly. DataJoint and workflow management systems (Airflow, Prefect, Flyte, Nextflow, Snakemake) solve related but distinct problems:
+
+| Aspect | Workflow Managers | DataJoint |
+|--------|-------------------|-----------|
+| Core abstraction | Tasks and DAGs | Tables and dependencies |
+| State management | External (files, databases) | Integrated (relational database) |
+| Scheduling | Built-in schedulers | External (or manual `populate()`) |
+| Distributed execution | Built-in | Via external tools |
+| Data model | Unstructured (files, blobs) | Structured (relational schema) |
+| Query capability | Limited | Full relational algebra |
+
+**DataJoint excels at:**
+
+- Defining *what* needs to be computed based on data dependencies
+- Ensuring computations are never duplicated
+- Maintaining referential integrity across pipeline stages
+- Querying intermediate and final results
+
+**Workflow managers excel at:**
+
+- Scheduling and orchestrating job execution
+- Distributing work across clusters
+- Retry logic and failure handling
+- Resource management
+
+**They complement each other.** DataJoint formalizes data dependencies so that external schedulers can effectively manage computational tasks. A common pattern:
+
+1. DataJoint defines the pipeline structure and tracks what's computed
+2. A workflow manager (or simple cron/SLURM scripts) calls [`populate()`](computation-model.md) on a schedule
+3. DataJoint determines what work remains and executes it
+
+## Is DataJoint a Lakehouse?
+
+DataJoint and lakehouses share goals—integrating structured data management with scalable storage and computation. However, they differ in approach:
+
+| Aspect | Lakehouse | DataJoint |
+|--------|-----------|-----------|
+| Data model | Flexible (structured + semi-structured) | Strict relational schema |
+| Schema enforcement | Schema-on-read optional | Schema-on-write enforced |
+| Primary use | Analytics on diverse data | Scientific workflows |
+| Computation model | SQL/Spark queries | Declarative `make()` methods |
+| Dependency tracking | Limited | Explicit via foreign keys |
+
+A **lakehouse** merges data lake flexibility with data warehouse structure, optimized for analytics workloads.
+
+**DataJoint** prioritizes:
+
+- Rigorous schema definitions
+- Explicit computational dependencies
+- Data integrity and reproducibility
+- Traceability within structured scientific datasets
+
+DataJoint can complement lakehouse architectures—using object storage for large files while maintaining relational structure for metadata and provenance.
+
+## Does DataJoint Require SQL Knowledge?
+
+No. DataJoint provides a Python API that abstracts SQL:
+
+| SQL | DataJoint |
+|-----|-----------|
+| `CREATE TABLE` | Define tables as Python classes |
+| `INSERT INTO` | `.insert()` method |
+| `SELECT * FROM` | `.to_arrays()`, `.to_dicts()`, `.to_pandas()` |
+| `JOIN` | `table1 * table2` |
+| `WHERE` | `table & condition` |
+| `GROUP BY` | `.aggr()` |
+
+Understanding relational concepts ([primary keys](entity-integrity.md), foreign keys, [normalization](normalization.md)) is helpful but not required to start. The [tutorials](../tutorials/index.md) teach these concepts progressively.
+
+Since DataJoint uses standard database backends (MySQL, PostgreSQL), data remains accessible via SQL for users who prefer it or need integration with other tools.
+
+## How Does DataJoint Handle Large Files?
+
+DataJoint uses a hybrid storage model called **Object-Augmented Schemas (OAS)**:
+
+- **Relational database**: Stores metadata, parameters, and relationships
+- **Object storage**: Stores large files (images, recordings, arrays)
+
+The database maintains references to external objects, preserving:
+
+- Referential integrity (files deleted with their parent records)
+- Query capability (filter by metadata, join across tables)
+- Deduplication (identical content stored once)
+
+See [Object Storage](../how-to/use-object-storage.md) for details.
+
+## Can Multiple Users Share a Pipeline?
+
+Yes. DataJoint pipelines are inherently collaborative:
+
+- **Shared database**: All users connect to the same MySQL/PostgreSQL instance
+- **Shared schema**: Table definitions are stored in the database
+- **Concurrent access**: ACID transactions prevent conflicts
+- **Job reservation**: `populate()` coordinates work across processes
+
+Teams typically:
+
+1. Share pipeline code via Git
+2. Connect to a shared database server
+3. Run `populate()` from multiple machines simultaneously
+
+See [Distributed Computing](../how-to/distributed-computing.md) for multi-process patterns.
+
+
+---
 ## File: explanation/index.md
 
 # Concepts
@@ -973,6 +1534,16 @@ and scalable.
 -   :material-puzzle: **[Custom Codecs](custom-codecs.md)**
 
     Extend DataJoint with domain-specific types. The codec extensibility system.
+
+-   :material-pipe: **[Data Pipelines](data-pipelines.md)**
+
+    From workflows to complete data operations systems. Project structure and
+    object-augmented schemas.
+
+-   :material-frequently-asked-questions: **[FAQ](faq.md)**
+
+    How DataJoint compares to ORMs, workflow managers, and lakehouses.
+    Common questions answered.
 
 </div>
 
@@ -1158,21 +1729,27 @@ class SubjectWeight(dj.Manual):
 
 # Query Algebra
 
-DataJoint provides a powerful query algebra with just five operators. These
-operators work on **entity sets** (query expressions) and always return entity
-sets, enabling arbitrary composition.
+DataJoint provides a powerful query algebra built on five core operators: restriction, join, projection, aggregation, and union. These operators work on **entity sets** (query expressions) and always return entity sets, enabling arbitrary composition.
 
-## The Five Operators
+## Algebraic Closure
+
+A fundamental property of DataJoint's query algebra is **algebraic closure**: every query result is itself a valid entity set with a well-defined **entity type** — you always know what kind of entity the result represents, identified by a specific primary key. Unlike SQL where query results are unstructured "bags of rows," DataJoint determines the entity type of each result based on the operator and the functional dependencies between operands.
+
+This means operators can be chained indefinitely — the output of any operation is a valid input to any other operation. See [Primary Keys](../reference/specs/primary-keys.md) for the precise rules.
+
+## Core Operators
 
 ```mermaid
 graph LR
     A[Entity Set] --> R[Restriction &]
     A --> J[Join *]
+    A --> E[Extend .extend]
     A --> P[Projection .proj]
     A --> G[Aggregation .aggr]
     A --> U[Union +]
     R --> B[Entity Set]
     J --> B
+    E --> B
     P --> B
     G --> B
     U --> B
@@ -1236,6 +1813,63 @@ DataJoint joins are **natural joins** that:
 - Match on attributes with the same name **and** lineage
 - Respect declared dependencies (no accidental matches)
 - Produce the intersection of matching entities
+
+### Extend (`.extend()`)
+
+Add attributes from another entity set while preserving all entities in the original set.
+
+```python
+# Add session info to each trial
+Trial.extend(Session)  # Adds session_date, subject_id to Trial
+
+# Add neuron properties to spike times
+SpikeTime.extend(Neuron)  # Adds cell_type, depth to SpikeTime
+```
+
+**How it differs from join:**
+
+- **Join (`*`)**: Returns only matching entities (inner join), primary key is the union of both PKs
+- **Extend**: Returns all entities from the left side (left join), primary key stays as the left side's PK
+
+**Primary key formation:**
+
+```python
+# Join: PK is union of both primary keys
+result = Session * Trial
+# PK: (session_id, trial_num)
+
+# Extend: PK stays as left side's PK
+result = Trial.extend(Session)
+# PK: (session_id, trial_num) - same as Trial
+# session_date is added as a non-primary attribute
+```
+
+**Requirement:** The left side must **determine** the right side. This means all primary key attributes from the right side must exist in the left side. This requirement ensures:
+
+1. Every entity in the left side can match at most one entity in the right side
+2. The left side's primary key uniquely identifies entities in the result
+3. No NULL values appear in the result's primary key
+
+```python
+# Valid: Trial determines Session
+# (session_id is in Trial's primary key)
+Trial.extend(Session)  ✓
+# Each trial belongs to exactly one session
+# Result PK: (session_id, trial_num)
+
+# Invalid: Session does NOT determine Trial
+# (trial_num is not in Session)
+Session.extend(Trial)  ✗  # Error: trial_num not in Session
+# A session has multiple trials - PK would be ambiguous
+```
+
+**Why use extend?**
+
+1. **Preserve all entities**: When you need attributes from a parent but want to keep all children (even orphans)
+2. **Clear intent**: Expresses "add attributes" rather than "combine entity sets"
+3. **No filtering**: Guarantees the same number of entities in the result
+
+Think of extend as projection-like: it adds attributes to existing entities without changing which entities are present.
 
 ## Projection (`.proj()`)
 
@@ -1357,15 +1991,16 @@ row = (query & key).fetch1()
 
 ## Summary
 
-| Operator | Symbol | Purpose |
-|----------|--------|---------|
+| Operator | Symbol/Method | Purpose |
+|----------|---------------|---------|
 | Restriction | `&`, `-` | Filter entities |
-| Join | `*` | Combine entity sets |
+| Join | `*` | Combine entity sets (inner join) |
+| Extend | `.extend()` | Add attributes (left join) |
 | Projection | `.proj()` | Select/transform attributes |
 | Aggregation | `.aggr()` | Summarize groups |
 | Union | `+` | Combine parallel sets |
 
-These five operators, combined with workflow-aware join semantics, provide
+These core operators, combined with workflow-aware join semantics, provide
 complete query capability for scientific data pipelines.
 
 
@@ -1378,6 +2013,9 @@ DataJoint implements the **Relational Workflow Model**—a paradigm that extends
 relational databases with native support for computational workflows. This model
 defines a new class of databases called **Computational Databases**, where
 computational transformations are first-class citizens of the data model.
+
+These concepts, along with DataJoint's schema definition language and query algebra,
+were first formalized in [Yatsenko et al., 2018](https://doi.org/10.48550/arXiv.1807.11104).
 
 ## The Problem with Traditional Approaches
 
@@ -1665,6 +2303,7 @@ Standardized, scientist-friendly types that work identically across backends.
 |------|-------------|
 | `char(n)` | Fixed-length string |
 | `varchar(n)` | Variable-length string |
+| `enum(...)` | Enumeration of string labels |
 
 ### Other Types
 
@@ -1675,7 +2314,6 @@ Standardized, scientist-friendly types that work identically across backends.
 | `datetime` | Date and time (UTC) |
 | `json` | JSON document |
 | `uuid` | Universally unique identifier |
-| `enum(...)` | Enumeration |
 | `bytes` | Raw binary |
 
 ## Layer 3: Codec Types
@@ -1827,6 +2465,33 @@ class Network(dj.Computed):
 
 DataJoint 2.0 is a major release that establishes DataJoint as a mature framework for scientific data pipelines. The version jump from 0.14 to 2.0 reflects the significance of these changes.
 
+> **📘 Upgrading from legacy DataJoint (pre-2.0)?**
+>
+> This page summarizes new features and concepts. For step-by-step migration instructions, see the **[Migration Guide](../how-to/migrate-to-v20.md)**.
+
+## Overview
+
+DataJoint 2.0 introduces fundamental improvements to type handling, job coordination, and object storage while maintaining compatibility with your existing pipelines during migration. Key themes:
+
+- **Explicit over implicit**: All type conversions are now explicit through the codec system
+- **Better distributed computing**: Per-table job coordination with improved error handling
+- **Object storage integration**: Native support for large arrays and files
+- **Future-proof architecture**: Portable types preparing for PostgreSQL backend support
+
+### Breaking Changes at a Glance
+
+If you're upgrading from legacy DataJoint, these changes require code updates:
+
+| Area | Legacy | 2.0 |
+|------|--------|-----|
+| **Fetch API** | `table.fetch()` | `table.to_dicts()` or `.to_arrays()` |
+| **Update** | `(table & key)._update('attr', val)` | `table.update1({**key, 'attr': val})` |
+| **Join** | `table1 @ table2` | `table1 * table2` (with semantic check) |
+| **Type syntax** | `longblob`, `int unsigned` | `<blob>`, `uint32` |
+| **Jobs** | `~jobs` table | Per-table `~~table_name` |
+
+See the [Migration Guide](../how-to/migrate-to-v20.md) for complete upgrade steps.
+
 ## Object-Augmented Schema (OAS)
 
 DataJoint 2.0 unifies relational tables with object storage into a single coherent system. The relational database stores metadata and references while large objects (arrays, files, Zarr datasets) are stored in object storage—with full referential integrity maintained across both layers.
@@ -1853,15 +2518,37 @@ zarr_array : <object@store> # Path-addressed for Zarr/HDF5
 """
 ```
 
-## Extensible Type System
+## Explicit Type System
 
-A three-layer architecture separates Python types, DataJoint core types, and storage.
+**Breaking change**: DataJoint 2.0 makes all type conversions explicit through a three-tier architecture.
 
 → [Type System Specification](../reference/specs/type-system.md) · [Codec API Specification](../reference/specs/codec-api.md)
 
-- **Core types**: Portable types like `int32`, `float64`, `uuid`, `json`
-- **Codecs**: Transform Python objects for storage (`<blob>`, `<attach>`, `<object@>`)
-- **Custom codecs**: Implement domain-specific types for your data
+### What Changed
+
+Legacy DataJoint overloaded MySQL types with implicit conversions:
+- `longblob` could be blob serialization OR inline attachment
+- `attach` was implicitly converted to longblob
+- `uuid` was used internally for external storage
+
+**DataJoint 2.0 makes everything explicit:**
+
+| Legacy (Implicit) | 2.0 (Explicit) |
+|-------------------|----------------|
+| `longblob` | `<blob>` |
+| `attach` | `<attach>` |
+| `blob@store` | `<blob@store>` |
+| `int unsigned` | `uint32` |
+
+### Three-Tier Architecture
+
+1. **Native types**: MySQL types (`INT`, `VARCHAR`, `LONGBLOB`)
+2. **Core types**: Portable aliases (`int32`, `float64`, `varchar`, `uuid`, `json`)
+3. **Codecs**: Serialization for Python objects (`<blob>`, `<attach>`, `<object@>`)
+
+### Custom Codecs
+
+Replace legacy AdaptedTypes with the new codec API:
 
 ```python
 class GraphCodec(dj.Codec):
@@ -1877,14 +2564,25 @@ class GraphCodec(dj.Codec):
 
 ## Jobs 2.0
 
-A redesigned job coordination system for distributed computing.
+**Breaking change**: Redesigned job coordination with per-table job management.
 
 → [AutoPopulate Specification](../reference/specs/autopopulate.md) · [Job Metadata Specification](../reference/specs/job-metadata.md)
 
-- **Per-table jobs**: Each computed table has its own jobs table (`Table.jobs`)
-- **Automatic refresh**: Job queue synchronized with pending work
-- **Distributed coordination**: Multiple workers coordinate via database
-- **Error tracking**: Built-in error table with stack traces
+### What Changed
+
+| Legacy (Schema-level) | 2.0 (Per-table) |
+|----------------------|-----------------|
+| One `~jobs` table per schema | One `~~table_name` per Computed/Imported table |
+| Opaque hashed keys | Native primary keys (readable) |
+| Statuses: `reserved`, `error`, `ignore` | Added: `pending`, `success` |
+| No priority support | Priority column (lower = more urgent) |
+
+### New Features
+
+- **Automatic refresh**: Job queue synchronized with pending work automatically
+- **Better coordination**: Multiple workers coordinate via database without conflicts
+- **Error tracking**: Built-in error table (`Table.jobs.errors`) with full stack traces
+- **Priority support**: Control computation order with priority values
 
 ```python
 # Distributed mode with coordination
@@ -1895,18 +2593,34 @@ Analysis.jobs.progress()  # {'pending': 10, 'reserved': 2, 'error': 0}
 
 # Handle errors
 Analysis.jobs.errors.to_dicts()
+
+# Set priorities
+Analysis.jobs.update({'session_id': 123}, priority=1)  # High priority
 ```
 
 ## Semantic Matching
 
-Query operations now use **lineage-based matching**—attributes are matched not just by name but by their origin through foreign key chains. This prevents accidental matches between attributes that happen to share a name but represent different concepts.
+**Breaking change**: Query operations now use **lineage-based matching** by default.
 
 → [Semantic Matching Specification](../reference/specs/semantic-matching.md)
 
+### What Changed
+
+Legacy DataJoint used SQL-style natural joins: attributes matched if they had the same name, regardless of meaning.
+
+**DataJoint 2.0 validates semantic lineage**: Attributes must share common origin through foreign key chains, not just coincidentally matching names.
+
 ```python
-# Attributes matched by lineage, not just name
-result = TableA * TableB  # Semantic join (default)
+# 2.0: Semantic join (default) - validates lineage
+result = TableA * TableB  # Only matches attributes with shared origin
+
+# Legacy behavior (if needed)
+result = TableA.join(TableB, semantic_check=False)
 ```
+
+**Why this matters**: Prevents accidental matches between attributes like `session_id` that happen to share a name but refer to different entities in different parts of your schema.
+
+**During migration**: If semantic matching fails, it often indicates a malformed join that should be reviewed rather than forced.
 
 ## Configuration System
 
@@ -1924,9 +2638,9 @@ export DJ_USER=myuser
 export DJ_PASS=mypassword
 ```
 
-## ObjectRef API
+## ObjectRef API (New)
 
-Path-addressed storage returns `ObjectRef` handles that support streaming access:
+**New feature**: Path-addressed storage returns `ObjectRef` handles that support streaming access without downloading entire datasets.
 
 ```python
 ref = (Dataset & key).fetch1('zarr_array')
@@ -1936,29 +2650,107 @@ z = zarr.open(ref.fsmap, mode='r')
 
 # Or download locally
 local_path = ref.download('/tmp/data')
+
+# Stream chunks without full download
+with ref.open('rb') as f:
+    chunk = f.read(1024)
 ```
+
+This enables efficient access to large datasets stored in Zarr, HDF5, or custom formats.
+
+## Deprecated and Removed
+
+### Removed APIs
+
+- **`.fetch()` method**: Replaced with `.to_dicts()`, `.to_arrays()`, or `.to_pandas()`
+- **`._update()` method**: Replaced with `.update1()`
+- **`@` operator (natural join)**: Use `*` with semantic matching or `.join(semantic_check=False)`
+- **`dj.U() * table` pattern**: Use just `table` (universal set is implicit)
+
+### Deprecated Features
+
+- **AdaptedTypes**: Replaced by codec system (still works but migration recommended)
+- **Native type syntax**: `int unsigned` → `uint32` (warnings on new tables)
+- **Legacy external storage** (`blob@store`): Replaced by `<blob@store>` codec syntax
+
+### Legacy Support
+
+During migration (Phases 1-3), both legacy and 2.0 APIs can coexist:
+- Legacy clients can still access data
+- 2.0 clients understand legacy column types
+- Dual attributes enable cross-testing
+
+After finalization (Phase 4+), only 2.0 clients are supported.
 
 ## License Change
 
-DataJoint 2.0 is licensed under the **Apache License 2.0** (previously LGPL). This provides more flexibility for commercial and academic use.
+DataJoint 2.0 is licensed under the **Apache License 2.0** (previously LGPL-2.1). This provides:
+- More permissive for commercial and academic use
+- Clearer patent grant provisions
+- Better compatibility with broader ecosystem
 
 ## Migration Path
 
-Upgrading from DataJoint 0.x requires:
+→ **[Complete Migration Guide](../how-to/migrate-to-v20.md)**
 
-1. Update configuration files
-2. Update blob syntax (`longblob` → `<blob>`)
-3. Update jobs code (schema-level → per-table)
-4. Test semantic matching behavior
+Upgrading from DataJoint 0.x is a **phased process** designed to minimize risk:
 
-See [Migrate from 0.x](../how-to/migrate-from-0x.md) for detailed upgrade steps.
+### Phase 1: Code Updates (Reversible)
+- Update Python code to 2.0 API patterns (`.fetch()` → `.to_dicts()`, etc.)
+- Update configuration files (`dj_local_conf.json` → `datajoint.json` + `.secrets/`)
+- **No database changes** — legacy clients still work
+
+### Phase 2: Type Migration (Reversible)
+- Update database column comments to use core types (`:uint32:`, `:<blob>:`)
+- Rebuild `~lineage` tables for semantic matching
+- Update Python table definitions
+- **Legacy clients still work** — only metadata changed
+
+### Phase 3: External Storage Dual Attributes (Reversible)
+- Create `*_v2` attributes alongside legacy external storage columns
+- Both APIs can access data during transition
+- Enables cross-testing between legacy and 2.0
+- **Legacy clients still work**
+
+### Phase 4: Finalize (Point of No Return)
+- Remove legacy external storage columns
+- Drop old `~jobs` and `~external_*` tables
+- **Legacy clients stop working** — database backup required
+
+### Phase 5: Adopt New Features (Optional)
+- Use new codecs (`<object@>`, `<npy@>`)
+- Leverage Jobs 2.0 features (priority, better errors)
+- Implement custom codecs for domain-specific types
+
+### Migration Support
+
+The migration guide includes:
+- **AI agent prompts** for automated migration steps
+- **Validation commands** to check migration status
+- **Rollback procedures** for each phase
+- **Dry-run modes** for all database changes
+
+Most users complete Phases 1-2 in a single session. Phases 3-4 only apply if you use legacy external storage.
 
 ## See Also
 
-- [Installation](../how-to/installation.md) — Get started with DataJoint 2.0
-- [Tutorials](../tutorials/index.md) — Learn DataJoint step by step
-- [Type System](type-system.md) — Core types and codecs
-- [Computation Model](computation-model.md) — Jobs 2.0 details
+### Migration
+- **[Migration Guide](../how-to/migrate-to-v20.md)** — Complete upgrade instructions
+- [Configuration](../how-to/configure-database.md) — Setup new configuration system
+
+### Core Concepts
+- [Type System](type-system.md) — Understand the three-tier type architecture
+- [Computation Model](computation-model.md) — Jobs 2.0 and AutoPopulate
+- [Query Algebra](query-algebra.md) — Semantic matching and operators
+
+### Getting Started
+- [Installation](../how-to/installation.md) — Install DataJoint 2.0
+- [Tutorials](../tutorials/index.md) — Learn by example
+
+### Reference
+- [Type System Specification](../reference/specs/type-system.md) — Complete type system details
+- [Codec API](../reference/specs/codec-api.md) — Build custom codecs
+- [AutoPopulate Specification](../reference/specs/autopopulate.md) — Jobs 2.0 reference
 
 
 ============================================================
@@ -1967,337 +2759,1417 @@ See [Migrate from 0.x](../how-to/migrate-from-0x.md) for detailed upgrade steps.
 
 
 ---
-## File: tutorials/01-getting-started.ipynb
+## File: tutorials/advanced/custom-codecs.ipynb
 
-# Getting Started
+# Custom Codecs
 
-This tutorial introduces DataJoint through a real image analysis pipeline that detects bright blobs in astronomical and biological images. By the end, you'll understand:
+This tutorial covers extending DataJoint's type system. You'll learn:
 
-- **Schemas** — Namespaces that group related tables
-- **Table types** — Manual, Lookup, and Computed tables
-- **Dependencies** — How tables relate through foreign keys
-- **Computation** — Automatic population of derived data
-- **Master-Part** — Atomic insertion of hierarchical results
-
-## The Problem
-
-We have images and want to detect bright spots (blobs) in them. Different detection parameters work better for different images, so we need to:
-
-1. Store our images
-2. Define parameter sets to try
-3. Run detection for each image × parameter combination
-4. Store and visualize results
-5. Select the best parameters for each image
-
-This is a **computational workflow** — a series of steps where each step depends on previous results. DataJoint makes these workflows reproducible and manageable.
-
-## Setup
-
-First, let's import our tools and create a schema (database namespace) for this project.
+- **Codec basics** — Encoding and decoding
+- **Creating codecs** — Domain-specific types
+- **Codec chaining** — Composing codecs
 
 
 ```python
 import datajoint as dj
-import matplotlib.pyplot as plt
-from skimage import data
-from skimage.feature import blob_doh
-from skimage.color import rgb2gray
+import numpy as np
 
-# Create a schema - this is our database namespace
-schema = dj.Schema('tutorial_blobs')
+schema = dj.Schema('tutorial_codecs')
 ```
 
 
-## Manual Tables: Storing Raw Data
+## Creating a Custom Codec
 
-A **Manual table** stores data that users enter directly — it's the starting point of your pipeline. Here we define an `Image` table to store our sample images.
 
-The `definition` string specifies:
-- **Primary key** (above `---`): attributes that uniquely identify each row
-- **Secondary attributes** (below `---`): additional data for each row
+```python
+import networkx as nx
+
+class GraphCodec(dj.Codec):
+    """Store NetworkX graphs."""
+    
+    name = "graph"  # Use as <graph>
+    
+    def get_dtype(self, is_store: bool) -> str:
+        return "<blob>"
+    
+    def encode(self, value, *, key=None, store_name=None):
+        return {'nodes': list(value.nodes(data=True)), 'edges': list(value.edges(data=True))}
+    
+    def decode(self, stored, *, key=None):
+        g = nx.Graph()
+        g.add_nodes_from(stored['nodes'])
+        g.add_edges_from(stored['edges'])
+        return g
+    
+    def validate(self, value):
+        if not isinstance(value, nx.Graph):
+            raise TypeError(f"Expected nx.Graph")
+```
+
 
 
 ```python
 @schema
-class Image(dj.Manual):
+class Connectivity(dj.Manual):
     definition = """
-    # Images for blob detection
-    image_id : uint8
+    conn_id : int
     ---
-    image_name : varchar(100)
-    image : <blob>              # serialized numpy array
+    network : <graph>
     """
 ```
 
 
-Now let's insert two sample images from scikit-image:
-
 
 ```python
-# Insert sample images
-Image.insert([
-    {'image_id': 1, 'image_name': 'Hubble Deep Field', 
-     'image': rgb2gray(data.hubble_deep_field())},
-    {'image_id': 2, 'image_name': 'Human Mitosis', 
-     'image': data.human_mitosis() / 255.0},
-], skip_duplicates=True)
+# Create and insert
+g = nx.Graph()
+g.add_edges_from([(1, 2), (2, 3), (1, 3)])
+Connectivity.insert1({'conn_id': 1, 'network': g})
 
-Image()
+# Fetch
+result = (Connectivity & {'conn_id': 1}).fetch1('network')
+print(f"Type: {type(result)}")
+print(f"Edges: {list(result.edges())}")
 ```
 
 
+## Codec Structure
 
 ```python
-# Visualize the images
-fig, axes = plt.subplots(1, 2, figsize=(10, 5))
-for ax, row in zip(axes, Image()):
-    ax.imshow(row['image'], cmap='gray_r')
-    ax.set_title(row['image_name'])
-    ax.axis('off')
-plt.tight_layout()
+class MyCodec(dj.Codec):
+    name = "mytype"  # Use as <mytype>
+    
+    def get_dtype(self, is_store: bool) -> str:
+        return "<blob>"  # Storage type
+    
+    def encode(self, value, *, key=None, store_name=None):
+        return serializable_data
+    
+    def decode(self, stored, *, key=None):
+        return python_object
+    
+    def validate(self, value):  # Optional
+        pass
 ```
 
+## Example: Spike Train
 
-## Lookup Tables: Parameter Sets
 
-A **Lookup table** stores reference data that doesn't change often — things like experimental protocols, parameter configurations, or categorical options.
+```python
+from dataclasses import dataclass
 
-For blob detection, we'll try different parameter combinations to find what works best for each image type.
+@dataclass
+class SpikeTrain:
+    times: np.ndarray
+    unit_id: int
+    quality: str
+
+class SpikeTrainCodec(dj.Codec):
+    name = "spike_train"
+    
+    def get_dtype(self, is_store: bool) -> str:
+        return "<blob>"
+    
+    def encode(self, value, *, key=None, store_name=None):
+        return {'times': value.times, 'unit_id': value.unit_id, 'quality': value.quality}
+    
+    def decode(self, stored, *, key=None):
+        return SpikeTrain(times=stored['times'], unit_id=stored['unit_id'], quality=stored['quality'])
+```
+
 
 
 ```python
 @schema
-class DetectionParams(dj.Lookup):
+class Unit(dj.Manual):
     definition = """
-    # Blob detection parameter sets
-    params_id : uint8
+    unit_id : int
     ---
-    min_sigma : float32         # minimum blob size
-    max_sigma : float32         # maximum blob size  
-    threshold : float32         # detection sensitivity
-    """
-    
-    # Pre-populate with parameter sets to try
-    contents = [
-        {'params_id': 1, 'min_sigma': 2.0, 'max_sigma': 6.0, 'threshold': 0.001},
-        {'params_id': 2, 'min_sigma': 3.0, 'max_sigma': 8.0, 'threshold': 0.002},
-        {'params_id': 3, 'min_sigma': 4.0, 'max_sigma': 20.0, 'threshold': 0.01},
-    ]
-
-DetectionParams()
-```
-
-
-## Computed Tables: Automatic Processing
-
-A **Computed table** automatically derives data from other tables. You define:
-
-1. **Dependencies** (using `->`) — which tables provide input
-2. **`make()` method** — how to compute results for one input combination
-
-DataJoint then handles:
-- Determining what needs to be computed
-- Running computations (optionally in parallel)
-- Tracking what's done vs. pending
-
-### Master-Part Structure
-
-Our detection produces multiple blobs per image. We use a **master-part** structure:
-- **Master** (`Detection`): One row per job, stores summary (blob count)
-- **Part** (`Detection.Blob`): One row per blob, stores details (x, y, radius)
-
-Both are inserted atomically — if anything fails, the whole transaction rolls back.
-
-
-```python
-@schema
-class Detection(dj.Computed):
-    definition = """
-    # Blob detection results
-    -> Image                    # depends on Image
-    -> DetectionParams          # depends on DetectionParams
-    ---
-    num_blobs : uint16          # number of blobs detected
-    """
-    
-    class Blob(dj.Part):
-        definition = """
-        # Individual detected blobs
-        -> master
-        blob_idx : uint16
-        ---
-        x : float32             # x coordinate
-        y : float32             # y coordinate  
-        radius : float32        # blob radius
-        """
-    
-    def make(self, key):
-        # Fetch the image and parameters
-        img = (Image & key).fetch1('image')
-        params = (DetectionParams & key).fetch1()
-        
-        # Run blob detection
-        blobs = blob_doh(
-            img,
-            min_sigma=params['min_sigma'],
-            max_sigma=params['max_sigma'],
-            threshold=params['threshold']
-        )
-        
-        # Insert master row
-        self.insert1({**key, 'num_blobs': len(blobs)})
-        
-        # Insert part rows (all blobs for this detection)
-        self.Blob.insert([
-            {**key, 'blob_idx': i, 'x': x, 'y': y, 'radius': r}
-            for i, (x, y, r) in enumerate(blobs)
-        ])
-```
-
-
-## Viewing the Schema
-
-DataJoint can visualize the relationships between tables:
-
-
-```python
-dj.Diagram(schema)
-```
-
-
-The diagram shows:
-- **Green** = Manual tables (user-entered data)
-- **Gray** = Lookup tables (reference data)
-- **Red** = Computed tables (derived data)
-- **Edges** = Dependencies (foreign keys), always flow top-to-bottom
-
-## Running the Pipeline
-
-Call `populate()` to run all pending computations. DataJoint automatically determines what needs to be computed: every combination of `Image` × `DetectionParams` that doesn't already have a `Detection` result.
-
-
-```python
-# Run all pending computations
-Detection.populate(display_progress=True)
-```
-
-
-
-```python
-# View results summary
-Detection()
-```
-
-
-We computed 6 results: 2 images × 3 parameter sets. Each shows how many blobs were detected.
-
-## Visualizing Results
-
-Let's see how different parameters affect detection:
-
-
-```python
-fig, axes = plt.subplots(2, 3, figsize=(12, 8))
-
-for ax, key in zip(axes.ravel(), Detection.keys(order_by='image_id, params_id')):
-    # Get image and detection info in one fetch
-    name, img, num_blobs = (Detection * Image & key).fetch1('image_name', 'image', 'num_blobs')
-    
-    ax.imshow(img, cmap='gray_r')
-    
-    # Get all blob coordinates in one query
-    x, y, r = (Detection.Blob & key).to_arrays('x', 'y', 'radius')
-    for xi, yi, ri in zip(x, y, r):
-        circle = plt.Circle((yi, xi), ri * 1.2, color='red', fill=False, alpha=0.6)
-        ax.add_patch(circle)
-    
-    ax.set_title(f"{name}\nParams {key['params_id']}: {num_blobs} blobs", fontsize=10)
-    ax.axis('off')
-
-plt.tight_layout()
-```
-
-
-## Querying Results
-
-DataJoint's query language makes it easy to explore results:
-
-
-```python
-# Find detections with fewer than 300 blobs
-Detection & 'num_blobs < 300'
-```
-
-
-
-```python
-# Join to see image names with blob counts
-(Image * Detection).proj('image_name', 'num_blobs')
-```
-
-
-## Storing Selections
-
-After reviewing the results, we can record which parameter set works best for each image. This is another Manual table that references our computed results:
-
-
-```python
-@schema
-class SelectedDetection(dj.Manual):
-    definition = """
-    # Best detection for each image
-    -> Image
-    ---
-    -> Detection
+    spikes : <spike_train>
     """
 
-# Select params 3 for Hubble (fewer, larger blobs)
-# Select params 1 for Mitosis (many small spots)
-SelectedDetection.insert([
-    {'image_id': 1, 'params_id': 3},
-    {'image_id': 2, 'params_id': 1},
-], skip_duplicates=True)
+train = SpikeTrain(times=np.sort(np.random.uniform(0, 100, 50)), unit_id=1, quality='good')
+Unit.insert1({'unit_id': 1, 'spikes': train})
 
-SelectedDetection()
+result = (Unit & {'unit_id': 1}).fetch1('spikes')
+print(f"Type: {type(result)}, Spikes: {len(result.times)}")
 ```
 
 
 
 ```python
-# View the final schema with selections
-dj.Diagram(schema)
-```
-
-
-## Key Concepts Recap
-
-| Concept | What It Does | Example |
-|---------|--------------|--------|
-| **Schema** | Groups related tables | `schema = dj.Schema('tutorial_blobs')` |
-| **Manual Table** | Stores user-entered data | `Image`, `SelectedDetection` |
-| **Lookup Table** | Stores reference/config data | `DetectionParams` |
-| **Computed Table** | Derives data automatically | `Detection` |
-| **Part Table** | Stores detailed results with master | `Detection.Blob` |
-| **Foreign Key** (`->`) | Creates dependency | `-> Image` |
-| **`populate()`** | Runs pending computations | `Detection.populate()` |
-| **Restriction** (`&`) | Filters rows | `Detection & 'num_blobs < 300'` |
-| **Join** (`*`) | Combines tables | `Image * Detection` |
-
-## Next Steps
-
-- [Schema Design](02-schema-design.ipynb) — Learn table types and relationships in depth
-- [Queries](04-queries.ipynb) — Master DataJoint's query operators
-- [Computation](05-computation.ipynb) — Build complex computational workflows
-
-
-```python
-# Cleanup: drop the schema for re-running the tutorial
 schema.drop(prompt=False)
 ```
 
 
 ---
-## File: tutorials/02-schema-design.ipynb
+## File: tutorials/advanced/distributed.ipynb
+
+# Distributed Computing
+
+This tutorial covers running computations across multiple workers. You'll learn:
+
+- **Jobs 2.0** — DataJoint's job coordination system
+- **Multi-process** — Parallel workers on one machine
+- **Multi-machine** — Cluster-scale computation
+- **Error handling** — Recovery and monitoring
+
+
+```python
+import datajoint as dj
+import numpy as np
+import time
+
+schema = dj.Schema('tutorial_distributed')
+
+# Clean up from previous runs
+schema.drop(prompt=False)
+schema = dj.Schema('tutorial_distributed')
+```
+
+
+## Setup
+
+
+```python
+@schema
+class Experiment(dj.Manual):
+    definition = """
+    exp_id : int
+    ---
+    n_samples : int
+    """
+
+@schema
+class Analysis(dj.Computed):
+    definition = """
+    -> Experiment
+    ---
+    result : float64
+    compute_time : float32
+    """
+
+    def make(self, key):
+        start = time.time()
+        n = (Experiment & key).fetch1('n_samples')
+        result = float(np.mean(np.random.randn(n) ** 2))
+        time.sleep(0.1)
+        self.insert1({**key, 'result': result, 'compute_time': time.time() - start})
+```
+
+
+
+```python
+Experiment.insert([{'exp_id': i, 'n_samples': 10000} for i in range(20)])
+print(f"To compute: {len(Analysis.key_source - Analysis)}")
+```
+
+
+## Direct vs Distributed Mode
+
+**Direct mode** (default): No coordination, suitable for single worker.
+
+**Distributed mode** (`reserve_jobs=True`): Workers coordinate via jobs table.
+
+
+```python
+# Distributed mode
+Analysis.populate(reserve_jobs=True, max_calls=5, display_progress=True)
+```
+
+
+## The Jobs Table
+
+
+```python
+# Refresh job queue
+result = Analysis.jobs.refresh()
+print(f"Added: {result['added']}")
+
+# Check status
+for status, count in Analysis.jobs.progress().items():
+    print(f"{status}: {count}")
+```
+
+
+## Multi-Process and Multi-Machine
+
+The `processes=N` parameter spawns multiple worker processes on one machine. However, this requires table classes to be defined in importable Python modules (not notebooks), because multiprocessing needs to pickle and transfer the class definitions to worker processes.
+
+For production use, define your tables in a module and run workers as scripts:
+
+```python
+# pipeline.py - Define your tables
+import datajoint as dj
+schema = dj.Schema('my_pipeline')
+
+@schema
+class Analysis(dj.Computed):
+    definition = """..."""
+    def make(self, key): ...
+```
+
+```python
+# worker.py - Run workers
+from pipeline import Analysis
+
+# Single machine, 4 processes
+Analysis.populate(reserve_jobs=True, processes=4)
+
+# Or run this script on multiple machines
+while True:
+    result = Analysis.populate(reserve_jobs=True, max_calls=100, suppress_errors=True)
+    if result['success_count'] == 0:
+        break
+```
+
+In this notebook, we'll demonstrate distributed coordination with a single process:
+
+
+```python
+# Complete remaining jobs with distributed coordination
+Analysis.populate(reserve_jobs=True, display_progress=True)
+print(f"Computed: {len(Analysis())}")
+```
+
+
+## Error Handling
+
+
+```python
+# View errors
+print(f"Errors: {len(Analysis.jobs.errors)}")
+
+# Retry failed jobs
+Analysis.jobs.errors.delete()
+Analysis.populate(reserve_jobs=True, suppress_errors=True)
+```
+
+
+## Quick Reference
+
+| Option | Description |
+|--------|-------------|
+| `reserve_jobs=True` | Enable coordination |
+| `processes=N` | N worker processes |
+| `max_calls=N` | Limit jobs per run |
+| `suppress_errors=True` | Continue on errors |
+
+
+```python
+schema.drop(prompt=False)
+```
+
+
+---
+## File: tutorials/advanced/json-type.ipynb
+
+# JSON Data Type
+
+This tutorial covers the `json` data type in DataJoint, which allows storing semi-structured data within tables. You'll learn:
+
+- When to use the JSON type
+- Defining tables with JSON attributes
+- Inserting JSON data
+- Querying and filtering JSON fields
+- Projecting JSON subfields
+
+## Prerequisites
+
+- **MySQL 8.0+** with `JSON_VALUE` function support
+- Percona is fully compatible
+- MariaDB is **not supported** (different `JSON_VALUE` syntax)
+
+
+```python
+import datajoint as dj
+```
+
+
+## Table Definition
+
+For this exercise, let's imagine we work for an awesome company that is organizing a fun RC car race across various teams in the company. Let's see which team has the fastest car! 🏎️
+
+This establishes 2 important entities: a `Team` and a `Car`. Normally the entities are mapped to their own dedicated table, however, let's assume that `Team` is well-structured but `Car` is less structured than we'd prefer. In other words, the structure for what makes up a *car* is varying too much between entries (perhaps because users of the pipeline haven't agreed yet on the definition? 🤷).
+
+This would make it a good use-case to keep `Team` as a table but make `Car` a `json` type defined within the `Team` table.
+
+Let's begin.
+
+
+```python
+import datajoint as dj
+
+# Clean up any existing schema from previous runs
+schema = dj.Schema('tutorial_json', create_tables=False)
+schema.drop()
+
+# Create fresh schema
+schema = dj.Schema('tutorial_json')
+```
+
+
+
+```python
+@schema
+class Team(dj.Lookup):
+    definition = """
+    # A team within a company
+    name: varchar(40)  # team name
+    ---
+    car=null: json  # A car belonging to a team (null to allow registering first but specifying car later)
+    
+    unique index(car.length:decimal(4, 1))  # Add an index if this key is frequently accessed
+    """
+```
+
+
+## Insert
+
+Let's suppose that engineering is first up to register their car.
+
+
+```python
+Team.insert1(
+    {
+        "name": "engineering",
+        "car": {
+            "name": "Rever",
+            "length": 20.5,
+            "inspected": True,
+            "tire_pressure": [32, 31, 33, 34],
+            "headlights": [
+                {
+                    "side": "left",
+                    "hyper_white": None,
+                },
+                {
+                    "side": "right",
+                    "hyper_white": None,
+                },
+            ],
+        },
+    }
+)
+```
+
+
+Next, business and marketing teams are up and register their cars.
+
+A few points to notice below:
+- The person signing up on behalf of marketing does not know the specifics of the car during registration but another team member will be updating this soon before the race.
+- Notice how the `business` and `engineering` teams appear to specify the same property but refer to it as `safety_inspected` and `inspected` respectfully.
+
+
+```python
+Team.insert(
+    [
+        {
+            "name": "marketing",
+            "car": None,
+        },
+        {
+            "name": "business",
+            "car": {
+                "name": "Chaching",
+                "length": 100,
+                "safety_inspected": False,
+                "tire_pressure": [34, 30, 27, 32],
+                "headlights": [
+                    {
+                        "side": "left",
+                        "hyper_white": True,
+                    },
+                    {
+                        "side": "right",
+                        "hyper_white": True,
+                    },
+                ],
+            },
+        },
+    ]
+)
+```
+
+
+We can preview the table data much like normal but notice how the value of `car` behaves like other BLOB-like attributes.
+
+
+```python
+Team()
+```
+
+
+## Restriction
+
+Now let's see what kinds of queries we can form to demonstrate how we can query this pipeline.
+
+
+```python
+# Which team has a `car` equal to 100 inches long?
+Team & {"car.length": 100}
+```
+
+
+
+```python
+# Which team has a `car` less than 50 inches long?
+Team & "car->>'$.length' < 50"
+```
+
+
+
+```python
+# Any team that has had their car inspected?
+Team & [{"car.inspected:unsigned": True}, {"car.safety_inspected:unsigned": True}]
+```
+
+
+
+```python
+# Which teams do not have hyper white lights for their first head light?
+Team & {"car.headlights[0].hyper_white": None}
+```
+
+
+Notice that the previous query will satisfy the `None` check if it experiences any of the following scenarios:
+- if entire record missing (`marketing` satisfies this)
+- JSON key is missing
+- JSON value is set to JSON `null` (`engineering` satisfies this)
+
+## Projection
+
+Projections can be quite useful with the `json` type since we can extract out just what we need. This allows greater query flexibility but more importantly, for us to be able to fetch only what is pertinent.
+
+
+```python
+# Only interested in the car names and the length but let the type be inferred
+q_untyped = Team.proj(
+    car_name="car.name",
+    car_length="car.length",
+)
+q_untyped
+```
+
+
+
+```python
+q_untyped.to_dicts()
+```
+
+
+
+```python
+# Nevermind, I'll specify the type explicitly
+q_typed = Team.proj(
+    car_name="car.name",
+    car_length="car.length:float",
+)
+q_typed
+```
+
+
+
+```python
+q_typed.to_dicts()
+```
+
+
+## Describe
+
+Lastly, the `.describe()` function on the `Team` table can help us generate the table's definition. This is useful if we are connected directly to the pipeline without the original source.
+
+
+```python
+rebuilt_definition = Team.describe()
+print(rebuilt_definition)
+```
+
+
+## Cleanup
+
+Finally, let's clean up what we created in this tutorial.
+
+
+```python
+schema.drop(prompt=False)
+```
+
+
+---
+## File: tutorials/advanced/sql-comparison.ipynb
+
+# DataJoint for SQL Users
+
+This tutorial maps SQL concepts to DataJoint for users with relational database experience. You'll see:
+
+- How DataJoint syntax corresponds to SQL
+- What DataJoint adds beyond standard SQL
+- When to use each approach
+
+**Prerequisites:** Familiarity with SQL (SELECT, JOIN, WHERE, GROUP BY).
+
+## Setup
+
+
+```python
+import datajoint as dj
+
+schema = dj.Schema('tutorial_sql_comparison')
+```
+
+
+## Schema Definition
+
+### SQL
+```sql
+CREATE TABLE Researcher (
+    researcher_id INT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(100),
+    PRIMARY KEY (researcher_id)
+);
+
+CREATE TABLE Subject (
+    subject_id INT NOT NULL,
+    species VARCHAR(32) NOT NULL,
+    sex ENUM('M', 'F', 'unknown'),
+    PRIMARY KEY (subject_id)
+);
+
+CREATE TABLE Session (
+    subject_id INT NOT NULL,
+    session_date DATE NOT NULL,
+    researcher_id INT NOT NULL,
+    notes VARCHAR(255),
+    PRIMARY KEY (subject_id, session_date),
+    FOREIGN KEY (subject_id) REFERENCES Subject(subject_id),
+    FOREIGN KEY (researcher_id) REFERENCES Researcher(researcher_id)
+);
+```
+
+### DataJoint
+
+
+```python
+@schema
+class Researcher(dj.Manual):
+    definition = """
+    researcher_id : int32
+    ---
+    name : varchar(100)
+    email : varchar(100)
+    """
+
+@schema
+class Subject(dj.Manual):
+    definition = """
+    subject_id : int32
+    ---
+    species : varchar(32)
+    sex : enum('M', 'F', 'unknown')
+    """
+
+@schema
+class Session(dj.Manual):
+    definition = """
+    -> Subject
+    session_date : date
+    ---
+    -> Researcher
+    notes : varchar(255)
+    """
+```
+
+
+### Key Differences
+
+| Aspect | SQL | DataJoint |
+|--------|-----|----------|
+| Primary key | `PRIMARY KEY (...)` | Above `---` line |
+| Foreign key | `FOREIGN KEY ... REFERENCES` | `-> TableName` |
+| Types | `INT`, `VARCHAR(n)` | `int32`, `varchar(n)` |
+| Table metadata | None | Table tier (`Manual`, `Computed`, etc.) |
+
+## Insert Sample Data
+
+
+```python
+Researcher.insert([
+    {'researcher_id': 1, 'name': 'Alice Chen', 'email': 'alice@lab.org'},
+    {'researcher_id': 2, 'name': 'Bob Smith', 'email': 'bob@lab.org'},
+])
+
+Subject.insert([
+    {'subject_id': 1, 'species': 'mouse', 'sex': 'M'},
+    {'subject_id': 2, 'species': 'mouse', 'sex': 'F'},
+    {'subject_id': 3, 'species': 'rat', 'sex': 'M'},
+])
+
+Session.insert([
+    {'subject_id': 1, 'session_date': '2024-06-01',
+     'researcher_id': 1, 'notes': 'First session'},
+    {'subject_id': 1, 'session_date': '2024-06-15',
+     'researcher_id': 1, 'notes': 'Follow-up'},
+    {'subject_id': 2, 'session_date': '2024-06-10',
+     'researcher_id': 2, 'notes': 'Initial'},
+    {'subject_id': 3, 'session_date': '2024-06-20',
+     'researcher_id': 2, 'notes': 'Rat study'},
+])
+```
+
+
+## Query Comparison
+
+### SELECT * FROM table
+
+
+```python
+# SQL: SELECT * FROM Subject
+Subject()
+```
+
+
+### WHERE — Restriction (`&`)
+
+
+```python
+# SQL: SELECT * FROM Subject WHERE sex = 'M'
+Subject & {'sex': 'M'}
+```
+
+
+
+```python
+# SQL: SELECT * FROM Subject WHERE species = 'mouse' AND sex = 'F'
+Subject & {'species': 'mouse', 'sex': 'F'}
+```
+
+
+
+```python
+# SQL: SELECT * FROM Session WHERE session_date > '2024-06-10'
+Session & 'session_date > "2024-06-10"'
+```
+
+
+### Restriction by Query (Subqueries)
+
+In SQL, you often use subqueries to filter based on another table:
+
+```sql
+-- Sessions with mice only
+SELECT * FROM Session 
+WHERE subject_id IN (SELECT subject_id FROM Subject WHERE species = 'mouse')
+```
+
+In DataJoint, you simply restrict by another query — no special subquery syntax needed:
+
+
+```python
+# SQL: SELECT * FROM Session 
+#      WHERE subject_id IN (SELECT subject_id FROM Subject WHERE species = 'mouse')
+
+# DataJoint: restrict Session by a query on Subject
+mice = Subject & {'species': 'mouse'}
+Session & mice
+```
+
+
+
+```python
+# Restrict by Alice's sessions (finds subjects she worked with)
+alice_sessions = Session & (Researcher & {'name': 'Alice Chen'})
+Subject & alice_sessions
+```
+
+
+## Semantic Matching
+
+A fundamental difference between SQL and DataJoint is **semantic matching** — the principle that attributes acquire meaning through foreign key relationships, and all binary operators use this meaning to determine how tables combine.
+
+### The Problem with SQL
+
+SQL requires you to explicitly specify how tables connect:
+
+```sql
+SELECT * FROM Session 
+JOIN Subject ON Session.subject_id = Subject.subject_id;
+```
+
+This is verbose and error-prone. Nothing prevents you from joining on unrelated columns that happen to share a name, or accidentally creating a Cartesian product when tables have no common columns.
+
+Experienced SQL programmers learn to always join through foreign key relationships. DataJoint makes this the **default and enforced behavior**.
+
+### How Semantic Matching Works
+
+In DataJoint, when you declare a foreign key with `-> Subject`, the `subject_id` attribute in your table inherits its **meaning** from the `Subject` table. This meaning propagates through the foreign key graph.
+
+**Semantic matching** means: all binary operators (`*`, `&`, `-`, `+`, `.aggr()`) match attributes based on shared meaning — those connected through foreign keys. If two tables have no semantically matching attributes, the operation raises an error rather than silently producing incorrect results.
+
+
+```python
+# All these operations use semantic matching on subject_id:
+
+# Join: combines Session and Subject on subject_id
+Session * Subject
+
+# Restriction: filters Session to rows matching the Subject query  
+Session & (Subject & {'species': 'mouse'})
+
+# Antijoin: Session rows NOT matching any Subject (none here, all subjects exist)
+Session - Subject
+```
+
+
+### One Join Operator Instead of Many
+
+SQL has multiple join types (`INNER`, `LEFT`, `RIGHT`, `FULL OUTER`, `CROSS`) because it must handle arbitrary column matching. DataJoint's single join operator (`*`) is sufficient because semantic matching is **more restrictive** than SQL's natural joins:
+
+- SQL natural joins match on **all columns with the same name** — which can accidentally match unrelated columns
+- DataJoint semantic joins match only on **attributes connected through foreign keys** — and raise an error if you attempt to join on attributes that shouldn't be joined
+
+This catches errors at query time rather than producing silently incorrect results.
+
+### Algebraic Closure
+
+In standard SQL, query results are just "bags of rows" — they don't have a defined entity type. You cannot know what kind of thing each row represents without external context.
+
+DataJoint achieves **algebraic closure**: every query result is a valid entity set with a well-defined **entity type**. You always know what kind of entity the result represents, identified by a specific primary key. This means:
+
+1. **Every operator returns a valid relation** — not just rows, but a set of entities of a known type
+2. **Operators compose indefinitely** — you can chain any sequence of operations
+3. **Results remain queryable** — a query result can be used as an operand in further operations
+
+The entity type (and its primary key) is determined by precise rules based on the operator and the functional dependencies between operands. See the [Primary Keys specification](../../reference/specs/primary-keys.md) for details.
+
+### SELECT columns — Projection (`.proj()`)
+
+
+```python
+# SQL: SELECT name, email FROM Researcher
+Researcher.proj('name', 'email')
+```
+
+
+
+```python
+# SQL: SELECT subject_id, species AS animal_type FROM Subject
+Subject.proj(animal_type='species')
+```
+
+
+### JOIN
+
+
+```python
+# SQL: SELECT * FROM Session JOIN Subject USING (subject_id)
+Session * Subject
+```
+
+
+
+```python
+# SQL: SELECT session_date, name, species 
+#      FROM Session 
+#      JOIN Subject USING (subject_id) 
+#      JOIN Researcher USING (researcher_id)
+(Session * Subject * Researcher).proj('session_date', 'name', 'species')
+```
+
+
+### GROUP BY — Aggregation (`.aggr()`)
+
+
+```python
+# SQL: SELECT subject_id, COUNT(*) as num_sessions 
+#      FROM Session GROUP BY subject_id
+Subject.aggr(Session, num_sessions='count(*)')
+```
+
+
+
+```python
+# SQL: SELECT researcher_id, name, COUNT(*) as num_sessions
+#      FROM Researcher JOIN Session USING (researcher_id)
+#      GROUP BY researcher_id
+Researcher.aggr(Session, num_sessions='count(*)')
+```
+
+
+
+```python
+# SQL: SELECT AVG(...), COUNT(*) FROM Session (no grouping)
+dj.U().aggr(Session, total_sessions='count(*)')
+```
+
+
+### NOT IN — Negative Restriction (`-`)
+
+
+```python
+# SQL: SELECT * FROM Subject 
+#      WHERE subject_id NOT IN (SELECT subject_id FROM Session)
+# (Subjects with no sessions)
+Subject - Session
+```
+
+
+### Combined Example
+
+
+```python
+# SQL: SELECT r.name, COUNT(*) as mouse_sessions
+#      FROM Researcher r
+#      JOIN Session s USING (researcher_id)
+#      JOIN Subject sub USING (subject_id)
+#      WHERE sub.species = 'mouse'
+#      GROUP BY r.researcher_id
+
+Researcher.aggr(
+    Session * (Subject & {'species': 'mouse'}),
+    mouse_sessions='count(*)'
+)
+```
+
+
+## Operator Reference
+
+| SQL | DataJoint | Notes |
+|-----|-----------|-------|
+| `SELECT *` | `Table()` | Display table |
+| `SELECT cols` | `.proj('col1', 'col2')` | Projection |
+| `SELECT col AS alias` | `.proj(alias='col')` | Rename |
+| `WHERE condition` | `& {'col': value}` or `& 'expr'` | Restriction |
+| `JOIN ... USING` | `Table1 * Table2` | Natural join |
+| `GROUP BY ... AGG()` | `.aggr(Table, alias='agg()')` | Aggregation |
+| `NOT IN (subquery)` | `Table1 - Table2` | Antijoin |
+| `UNION` | `Table1 + Table2` | Union |
+
+## What DataJoint Adds
+
+DataJoint is not just "Python syntax for SQL." It adds:
+
+### 1. Table Tiers
+
+Tables are classified by their role in the workflow:
+
+| Tier | Purpose | SQL Equivalent |
+|------|---------|----------------|
+| `Lookup` | Reference data, parameters | Regular table |
+| `Manual` | User-entered data | Regular table |
+| `Imported` | Data from external files | Regular table + trigger |
+| `Computed` | Derived results | Materialized view + trigger |
+
+### 2. Automatic Computation
+
+Computed tables have a `make()` method that runs automatically. An important principle: **`make()` should only fetch data from upstream tables** — those declared as dependencies in the table definition.
+
+
+```python
+@schema
+class SessionAnalysis(dj.Computed):
+    definition = """
+    -> Session           # depends on Session
+    ---
+    day_of_week : varchar(10)
+    """
+    
+    def make(self, key):
+        # Fetch only from upstream tables (Session and its dependencies)
+        date = (Session & key).fetch1('session_date')
+        self.insert1({**key, 'day_of_week': date.strftime('%A')})
+```
+
+
+
+```python
+# Automatically compute for all sessions
+SessionAnalysis.populate(display_progress=True)
+SessionAnalysis()
+```
+
+
+In SQL, you'd need triggers, stored procedures, or external scheduling to achieve this.
+
+### 3. Cascading Deletes
+
+DataJoint enforces referential integrity with automatic cascading:
+
+
+```python
+# Deleting a session would delete its computed analysis
+# (Session & {'subject_id': 1, 'session_date': '2024-06-01'}).delete()  # Uncomment to try
+```
+
+
+### 4. Schema as Workflow
+
+The diagram shows the computational workflow, not just relationships:
+
+
+```python
+dj.Diagram(schema)
+```
+
+
+- **Green** = Manual (input)
+- **Red** = Computed (derived)
+- Arrows show dependency/execution order
+
+### 5. Object Storage Integration
+
+Store large objects (arrays, files) with relational semantics:
+
+```python
+class Recording(dj.Imported):
+    definition = """
+    -> Session
+    ---
+    raw_data : <blob>       # NumPy array stored in database
+    video : <blob@storage>  # Large file stored externally
+    """
+```
+
+SQL has no standard way to handle this.
+
+## When to Use Raw SQL
+
+DataJoint generates SQL under the hood. Sometimes raw SQL is useful:
+
+
+```python
+# See the generated SQL for any query
+query = Session * Subject & {'species': 'mouse'}
+print(query.make_sql())
+```
+
+
+
+```python
+# Execute raw SQL when needed
+# result = dj.conn().query('SELECT * FROM ...')
+```
+
+
+## Summary
+
+| Feature | SQL | DataJoint |
+|---------|-----|----------|
+| Query language | SQL strings | Python operators |
+| Schema definition | DDL | Python classes |
+| Foreign keys | Manual declaration | `->` syntax |
+| Table purpose | Implicit | Explicit tiers |
+| Automatic computation | Triggers/procedures | `populate()` |
+| Large objects | BLOBs (limited) | Codec system |
+| Workflow visualization | None | `dj.Diagram()` |
+
+DataJoint uses SQL databases (MySQL/PostgreSQL) underneath but provides:
+- **Pythonic syntax** for queries
+- **Workflow semantics** for scientific pipelines
+- **Automatic computation** via `populate()`
+- **Object storage** for large scientific data
+
+
+```python
+# Cleanup
+schema.drop(prompt=False)
+```
+
+
+---
+## File: tutorials/basics/01-first-pipeline.ipynb
+
+# A Simple Pipeline
+
+This tutorial introduces DataJoint by building a simple research lab database. You'll learn to:
+
+- Define tables with primary keys and dependencies
+- Insert and query data
+- Use the four core operations: restriction, projection, join, aggregation
+- Understand the schema diagram
+
+We'll work with **Manual tables** only—tables where you enter data directly. Later tutorials introduce automated computation.
+
+For complete working examples, see:
+- [University Database](../examples/university.ipynb) — Academic records with complex queries
+- [Blob Detection](../examples/blob-detection.ipynb) — Image processing with computation
+
+## Setup
+
+
+```python
+import datajoint as dj
+
+schema = dj.Schema('tutorial_first_pipeline')
+```
+
+
+## The Domain: A Research Lab
+
+We'll model a research lab that:
+- Has **researchers** who conduct experiments
+- Works with **subjects** (e.g., mice)
+- Runs **sessions** where data is collected
+- Collects **recordings** during each session
+
+```mermaid
+flowchart TD
+    Researcher --> Session
+    Subject --> Session
+    Session --> Recording
+```
+
+## Defining Tables
+
+Each table is a Python class. The `definition` string specifies:
+- **Primary key** (above `---`) — uniquely identifies each row
+- **Attributes** (below `---`) — additional data for each row
+- **Dependencies** (`->`) — references to other tables
+
+
+```python
+@schema
+class Researcher(dj.Manual):
+    definition = """
+    researcher_id : int32
+    ---
+    researcher_name : varchar(100)
+    email : varchar(100)
+    """
+```
+
+
+
+```python
+@schema
+class Subject(dj.Manual):
+    definition = """
+    subject_id : int32
+    ---
+    species : varchar(32)
+    date_of_birth : date
+    sex : enum('M', 'F', 'unknown')
+    """
+```
+
+
+### Dependencies
+
+A `Session` involves one researcher and one subject. The `->` syntax creates a **dependency** (foreign key):
+
+
+```python
+@schema
+class Session(dj.Manual):
+    definition = """
+    -> Subject
+    session_date : date
+    ---
+    -> Researcher
+    session_notes : varchar(255)
+    """
+```
+
+
+The `-> Subject` in the primary key means:
+- `subject_id` is automatically included in Session's primary key
+- Combined with `session_date`, each session is uniquely identified
+- You cannot create a session for a non-existent subject
+
+The `-> Researcher` below the line is a non-primary dependency—it records who ran the session but isn't part of the unique identifier.
+
+
+```python
+@schema
+class Recording(dj.Manual):
+    definition = """
+    -> Session
+    recording_id : int16
+    ---
+    duration : float32          # recording duration (seconds)
+    quality : enum('good', 'fair', 'poor')
+    """
+```
+
+
+## Schema Diagram
+
+The diagram shows tables and their dependencies:
+
+
+```python
+dj.Diagram(schema)
+```
+
+
+**Reading the diagram:**
+- **Green boxes** = Manual tables (you enter data)
+- **Solid lines** = Primary key dependencies (part of identity)
+- **Dashed lines** = Non-primary dependencies (references)
+
+## Inserting Data
+
+Data must be inserted in dependency order—you can't reference something that doesn't exist.
+
+
+```python
+# First: tables with no dependencies
+Researcher.insert([
+    {'researcher_id': 1, 'researcher_name': 'Alice Chen',
+     'email': 'alice@lab.org'},
+    {'researcher_id': 2, 'researcher_name': 'Bob Smith',
+     'email': 'bob@lab.org'},
+])
+
+Subject.insert([
+    {'subject_id': 1, 'species': 'mouse',
+     'date_of_birth': '2024-01-15', 'sex': 'M'},
+    {'subject_id': 2, 'species': 'mouse',
+     'date_of_birth': '2024-01-20', 'sex': 'F'},
+    {'subject_id': 3, 'species': 'mouse',
+     'date_of_birth': '2024-02-01', 'sex': 'M'},
+])
+```
+
+
+
+```python
+# Then: tables that depend on others
+Session.insert([
+    {'subject_id': 1, 'session_date': '2024-06-01',
+     'researcher_id': 1, 'session_notes': 'First session'},
+    {'subject_id': 1, 'session_date': '2024-06-15',
+     'researcher_id': 1, 'session_notes': 'Follow-up'},
+    {'subject_id': 2, 'session_date': '2024-06-10',
+     'researcher_id': 2, 'session_notes': 'Initial recording'},
+])
+```
+
+
+
+```python
+# Finally: tables at the bottom of the hierarchy
+Recording.insert([
+    {'subject_id': 1, 'session_date': '2024-06-01', 'recording_id': 1,
+     'duration': 300.5, 'quality': 'good'},
+    {'subject_id': 1, 'session_date': '2024-06-01', 'recording_id': 2,
+     'duration': 450.0, 'quality': 'good'},
+    {'subject_id': 1, 'session_date': '2024-06-15', 'recording_id': 1,
+     'duration': 600.0, 'quality': 'fair'},
+    {'subject_id': 2, 'session_date': '2024-06-10', 'recording_id': 1,
+     'duration': 350.0, 'quality': 'good'},
+])
+```
+
+
+## Viewing Data
+
+Display a table by calling it:
+
+
+```python
+Subject()
+```
+
+
+
+```python
+Recording()
+```
+
+
+## The Four Core Operations
+
+DataJoint queries use four fundamental operations. These compose to answer any question about your data.
+
+### 1. Restriction (`&`) — Filter rows
+
+Keep only rows matching a condition:
+
+
+```python
+# Subjects that are male
+Subject & {'sex': 'M'}
+```
+
+
+
+```python
+# Recordings with good quality
+Recording & 'quality = "good"'
+```
+
+
+
+```python
+# Sessions for subject 1
+Session & {'subject_id': 1}
+```
+
+
+### 2. Projection (`.proj()`) — Select columns
+
+Choose which attributes to return, or compute new ones:
+
+
+```python
+# Just names and emails
+Researcher.proj('researcher_name', 'email')
+```
+
+
+
+```python
+# Compute duration in minutes
+Recording.proj(duration_min='duration / 60')
+```
+
+
+### 3. Join (`*`) — Combine tables
+
+Merge data from related tables:
+
+
+```python
+# Sessions with subject info
+Session * Subject
+```
+
+
+
+```python
+# Full recording details with subject and researcher
+(Recording * Session * Subject * Researcher).proj(
+    'researcher_name', 'species', 'duration', 'quality'
+)
+```
+
+
+### 4. Aggregation (`.aggr()`) — Summarize groups
+
+Compute statistics across groups of rows:
+
+
+```python
+# Count recordings per session
+Session.aggr(Recording, num_recordings='count(*)')
+```
+
+
+
+```python
+# Total recording time per subject
+Subject.aggr(Recording, total_duration='sum(duration)')
+```
+
+
+
+```python
+# Average duration across all recordings
+dj.U().aggr(Recording, avg_duration='avg(duration)')
+```
+
+
+## Combining Operations
+
+Operations chain together to answer complex questions:
+
+
+```python
+# Good-quality recordings for male subjects, with researcher name
+(
+    Recording 
+    & 'quality = "good"' 
+    & (Subject & {'sex': 'M'})
+) * Session * Researcher.proj('researcher_name')
+```
+
+
+
+```python
+# Count of good recordings per researcher
+Researcher.aggr(
+    Session * (Recording & 'quality = "good"'),
+    good_recordings='count(*)'
+)
+```
+
+
+## Fetching Data
+
+To get data into Python, use fetch methods:
+
+
+```python
+# Fetch as list of dicts
+Subject.to_dicts()
+```
+
+
+
+```python
+# Fetch specific attributes as arrays
+durations = (Recording & 'quality = "good"').to_arrays('duration')
+print(f"Good recording durations: {durations}")
+```
+
+
+
+```python
+# Fetch one row
+one_subject = (Subject & {'subject_id': 1}).fetch1()
+print(f"Subject 1: {one_subject}")
+```
+
+
+## Deleting Data
+
+Deleting respects dependencies—downstream data is deleted automatically:
+
+
+```python
+# This would delete the session AND all its recordings
+# (Session & {'subject_id': 2, 'session_date': '2024-06-10'}).delete()
+
+# Uncomment to try (will prompt for confirmation)
+```
+
+
+## Summary
+
+You've learned the fundamentals of DataJoint:
+
+| Concept | Description |
+|---------|-------------|
+| **Tables** | Python classes with a `definition` string |
+| **Primary key** | Above `---`, uniquely identifies rows |
+| **Dependencies** | `->` creates foreign keys |
+| **Restriction** | `&` filters rows |
+| **Projection** | `.proj()` selects/computes columns |
+| **Join** | `*` combines tables |
+| **Aggregation** | `.aggr()` summarizes groups |
+
+### Next Steps
+
+- [Schema Design](02-schema-design.ipynb) — Primary keys, relationships, table tiers
+- [Queries](04-queries.ipynb) — Advanced query patterns
+- [Computation](05-computation.ipynb) — Automated processing with Imported/Computed tables
+
+### Complete Examples
+
+- [University Database](../examples/university.ipynb) — Complex queries on academic records
+- [Blob Detection](../examples/blob-detection.ipynb) — Image processing pipeline with computation
+
+
+```python
+# Cleanup
+schema.drop(prompt=False)
+```
+
+
+---
+## File: tutorials/basics/02-schema-design.ipynb
 
 # Schema Design
 
@@ -2468,7 +4340,11 @@ The `->` syntax creates a **foreign key** dependency. Foreign keys:
 
 ```python
 # Let's insert some data to see how foreign keys work
-Lab.insert1({'lab_id': 'tolias', 'lab_name': 'Tolias Lab', 'institution': 'Baylor College of Medicine'})
+Lab.insert1({
+    'lab_id': 'tolias',
+    'lab_name': 'Tolias Lab',
+    'institution': 'Baylor College of Medicine'
+})
 # Note: created_at is auto-populated with CURRENT_TIMESTAMP
 
 Subject.insert1({
@@ -2654,9 +4530,33 @@ dj.Diagram(schema)
 
 ### Reading the Diagram
 
-- **Colors**: Green = Manual, Gray = Lookup, Red = Computed, Blue = Imported
-- **Solid lines**: Foreign key in primary key (one-to-many containment)
-- **Dashed lines**: Foreign key in secondary attributes (reference)
+DataJoint diagrams show tables as nodes and foreign keys as edges. The notation conveys relationship semantics at a glance.
+
+**Line Styles:**
+
+| Line | Style | Relationship | Meaning |
+|------|-------|--------------|---------|
+| ━━━ | Thick solid | Extension | FK **is** entire PK (one-to-one) |
+| ─── | Thin solid | Containment | FK **in** PK with other fields (one-to-many) |
+| ┄┄┄ | Dashed | Reference | FK in secondary attributes (one-to-many) |
+
+**Visual Indicators:**
+
+| Indicator | Meaning |
+|-----------|---------|
+| **Underlined name** | Introduces new dimension (new PK attributes) |
+| Non-underlined name | Inherits all dimensions (PK entirely from FKs) |
+| **Green** | Manual table |
+| **Gray** | Lookup table |
+| **Red** | Computed table |
+| **Blue** | Imported table |
+| **Orange dots** | Renamed foreign keys (via `.proj()`) |
+
+**Key principle:** Solid lines mean the parent's identity becomes part of the child's identity. Dashed lines mean the child maintains independent identity.
+
+**Note:** Diagrams do NOT show `[nullable]` or `[unique]` modifiers—check table definitions for these constraints.
+
+See [How to Read Diagrams](../../how-to/read-diagrams.ipynb) for diagram operations and comparison to ER notation.
 
 ## Insert Test Data and Populate
 
@@ -2773,7 +4673,7 @@ schema.drop(prompt=False)
 
 
 ---
-## File: tutorials/03-data-entry.ipynb
+## File: tutorials/basics/03-data-entry.ipynb
 
 # Data Entry
 
@@ -2882,8 +4782,18 @@ Use `insert()` to add multiple rows at once. This is more efficient than calling
 ```python
 # Insert multiple rows as a list of dictionaries
 Subject.insert([
-    {'subject_id': 'M002', 'lab_id': 'tolias', 'species': 'Mus musculus', 'date_of_birth': '2026-02-01'},
-    {'subject_id': 'M003', 'lab_id': 'tolias', 'species': 'Mus musculus', 'date_of_birth': '2026-02-15'},
+    {
+        'subject_id': 'M002',
+        'lab_id': 'tolias',
+        'species': 'Mus musculus',
+        'date_of_birth': '2026-02-01'
+    },
+    {
+        'subject_id': 'M003',
+        'lab_id': 'tolias',
+        'species': 'Mus musculus',
+        'date_of_birth': '2026-02-15'
+    },
 ])
 
 Subject()
@@ -2997,11 +4907,16 @@ with dj.conn().transaction:
         'duration': 45.5
     })
     Session.Trial.insert([
-        {'subject_id': 'M001', 'session_idx': 1, 'trial_idx': 1, 'outcome': 'hit', 'reaction_time': 0.35},
-        {'subject_id': 'M001', 'session_idx': 1, 'trial_idx': 2, 'outcome': 'miss', 'reaction_time': 0.82},
-        {'subject_id': 'M001', 'session_idx': 1, 'trial_idx': 3, 'outcome': 'hit', 'reaction_time': 0.41},
-        {'subject_id': 'M001', 'session_idx': 1, 'trial_idx': 4, 'outcome': 'false_alarm', 'reaction_time': 0.28},
-        {'subject_id': 'M001', 'session_idx': 1, 'trial_idx': 5, 'outcome': 'hit', 'reaction_time': 0.39},
+        {'subject_id': 'M001', 'session_idx': 1, 'trial_idx': 1,
+         'outcome': 'hit', 'reaction_time': 0.35},
+        {'subject_id': 'M001', 'session_idx': 1, 'trial_idx': 2,
+         'outcome': 'miss', 'reaction_time': 0.82},
+        {'subject_id': 'M001', 'session_idx': 1, 'trial_idx': 3,
+         'outcome': 'hit', 'reaction_time': 0.41},
+        {'subject_id': 'M001', 'session_idx': 1, 'trial_idx': 4,
+         'outcome': 'false_alarm', 'reaction_time': 0.28},
+        {'subject_id': 'M001', 'session_idx': 1, 'trial_idx': 5,
+         'outcome': 'hit', 'reaction_time': 0.39},
     ])
 
 # Both master and parts committed together, or neither if error occurred
@@ -3136,10 +5051,17 @@ The `prompt` parameter controls whether `delete()` asks for confirmation. When `
 ```python
 # Add more data for demonstration
 with dj.conn().transaction:
-    Session.insert1({'subject_id': 'M002', 'session_idx': 1, 'session_date': '2026-01-07', 'duration': 30.0})
+    Session.insert1({
+        'subject_id': 'M002',
+        'session_idx': 1,
+        'session_date': '2026-01-07',
+        'duration': 30.0
+    })
     Session.Trial.insert([
-        {'subject_id': 'M002', 'session_idx': 1, 'trial_idx': 1, 'outcome': 'hit', 'reaction_time': 0.40},
-        {'subject_id': 'M002', 'session_idx': 1, 'trial_idx': 2, 'outcome': 'hit', 'reaction_time': 0.38},
+        {'subject_id': 'M002', 'session_idx': 1, 'trial_idx': 1,
+         'outcome': 'hit', 'reaction_time': 0.40},
+        {'subject_id': 'M002', 'session_idx': 1, 'trial_idx': 2,
+         'outcome': 'hit', 'reaction_time': 0.38},
     ])
 
 # Delete with prompt=False (no confirmation prompt)
@@ -3155,10 +5077,17 @@ When source data needs to change, the correct pattern is **delete → insert →
 ```python
 # Add a session with trials (using transaction for compositional integrity)
 with dj.conn().transaction:
-    Session.insert1({'subject_id': 'M003', 'session_idx': 1, 'session_date': '2026-01-08', 'duration': 40.0})
+    Session.insert1({
+        'subject_id': 'M003',
+        'session_idx': 1,
+        'session_date': '2026-01-08',
+        'duration': 40.0
+    })
     Session.Trial.insert([
-        {'subject_id': 'M003', 'session_idx': 1, 'trial_idx': 1, 'outcome': 'hit', 'reaction_time': 0.35},
-        {'subject_id': 'M003', 'session_idx': 1, 'trial_idx': 2, 'outcome': 'miss', 'reaction_time': 0.50},
+        {'subject_id': 'M003', 'session_idx': 1, 'trial_idx': 1,
+         'outcome': 'hit', 'reaction_time': 0.35},
+        {'subject_id': 'M003', 'session_idx': 1, 'trial_idx': 2,
+         'outcome': 'miss', 'reaction_time': 0.50},
     ])
 
 # Compute results
@@ -3184,7 +5113,7 @@ with dj.conn().transaction:
     Session.insert1({**key, 'session_date': '2026-01-08', 'duration': 40.0})
     Session.Trial.insert([
         {**key, 'trial_idx': 1, 'outcome': 'hit', 'reaction_time': 0.35},
-        {**key, 'trial_idx': 2, 'outcome': 'hit', 'reaction_time': 0.50},  # Corrected!
+        {**key, 'trial_idx': 2, 'outcome': 'hit', 'reaction_time': 0.50},
     ])
 
 # 3. Recompute
@@ -3244,10 +5173,17 @@ Single operations are atomic by default. Use explicit transactions for:
 ```python
 # Atomic transaction - all inserts succeed or none do
 with dj.conn().transaction:
-    Session.insert1({'subject_id': 'M007', 'session_idx': 1, 'session_date': '2026-01-10', 'duration': 35.0})
+    Session.insert1({
+        'subject_id': 'M007',
+        'session_idx': 1,
+        'session_date': '2026-01-10',
+        'duration': 35.0
+    })
     Session.Trial.insert([
-        {'subject_id': 'M007', 'session_idx': 1, 'trial_idx': 1, 'outcome': 'hit', 'reaction_time': 0.33},
-        {'subject_id': 'M007', 'session_idx': 1, 'trial_idx': 2, 'outcome': 'miss', 'reaction_time': 0.45},
+        {'subject_id': 'M007', 'session_idx': 1, 'trial_idx': 1,
+         'outcome': 'hit', 'reaction_time': 0.33},
+        {'subject_id': 'M007', 'session_idx': 1, 'trial_idx': 2,
+         'outcome': 'miss', 'reaction_time': 0.45},
     ])
 
 print(f"Session inserted with {len(Session.Trial & {'subject_id': 'M007'})} trials")
@@ -3335,7 +5271,7 @@ schema.drop(prompt=False)
 
 
 ---
-## File: tutorials/04-queries.ipynb
+## File: tutorials/basics/04-queries.ipynb
 
 # Queries
 
@@ -3418,20 +5354,29 @@ Experimenter.insert([
 ])
 
 subjects = [
-    {'subject_id': 'M001', 'species': 'Mus musculus', 'date_of_birth': '2026-01-15', 'sex': 'M', 'weight': 25.3},
-    {'subject_id': 'M002', 'species': 'Mus musculus', 'date_of_birth': '2026-02-01', 'sex': 'F', 'weight': 22.1},
-    {'subject_id': 'M003', 'species': 'Mus musculus', 'date_of_birth': '2026-02-15', 'sex': 'M', 'weight': 26.8},
-    {'subject_id': 'R001', 'species': 'Rattus norvegicus', 'date_of_birth': '2024-01-01', 'sex': 'F', 'weight': 280.5},
+    {'subject_id': 'M001', 'species': 'Mus musculus',
+     'date_of_birth': '2026-01-15', 'sex': 'M', 'weight': 25.3},
+    {'subject_id': 'M002', 'species': 'Mus musculus',
+     'date_of_birth': '2026-02-01', 'sex': 'F', 'weight': 22.1},
+    {'subject_id': 'M003', 'species': 'Mus musculus',
+     'date_of_birth': '2026-02-15', 'sex': 'M', 'weight': 26.8},
+    {'subject_id': 'R001', 'species': 'Rattus norvegicus',
+     'date_of_birth': '2024-01-01', 'sex': 'F', 'weight': 280.5},
 ]
 Subject.insert(subjects)
 
 # Insert sessions
 sessions = [
-    {'subject_id': 'M001', 'session_idx': 1, 'experimenter_id': 'alice', 'session_date': '2026-01-06', 'duration': 45.0},
-    {'subject_id': 'M001', 'session_idx': 2, 'experimenter_id': 'alice', 'session_date': '2026-01-07', 'duration': 50.0},
-    {'subject_id': 'M002', 'session_idx': 1, 'experimenter_id': 'bob', 'session_date': '2026-01-06', 'duration': 40.0},
-    {'subject_id': 'M002', 'session_idx': 2, 'experimenter_id': 'bob', 'session_date': '2026-01-08', 'duration': 55.0},
-    {'subject_id': 'M003', 'session_idx': 1, 'experimenter_id': 'alice', 'session_date': '2026-01-07', 'duration': 35.0},
+    {'subject_id': 'M001', 'session_idx': 1, 'experimenter_id': 'alice',
+     'session_date': '2026-01-06', 'duration': 45.0},
+    {'subject_id': 'M001', 'session_idx': 2, 'experimenter_id': 'alice',
+     'session_date': '2026-01-07', 'duration': 50.0},
+    {'subject_id': 'M002', 'session_idx': 1, 'experimenter_id': 'bob',
+     'session_date': '2026-01-06', 'duration': 40.0},
+    {'subject_id': 'M002', 'session_idx': 2, 'experimenter_id': 'bob',
+     'session_date': '2026-01-08', 'duration': 55.0},
+    {'subject_id': 'M003', 'session_idx': 1, 'experimenter_id': 'alice',
+     'session_date': '2026-01-07', 'duration': 35.0},
 ]
 Session.insert(sessions)
 
@@ -3450,7 +5395,8 @@ for s in sessions:
         })
 Session.Trial.insert(trials)
 
-print(f"Subjects: {len(Subject())}, Sessions: {len(Session())}, Trials: {len(Session.Trial())}")
+print(f"Subjects: {len(Subject())}, Sessions: {len(Session())}, "
+      f"Trials: {len(Session.Trial())}")
 ```
 
 
@@ -4030,7 +5976,7 @@ schema.drop(prompt=False)
 
 
 ---
-## File: tutorials/05-computation.ipynb
+## File: tutorials/basics/05-computation.ipynb
 
 # Computation
 
@@ -4134,7 +6080,8 @@ for s in sessions:
         })
 Session.Trial.insert(trials)
 
-print(f"Subjects: {len(Subject())}, Sessions: {len(Session())}, Trials: {len(Session.Trial())}")
+print(f"Subjects: {len(Subject())}, Sessions: {len(Session())}, "
+      f"Trials: {len(Session.Trial())}")
 ```
 
 
@@ -4561,7 +6508,7 @@ schema.drop(prompt=False)
 
 
 ---
-## File: tutorials/06-object-storage.ipynb
+## File: tutorials/basics/06-object-storage.ipynb
 
 # Object-Augmented Schemas
 
@@ -4625,7 +6572,7 @@ Use `<blob>` to store arbitrary Python objects:
 @schema
 class Recording(dj.Manual):
     definition = """
-    recording_id : int
+    recording_id : uint16
     ---
     metadata : <blob>         # Dict, stored in database
     waveform : <blob>         # NumPy array, stored in database
@@ -4672,7 +6619,7 @@ The `<blob>` codec handles:
 @schema
 class AnalysisResult(dj.Manual):
     definition = """
-    result_id : int
+    result_id : uint16
     ---
     arrays : <blob>
     nested_data : <blob>
@@ -4711,13 +6658,8 @@ import os
 # Create a store for this tutorial
 store_path = tempfile.mkdtemp(prefix='dj_store_')
 
-# Configure object storage (global settings for staged_insert1)
-dj.config.object_storage.protocol = 'file'
-dj.config.object_storage.location = store_path
-dj.config.object_storage.project_name = 'tutorial'
-
-# Also configure as a named store for <blob@tutorial> syntax
-dj.config.object_storage.stores['tutorial'] = {
+# Configure a named store for this tutorial
+dj.config.stores['tutorial'] = {
     'protocol': 'file',
     'location': store_path
 }
@@ -4733,7 +6675,7 @@ print(f"Store configured at: {store_path}")
 @schema
 class LargeRecording(dj.Manual):
     definition = """
-    recording_id : int
+    recording_id : uint16
     ---
     small_data : <blob>            # In database (small)
     large_data : <blob@tutorial>   # In object storage (large)
@@ -4777,9 +6719,9 @@ for root, dirs, files in os.walk(store_path):
 ```
 
 
-### Content-Addressed Storage
+### Hash-Addressed Storage
 
-`<blob@>` uses content-addressed (hash-based) storage. Identical data is stored only once:
+`<blob@>` uses hash-addressed storage. Data is identified by a Base32-encoded MD5 hash, enabling automatic deduplication—identical data is stored only once:
 
 
 ```python
@@ -4799,9 +6741,9 @@ print(f"Files in store: {len(files)}")
 ```
 
 
-## Path-Addressed Storage with `<object@>`
+## Schema-Addressed Storage with `<object@>`
 
-While `<blob@>` uses content-addressed (hash-based) storage with deduplication, `<object@>` uses **path-addressed** storage where each row has its own dedicated storage path:
+While `<blob@>` uses hash-addressed storage with deduplication, `<object@>` uses **schema-addressed** storage where each row has its own dedicated storage path:
 
 | Aspect | `<blob@>` | `<object@>` |
 |--------|-----------|-------------|
@@ -4856,12 +6798,13 @@ with ImagingSession.staged_insert1 as staged:
     store = staged.store('frames', '.zarr')
     
     # Create Zarr array directly in object storage
-    z = zarr.open(store, mode='w', shape=(n_frames, height, width), 
+    z = zarr.open(store, mode='w', shape=(n_frames, height, width),
                   chunks=(10, height, width), dtype='uint16')
     
     # Write frames as they are "acquired"
     for i in range(n_frames):
-        z[i] = np.random.randint(0, 4096, (height, width), dtype='uint16')
+        frame = np.random.randint(0, 4096, (height, width), dtype='uint16')
+        z[i] = frame
     
     # Set remaining attributes
     staged.rec['n_frames'] = n_frames
@@ -4908,7 +6851,7 @@ Use `<attach>` to store files with their original names preserved:
 @schema
 class Document(dj.Manual):
     definition = """
-    doc_id : int
+    doc_id : uint16
     ---
     report : <attach@tutorial>
     """
@@ -5055,12 +6998,12 @@ archived_data : <blob@archive>
 @schema
 class Experiment(dj.Manual):
     definition = """
-    exp_id : int
+    exp_id : uint16
     ---
     # Queryable metadata
     date : date
-    duration : float
-    n_trials : int
+    duration : float32
+    n_trials : uint16
     # Large data
     raw_data : <blob@>
     """
@@ -5074,6 +7017,40 @@ video : <attach@>
 config_file : <attach@>
 ```
 
+## Garbage Collection
+
+Hash-addressed storage (`<blob@>`, `<attach@>`, `<hash@>`) uses deduplication—identical content is stored once. This means deleting a row doesn't automatically delete the stored content, since other rows might reference it.
+
+Use garbage collection to clean up orphaned content:
+
+```python
+import datajoint as dj
+
+# Preview what would be deleted (dry run)
+stats = dj.gc.collect(dry_run=True)
+print(f"Orphaned items: {stats['orphaned']}")
+print(f"Space to reclaim: {stats['orphaned_bytes'] / 1e6:.1f} MB")
+
+# Actually delete orphaned content
+stats = dj.gc.collect()
+print(f"Deleted: {stats['deleted']} items")
+```
+
+### When to Run Garbage Collection
+
+- **After bulk deletions** — Clean up storage after removing many rows
+- **Periodically** — Schedule weekly/monthly cleanup jobs
+- **Before archiving** — Reclaim space before backups
+
+### Key Points
+
+- GC only affects hash-addressed types (`<blob@>`, `<attach@>`, `<hash@>`)
+- Schema-addressed types (`<object@>`, `<npy@>`) are deleted with their rows
+- Always use `dry_run=True` first to preview changes
+- GC is safe—it only deletes content with zero references
+
+See [Clean Up Storage](../how-to/garbage-collection.md) for detailed usage.
+
 ## Quick Reference
 
 | Pattern | Use Case |
@@ -5082,11 +7059,12 @@ config_file : <attach@>
 | `<blob@>` | Large arrays with deduplication |
 | `<blob@store>` | Large arrays in specific store |
 | `<attach@store>` | Files preserving names |
-| `<object@store>` | Path-addressed data (Zarr, HDF5) |
+| `<object@store>` | Schema-addressed data (Zarr, HDF5) |
 
 ## Next Steps
 
 - [Configure Object Storage](../how-to/configure-storage.md) — Set up S3, MinIO, or filesystem stores
+- [Clean Up Storage](../how-to/garbage-collection.md) — Garbage collection for hash-addressed storage
 - [Custom Codecs](advanced/custom-codecs.ipynb) — Define domain-specific types
 - [Manage Large Data](../how-to/manage-large-data.md) — Performance optimization
 
@@ -5100,7 +7078,3311 @@ shutil.rmtree(store_path, ignore_errors=True)
 
 
 ---
-## File: tutorials/07-university.ipynb
+## File: tutorials/domain/allen-ccf/allen-ccf.ipynb
+
+# Allen Common Coordinate Framework (CCF)
+
+This tutorial demonstrates how to model the Allen Mouse Brain Common Coordinate Framework in DataJoint. You'll learn to:
+
+- Model **hierarchical structures** (brain region ontology)
+- Use **Part tables** for large-scale voxel data
+- Handle **self-referential relationships** (parent regions)
+- **Batch insert** large datasets efficiently
+
+## The Allen CCF
+
+The CCF is a 3D reference atlas of the mouse brain, providing:
+- Coordinate system with voxel resolution (10, 25, 50, or 100 µm)
+- Hierarchical ontology of ~1300 brain regions
+- Region boundaries for each voxel
+
+**Reference:**
+> Wang Q, Ding SL, Li Y, et al. (2020). The Allen Mouse Brain Common Coordinate Framework: A 3D Reference Atlas. *Cell*, 181(4), 936-953.e20. DOI: [10.1016/j.cell.2020.04.007](https://doi.org/10.1016/j.cell.2020.04.007)
+
+## Data Sources
+
+- **Ontology**: [structure_graph.csv](http://api.brain-map.org/api/v2/data/query.csv?criteria=model::Structure,rma::criteria,[ontology_id$eq1],rma::options[order$eq%27structures.graph_order%27][num_rows$eqall])
+- **Volume**: [Allen Institute Archive](http://download.alleninstitute.org/informatics-archive/current-release/mouse_ccf/annotation/)
+
+> **Note**: This tutorial works with the ontology (small CSV). The full 3D volume requires ~100MB+ download.
+
+## Setup
+
+
+```python
+import datajoint as dj
+import numpy as np
+import pandas as pd
+from pathlib import Path
+import urllib.request
+
+schema = dj.Schema('tutorial_allen_ccf')
+
+DATA_DIR = Path('./data')
+DATA_DIR.mkdir(exist_ok=True)
+```
+
+
+## Download Brain Region Ontology
+
+The ontology defines the hierarchical structure of brain regions.
+
+
+```python
+ONTOLOGY_URL = (
+    "http://api.brain-map.org/api/v2/data/query.csv?"
+    "criteria=model::Structure,rma::criteria,[ontology_id$eq1],"
+    "rma::options[order$eq%27structures.graph_order%27][num_rows$eqall]"
+)
+ONTOLOGY_FILE = DATA_DIR / 'allen_structure_graph.csv'
+
+if not ONTOLOGY_FILE.exists():
+    print("Downloading Allen brain structure ontology...")
+    urllib.request.urlretrieve(ONTOLOGY_URL, ONTOLOGY_FILE)
+    print(f"Downloaded to {ONTOLOGY_FILE}")
+else:
+    print(f"Using cached {ONTOLOGY_FILE}")
+
+ontology = pd.read_csv(ONTOLOGY_FILE)
+print(f"Loaded {len(ontology)} brain regions")
+ontology.head()
+```
+
+
+## Schema Design
+
+### CCF Master Table
+
+The master table stores atlas metadata. Multiple CCF versions (different resolutions) can coexist.
+
+
+```python
+@schema
+class CCF(dj.Manual):
+    definition = """
+    # Common Coordinate Framework atlas
+    ccf_id : int32
+    ---
+    ccf_version : varchar(64)       # e.g., 'CCFv3'
+    ccf_resolution : float32        # voxel resolution in microns
+    ccf_description : varchar(255)
+    """
+```
+
+
+### Brain Region Table
+
+Each brain region has an ID, name, acronym, and color code for visualization.
+
+
+```python
+@schema
+class BrainRegion(dj.Imported):
+    definition = """
+    # Brain region from Allen ontology
+    -> CCF
+    region_id : int32               # Allen structure ID
+    ---
+    acronym : varchar(32)           # short name (e.g., 'VISp')
+    region_name : varchar(255)      # full name
+    color_hex : varchar(6)          # hex color code for visualization
+    structure_order : int32         # order in hierarchy
+    """
+
+    def make(self, key):
+        # Load ontology and insert all regions for this CCF
+        ontology = pd.read_csv(ONTOLOGY_FILE)
+        
+        entries = [
+            {
+                **key,
+                'region_id': row['id'],
+                'acronym': row['acronym'],
+                'region_name': row['safe_name'],
+                'color_hex': row['color_hex_triplet'],
+                'structure_order': row['graph_order'],
+            }
+            for _, row in ontology.iterrows()
+        ]
+        
+        self.insert(entries)
+        print(f"Inserted {len(entries)} brain regions")
+```
+
+
+### Hierarchical Parent-Child Relationships
+
+Brain regions form a hierarchy (e.g., Visual Cortex → Primary Visual Area → Layer 1). We model this with a self-referential foreign key.
+
+
+```python
+@schema
+class RegionParent(dj.Imported):
+    definition = """
+    # Hierarchical parent-child relationships
+    -> BrainRegion
+    ---
+    -> BrainRegion.proj(parent_id='region_id')   # parent region
+    depth : int16                                 # depth in hierarchy (root=0)
+    """
+
+    def make(self, key):
+        ontology = pd.read_csv(ONTOLOGY_FILE)
+        
+        # Build parent mapping
+        parent_map = dict(zip(ontology['id'], ontology['parent_structure_id']))
+        
+        entries = []
+        for _, row in ontology.iterrows():
+            parent_id = row['parent_structure_id']
+            # Skip root (no parent) or if parent not in ontology
+            if pd.isna(parent_id):
+                parent_id = row['id']  # root points to itself
+            
+            entries.append({
+                **key,
+                'region_id': row['id'],
+                'parent_id': int(parent_id),
+                'depth': row['depth'],
+            })
+        
+        self.insert(entries)
+        print(f"Inserted {len(entries)} parent relationships")
+```
+
+
+### Voxel Data (Optional)
+
+For the full atlas, each voxel maps to a brain region. This is a large table (~10M+ rows for 10µm resolution).
+
+**Design note:** `CCF` is part of the primary key because a voxel's identity depends on which atlas it belongs to. The coordinate `(x=5000, y=3000, z=4000)` exists in every atlas version (10µm, 25µm, etc.) but represents different physical mappings. Without `ccf_id` in the primary key, you couldn't store voxels from multiple atlas resolutions.
+
+> **Note**: We define the schema but don't populate it in this tutorial due to data size.
+
+
+```python
+@schema
+class Voxel(dj.Imported):
+    definition = """
+    # Brain atlas voxels
+    -> CCF
+    x : int32                       # AP axis (µm)
+    y : int32                       # DV axis (µm) 
+    z : int32                       # ML axis (µm)
+    ---
+    -> BrainRegion
+    index(y, z)                     # for efficient coronal slice queries
+    """
+    
+    # Note: make() would load NRRD file and insert voxels
+    # Skipped in this tutorial due to data size
+```
+
+
+## View Schema
+
+
+```python
+dj.Diagram(schema)
+```
+
+
+## Populate the Database
+
+
+```python
+# Insert CCF metadata
+CCF.insert1(
+    {
+        'ccf_id': 1,
+        'ccf_version': 'CCFv3',
+        'ccf_resolution': 25.0,
+        'ccf_description': 'Allen Mouse CCF v3 (25µm resolution)'
+    },
+    skip_duplicates=True
+)
+
+CCF()
+```
+
+
+
+```python
+# Populate brain regions
+BrainRegion.populate(display_progress=True)
+```
+
+
+
+```python
+# View sample regions
+BrainRegion() & 'region_id < 100'
+```
+
+
+
+```python
+# Populate parent relationships
+RegionParent.populate(display_progress=True)
+```
+
+
+## Querying the Hierarchy
+
+### Find a Region by Acronym
+
+
+```python
+# Find primary visual cortex
+BrainRegion & 'acronym = "VISp"'
+```
+
+
+### Find Children of a Region
+
+
+```python
+# Get VISp region ID
+visp = (BrainRegion & 'acronym = "VISp"').fetch1()
+visp_id = visp['region_id']
+
+# Find all children (direct descendants)
+children = BrainRegion * (RegionParent & f'parent_id = {visp_id}' & f'region_id != {visp_id}')
+children.proj('acronym', 'region_name')
+```
+
+
+### Find Parent Path (Ancestors)
+
+
+```python
+def get_ancestors(region_acronym, ccf_id=1):
+    """Get the path from a region to the root."""
+    region = (BrainRegion & f'acronym = "{region_acronym}"' & f'ccf_id = {ccf_id}').fetch1()
+    region_id = region['region_id']
+    
+    path = [region['acronym']]
+    
+    while True:
+        parent_id = (RegionParent & {'ccf_id': ccf_id, 'region_id': region_id}).fetch1('parent_id')
+        if parent_id == region_id:  # reached root
+            break
+        parent = (BrainRegion & {'ccf_id': ccf_id, 'region_id': parent_id}).fetch1()
+        path.append(parent['acronym'])
+        region_id = parent_id
+    
+    return ' → '.join(reversed(path))
+
+# Show path from VISp layer 1 to root
+print("Path from VISp1 to root:")
+print(get_ancestors('VISp1'))
+```
+
+
+### Count Regions by Depth
+
+
+```python
+# Aggregate regions by depth in hierarchy
+import matplotlib.pyplot as plt
+
+depths = (RegionParent & 'ccf_id = 1').to_arrays('depth')
+unique, counts = np.unique(depths, return_counts=True)
+
+plt.figure(figsize=(10, 4))
+plt.bar(unique, counts)
+plt.xlabel('Depth in Hierarchy')
+plt.ylabel('Number of Regions')
+plt.title('Brain Regions by Hierarchy Depth')
+plt.xticks(unique)
+```
+
+
+### Search Regions by Name
+
+
+```python
+# Find all visual-related regions
+(BrainRegion & 'region_name LIKE "%Visual%"').proj('acronym', 'region_name')
+```
+
+
+## Extending the Schema
+
+### Recording Locations
+
+A common use case is tracking where electrodes were placed during recordings.
+
+**Design choice:** Here we use `recording_id` alone as the primary key, with `BrainRegion` (which includes `ccf_id`) as a dependent attribute. This means each recording has exactly one canonical atlas registration.
+
+An alternative design would include `ccf_id` in the primary key:
+```python
+recording_id : int32
+-> CCF
+---
+...
+```
+This would allow the same recording to be registered to multiple atlas versions (e.g., comparing assignments in CCFv2 vs CCFv3). Choose based on your use case:
+
+| Design | Primary Key | Use Case |
+|--------|-------------|----------|
+| Single registration | `recording_id` | One canonical atlas per lab |
+| Multi-atlas | `(recording_id, ccf_id)` | Compare across atlas versions |
+
+
+```python
+@schema
+class RecordingSite(dj.Manual):
+    definition = """
+    # Recording electrode location
+    recording_id : int32
+    ---
+    ap : float32                    # anterior-posterior (µm from bregma)
+    dv : float32                    # dorsal-ventral (µm from brain surface)
+    ml : float32                    # medial-lateral (µm from midline)
+    -> BrainRegion                  # assigned brain region (includes ccf_id)
+    """
+
+# Insert example recording sites
+RecordingSite.insert([
+    {'recording_id': 1, 'ccf_id': 1, 'ap': -3500, 'dv': 500, 'ml': 2500, 
+     'region_id': (BrainRegion & 'acronym="VISp"').fetch1('region_id')},
+    {'recording_id': 2, 'ccf_id': 1, 'ap': -1800, 'dv': 1200, 'ml': 1500,
+     'region_id': (BrainRegion & 'acronym="CA1"').fetch1('region_id')},
+], skip_duplicates=True)
+
+# View recordings with region info
+RecordingSite * BrainRegion.proj('acronym', 'region_name')
+```
+
+
+## Summary
+
+This tutorial demonstrated DataJoint patterns for atlas and ontology data:
+
+| Pattern | Example | Purpose |
+|---------|---------|--------|
+| **Hierarchical data** | `BrainRegion`, `RegionParent` | Model tree structures |
+| **Self-referential FK** | `parent_id → region_id` | Parent-child relationships |
+| **Batch insert** | `self.insert(entries)` | Efficient bulk loading |
+| **Secondary index** | `index(y, z)` | Optimize spatial queries |
+| **Linked tables** | `RecordingSite → BrainRegion` | Reference atlas in experiments |
+
+### Loading Full Atlas Data
+
+To load the complete 3D volume:
+
+1. Download NRRD file from [Allen Institute](http://download.alleninstitute.org/informatics-archive/current-release/mouse_ccf/annotation/ccf_2017/)
+2. Install `pynrrd`: `pip install pynrrd`
+3. Load and insert voxels (see [Element Electrode Localization](https://github.com/datajoint/element-electrode-localization))
+
+
+```python
+# Final schema diagram
+dj.Diagram(schema)
+```
+
+
+
+```python
+# Cleanup
+schema.drop(prompt=False)
+```
+
+
+---
+## File: tutorials/domain/calcium-imaging/calcium-imaging.ipynb
+
+# Calcium Imaging Pipeline
+
+This tutorial builds a complete calcium imaging analysis pipeline using DataJoint. You'll learn to:
+
+- **Import** raw imaging data from TIFF files
+- **Segment** cells using parameterized detection
+- **Extract** fluorescence traces from detected ROIs
+- Use **Lookup tables** for analysis parameters
+- Use **Part tables** for one-to-many results
+
+## The Pipeline
+
+<img src="/images/calcium-pipeline.svg" alt="Calcium Imaging Pipeline" width="700">
+
+**Legend:** Green = Manual, Gray = Lookup, Blue = Imported, Red = Computed, White = Part
+
+Each scan produces a TIFF movie. We compute an average frame, segment cells using threshold-based detection, and extract fluorescence traces for each detected ROI.
+
+## Setup
+
+
+```python
+import datajoint as dj
+import numpy as np
+import matplotlib.pyplot as plt
+from pathlib import Path
+from skimage import io
+from scipy import ndimage
+
+schema = dj.Schema('tutorial_calcium_imaging')
+
+# Data directory (relative to this notebook)
+DATA_DIR = Path('./data')
+```
+
+
+## Manual Tables: Experiment Metadata
+
+We start with tables for subjects, sessions, and scan metadata. These are **Manual tables** - data entered by experimenters or recording systems.
+
+
+```python
+@schema
+class Mouse(dj.Manual):
+    definition = """
+    mouse_id : int32
+    ---
+    dob : date
+    sex : enum('M', 'F', 'unknown')
+    """
+
+
+@schema
+class Session(dj.Manual):
+    definition = """
+    -> Mouse
+    session_date : date
+    ---
+    experimenter : varchar(100)
+    """
+
+
+@schema
+class Scan(dj.Manual):
+    definition = """
+    -> Session
+    scan_idx : int16
+    ---
+    depth : float32           # imaging depth (um)
+    wavelength : float32      # laser wavelength (nm)
+    laser_power : float32     # laser power (mW)
+    fps : float32             # frames per second
+    file_name : varchar(128)  # TIFF filename
+    """
+```
+
+
+### Insert Sample Data
+
+
+```python
+# Insert mouse
+Mouse.insert1(
+    {'mouse_id': 0, 'dob': '2017-03-01', 'sex': 'M'},
+    skip_duplicates=True
+)
+
+# Insert session
+Session.insert1(
+    {'mouse_id': 0, 'session_date': '2017-05-15', 'experimenter': 'Alice'},
+    skip_duplicates=True
+)
+
+# Insert scans (we have 3 TIFF files)
+Scan.insert([
+    {'mouse_id': 0, 'session_date': '2017-05-15', 'scan_idx': 1,
+     'depth': 150, 'wavelength': 920, 'laser_power': 26, 'fps': 15,
+     'file_name': 'example_scan_01.tif'},
+    {'mouse_id': 0, 'session_date': '2017-05-15', 'scan_idx': 2,
+     'depth': 200, 'wavelength': 920, 'laser_power': 24, 'fps': 15,
+     'file_name': 'example_scan_02.tif'},
+    {'mouse_id': 0, 'session_date': '2017-05-15', 'scan_idx': 3,
+     'depth': 250, 'wavelength': 920, 'laser_power': 25, 'fps': 15,
+     'file_name': 'example_scan_03.tif'},
+], skip_duplicates=True)
+
+Scan()
+```
+
+
+## Imported Table: Average Frame
+
+An **Imported table** pulls data from external files. Here we load each TIFF movie and compute the average frame across all time points.
+
+The `make()` method defines how to compute one entry. DataJoint's `populate()` calls it for each pending entry.
+
+
+```python
+@schema
+class AverageFrame(dj.Imported):
+    definition = """
+    -> Scan
+    ---
+    average_frame : <blob>    # mean fluorescence across frames
+    """
+
+    def make(self, key):
+        # Get filename from Scan table
+        file_name = (Scan & key).fetch1('file_name')
+        file_path = DATA_DIR / file_name
+        
+        # Load TIFF and compute average
+        movie = io.imread(file_path)
+        avg_frame = movie.mean(axis=0)
+        
+        # Insert result
+        self.insert1({**key, 'average_frame': avg_frame})
+        print(f"Processed {file_name}: {movie.shape[0]} frames")
+```
+
+
+
+```python
+# Populate computes all pending entries
+AverageFrame.populate(display_progress=True)
+```
+
+
+
+```python
+# Visualize average frames
+fig, axes = plt.subplots(1, 3, figsize=(12, 4))
+for ax, key in zip(axes, AverageFrame.keys()):
+    avg = (AverageFrame & key).fetch1('average_frame')
+    ax.imshow(avg, cmap='gray')
+    ax.set_title(f"Scan {key['scan_idx']}")
+    ax.axis('off')
+plt.tight_layout()
+```
+
+
+## Lookup Table: Segmentation Parameters
+
+A **Lookup table** stores parameter sets that don't change often. This lets us run the same analysis with different parameters and compare results.
+
+Our cell segmentation has two parameters:
+- `threshold`: intensity threshold for detecting bright regions
+- `min_size`: minimum blob size (filters out noise)
+
+
+```python
+@schema
+class SegmentationParam(dj.Lookup):
+    definition = """
+    seg_param_id : int16
+    ---
+    threshold : float32    # intensity threshold
+    min_size : int32       # minimum blob size (pixels)
+    """
+    
+    # Pre-populate with parameter sets to try
+    contents = [
+        {'seg_param_id': 1, 'threshold': 50.0, 'min_size': 50},
+        {'seg_param_id': 2, 'threshold': 60.0, 'min_size': 50},
+    ]
+
+SegmentationParam()
+```
+
+
+## Computed Table with Part Table: Segmentation
+
+A **Computed table** derives data from other DataJoint tables. Here, `Segmentation` depends on both `AverageFrame` and `SegmentationParam` - DataJoint will compute all combinations.
+
+Since each segmentation produces multiple ROIs, we use a **Part table** (`Roi`) to store the individual masks. The master table stores summary info; part tables store detailed results.
+
+
+```python
+@schema
+class Segmentation(dj.Computed):
+    definition = """
+    -> AverageFrame
+    -> SegmentationParam
+    ---
+    num_rois : int16          # number of detected ROIs
+    segmented_mask : <blob>   # labeled mask image
+    """
+
+    class Roi(dj.Part):
+        definition = """
+        -> master
+        roi_idx : int16
+        ---
+        mask : <blob>         # binary mask for this ROI
+        center_x : float32    # ROI center x coordinate
+        center_y : float32    # ROI center y coordinate
+        """
+
+    def make(self, key):
+        # Fetch inputs
+        avg_frame = (AverageFrame & key).fetch1('average_frame')
+        threshold, min_size = (SegmentationParam & key).fetch1('threshold', 'min_size')
+        
+        # Threshold to get binary mask
+        binary_mask = avg_frame > threshold
+        
+        # Label connected components
+        labeled, num_labels = ndimage.label(binary_mask)
+        
+        # Filter by size and extract ROIs
+        roi_masks = []
+        for i in range(1, num_labels + 1):  # 0 is background
+            roi_mask = (labeled == i)
+            if roi_mask.sum() >= min_size:
+                roi_masks.append(roi_mask)
+        
+        # Re-label the filtered mask
+        final_mask = np.zeros_like(labeled)
+        for i, mask in enumerate(roi_masks, 1):
+            final_mask[mask] = i
+        
+        # Insert master entry
+        self.insert1({
+            **key,
+            'num_rois': len(roi_masks),
+            'segmented_mask': final_mask
+        })
+        
+        # Insert part entries (one per ROI)
+        for roi_idx, mask in enumerate(roi_masks):
+            # Compute center of mass
+            cy, cx = ndimage.center_of_mass(mask)
+            self.Roi.insert1({
+                **key,
+                'roi_idx': roi_idx,
+                'mask': mask,
+                'center_x': cx,
+                'center_y': cy
+            })
+        
+        print(f"Scan {key['scan_idx']}, params {key['seg_param_id']}: {len(roi_masks)} ROIs")
+```
+
+
+
+```python
+# Populate all AverageFrame x SegmentationParam combinations
+Segmentation.populate(display_progress=True)
+```
+
+
+
+```python
+# View results summary
+Segmentation()
+```
+
+
+
+```python
+# View individual ROIs
+Segmentation.Roi()
+```
+
+
+### Visualize Segmentation Results
+
+
+```python
+# Compare segmentation with different parameters for scan 1
+fig, axes = plt.subplots(1, 3, figsize=(12, 4))
+
+key = {'mouse_id': 0, 'session_date': '2017-05-15', 'scan_idx': 1}
+avg_frame = (AverageFrame & key).fetch1('average_frame')
+
+axes[0].imshow(avg_frame, cmap='gray')
+axes[0].set_title('Average Frame')
+axes[0].axis('off')
+
+for ax, param_id in zip(axes[1:], [1, 2]):
+    seg_key = {**key, 'seg_param_id': param_id}
+    mask, num_rois = (Segmentation & seg_key).fetch1('segmented_mask', 'num_rois')
+    threshold = (SegmentationParam & {'seg_param_id': param_id}).fetch1('threshold')
+    
+    ax.imshow(avg_frame, cmap='gray')
+    ax.imshow(mask, cmap='tab10', alpha=0.5 * (mask > 0))
+    ax.set_title(f'Threshold={threshold}: {num_rois} ROIs')
+    ax.axis('off')
+
+plt.tight_layout()
+```
+
+
+## Fluorescence Trace Extraction
+
+Now we extract the fluorescence time series for each ROI. This requires going back to the raw TIFF movie, so we use an **Imported table**.
+
+The master table (`Fluorescence`) stores shared time axis; the part table (`Trace`) stores each ROI's trace.
+
+
+```python
+@schema
+class Fluorescence(dj.Imported):
+    definition = """
+    -> Segmentation
+    ---
+    timestamps : <blob>    # time for each frame (seconds)
+    """
+
+    class Trace(dj.Part):
+        definition = """
+        -> master
+        -> Segmentation.Roi
+        ---
+        trace : <blob>     # fluorescence trace (mean within ROI mask)
+        """
+
+    def make(self, key):
+        # Get scan info and load movie
+        file_name, fps = (Scan & key).fetch1('file_name', 'fps')
+        movie = io.imread(DATA_DIR / file_name)
+        n_frames = movie.shape[0]
+        
+        # Create time axis
+        timestamps = np.arange(n_frames) / fps
+        
+        # Insert master entry
+        self.insert1({**key, 'timestamps': timestamps})
+        
+        # Extract trace for each ROI
+        for roi_key in (Segmentation.Roi & key).keys():
+            mask = (Segmentation.Roi & roi_key).fetch1('mask')
+            
+            # Compute mean fluorescence within mask for each frame
+            trace = np.array([frame[mask].mean() for frame in movie])
+            
+            self.Trace.insert1({**roi_key, 'trace': trace})
+        
+        n_rois = len(Segmentation.Roi & key)
+        print(f"Extracted {n_rois} traces from {file_name}")
+```
+
+
+
+```python
+Fluorescence.populate(display_progress=True)
+```
+
+
+### Visualize Fluorescence Traces
+
+
+```python
+# Plot traces for one segmentation result
+key = {'mouse_id': 0, 'session_date': '2017-05-15', 'scan_idx': 1, 'seg_param_id': 2}
+
+timestamps = (Fluorescence & key).fetch1('timestamps')
+traces = (Fluorescence.Trace & key).to_arrays('trace')
+
+plt.figure(figsize=(12, 4))
+for i, trace in enumerate(traces):
+    plt.plot(timestamps, trace + i * 20, label=f'ROI {i}')  # offset for visibility
+
+plt.xlabel('Time (s)')
+plt.ylabel('Fluorescence (offset)')
+plt.title('Fluorescence Traces')
+plt.legend()
+plt.tight_layout()
+```
+
+
+## Pipeline Diagram
+
+
+```python
+dj.Diagram(schema)
+```
+
+
+**Legend:**
+- **Green rectangles**: Manual tables (user-entered data)
+- **Gray rectangles**: Lookup tables (parameters)
+- **Blue ovals**: Imported tables (data from files)
+- **Red ovals**: Computed tables (derived from other tables)
+- **Plain text**: Part tables (detailed results)
+
+## Summary
+
+This pipeline demonstrates key DataJoint patterns for imaging analysis:
+
+| Concept | Example | Purpose |
+|---------|---------|--------|
+| **Manual tables** | `Mouse`, `Session`, `Scan` | Store experiment metadata |
+| **Imported tables** | `AverageFrame`, `Fluorescence` | Load data from external files |
+| **Computed tables** | `Segmentation` | Derive data from other tables |
+| **Lookup tables** | `SegmentationParam` | Store analysis parameters |
+| **Part tables** | `Roi`, `Trace` | Store one-to-many results |
+| **`populate()`** | Auto-compute missing entries | Automatic pipeline execution |
+
+### Key Benefits
+
+1. **Parameter tracking**: Different segmentation parameters stored alongside results
+2. **Reproducibility**: Re-run `populate()` to recompute after changes
+3. **Data integrity**: Foreign keys ensure consistent relationships
+4. **Provenance**: Clear lineage from raw data to final traces
+
+
+```python
+# Cleanup: drop schema for re-running
+schema.drop(prompt=False)
+```
+
+
+---
+## File: tutorials/domain/electrophysiology/electrophysiology.ipynb
+
+# Electrophysiology Pipeline
+
+This tutorial builds an electrophysiology analysis pipeline using DataJoint. You'll learn to:
+
+- **Import** neural recordings from data files
+- **Compute** activity statistics
+- **Detect spikes** using parameterized thresholds
+- **Extract waveforms** using Part tables
+
+## The Pipeline
+
+<img src="/images/ephys-pipeline.svg" alt="Electrophysiology Pipeline" width="600">
+
+**Legend:** Green = Manual, Gray = Lookup, Blue = Imported, Red = Computed, White = Part
+
+Each session records from neurons. We compute statistics, detect spikes with configurable thresholds, and extract spike waveforms.
+
+## Setup
+
+
+```python
+import datajoint as dj
+import numpy as np
+import matplotlib.pyplot as plt
+from pathlib import Path
+
+schema = dj.Schema('tutorial_electrophysiology')
+
+# Data directory (relative to this notebook)
+DATA_DIR = Path('./data')
+```
+
+
+## Manual Tables: Experiment Metadata
+
+
+```python
+@schema
+class Mouse(dj.Manual):
+    definition = """
+    mouse_id : int32
+    ---
+    dob : date
+    sex : enum('M', 'F', 'unknown')
+    """
+
+
+@schema
+class Session(dj.Manual):
+    definition = """
+    -> Mouse
+    session_date : date
+    ---
+    experimenter : varchar(100)
+    """
+```
+
+
+### Insert Sample Data
+
+Our data files follow the naming convention `data_{mouse_id}_{session_date}.npy`.
+
+
+```python
+# Insert mice
+Mouse.insert([
+    {'mouse_id': 0, 'dob': '2017-03-01', 'sex': 'M'},
+    {'mouse_id': 5, 'dob': '2016-12-25', 'sex': 'F'},
+    {'mouse_id': 100, 'dob': '2017-05-12', 'sex': 'F'},
+], skip_duplicates=True)
+
+# Insert sessions (matching our data files)
+Session.insert([
+    {'mouse_id': 0, 'session_date': '2017-05-15', 'experimenter': 'Alice'},
+    {'mouse_id': 0, 'session_date': '2017-05-19', 'experimenter': 'Alice'},
+    {'mouse_id': 5, 'session_date': '2017-01-05', 'experimenter': 'Bob'},
+    {'mouse_id': 100, 'session_date': '2017-05-25', 'experimenter': 'Carol'},
+    {'mouse_id': 100, 'session_date': '2017-06-01', 'experimenter': 'Carol'},
+], skip_duplicates=True)
+
+Session()
+```
+
+
+## Imported Table: Neuron Activity
+
+Each data file contains recordings from one or more neurons. We import each neuron's activity trace.
+
+
+```python
+@schema
+class Neuron(dj.Imported):
+    definition = """
+    -> Session
+    neuron_id : int16
+    ---
+    activity : <blob>    # neural activity trace
+    """
+
+    def make(self, key):
+        # Construct filename from key
+        filename = f"data_{key['mouse_id']}_{key['session_date']}.npy"
+        filepath = DATA_DIR / filename
+        
+        # Load data (shape: n_neurons x n_timepoints)
+        data = np.load(filepath)
+        
+        # Insert one row per neuron
+        for neuron_id, activity in enumerate(data):
+            self.insert1({
+                **key,
+                'neuron_id': neuron_id,
+                'activity': activity
+            })
+        
+        print(f"Imported {len(data)} neuron(s) from {filename}")
+```
+
+
+
+```python
+Neuron.populate(display_progress=True)
+```
+
+
+
+```python
+Neuron()
+```
+
+
+### Visualize Neural Activity
+
+
+```python
+fig, axes = plt.subplots(2, 3, figsize=(12, 6))
+
+for ax, key in zip(axes.ravel(), Neuron.keys()):
+    activity = (Neuron & key).fetch1('activity')
+    ax.plot(activity)
+    ax.set_title(f"Mouse {key['mouse_id']}, {key['session_date']}")
+    ax.set_xlabel('Time bin')
+    ax.set_ylabel('Activity')
+
+# Hide unused subplot
+axes[1, 2].axis('off')
+plt.tight_layout()
+```
+
+
+## Computed Table: Activity Statistics
+
+For each neuron, compute basic statistics of the activity trace.
+
+
+```python
+@schema
+class ActivityStats(dj.Computed):
+    definition = """
+    -> Neuron
+    ---
+    mean_activity : float32
+    std_activity : float32
+    max_activity : float32
+    """
+
+    def make(self, key):
+        activity = (Neuron & key).fetch1('activity')
+        
+        self.insert1({
+            **key,
+            'mean_activity': activity.mean(),
+            'std_activity': activity.std(),
+            'max_activity': activity.max()
+        })
+```
+
+
+
+```python
+ActivityStats.populate(display_progress=True)
+ActivityStats()
+```
+
+
+## Lookup Table: Spike Detection Parameters
+
+Spike detection depends on threshold choice. Using a Lookup table, we can run detection with multiple thresholds and compare results.
+
+
+```python
+@schema
+class SpikeParams(dj.Lookup):
+    definition = """
+    spike_param_id : int16
+    ---
+    threshold : float32    # spike detection threshold
+    """
+    
+    contents = [
+        {'spike_param_id': 1, 'threshold': 0.5},
+        {'spike_param_id': 2, 'threshold': 0.9},
+    ]
+
+SpikeParams()
+```
+
+
+## Computed Table with Part Table: Spike Detection
+
+Detect spikes by finding threshold crossings. Store:
+- **Master table**: spike count and binary spike array
+- **Part table**: waveform for each spike
+
+
+```python
+@schema
+class Spikes(dj.Computed):
+    definition = """
+    -> Neuron
+    -> SpikeParams
+    ---
+    spike_times : <blob>    # indices of detected spikes
+    spike_count : int32     # total number of spikes
+    """
+
+    class Waveform(dj.Part):
+        definition = """
+        -> master
+        spike_idx : int32
+        ---
+        waveform : <blob>    # activity around spike (±40 samples)
+        """
+
+    def make(self, key):
+        # Fetch inputs
+        activity = (Neuron & key).fetch1('activity')
+        threshold = (SpikeParams & key).fetch1('threshold')
+        
+        # Detect threshold crossings (rising edge)
+        above_threshold = (activity > threshold).astype(int)
+        rising_edge = np.diff(above_threshold) > 0
+        spike_times = np.where(rising_edge)[0] + 1  # +1 to get crossing point
+        
+        # Insert master entry
+        self.insert1({
+            **key,
+            'spike_times': spike_times,
+            'spike_count': len(spike_times)
+        })
+        
+        # Extract and insert waveforms
+        window = 40  # samples before and after spike
+        for spike_idx, t in enumerate(spike_times):
+            # Skip spikes too close to edges
+            if t < window or t >= len(activity) - window:
+                continue
+            
+            waveform = activity[t - window : t + window]
+            self.Waveform.insert1({
+                **key,
+                'spike_idx': spike_idx,
+                'waveform': waveform
+            })
+```
+
+
+
+```python
+Spikes.populate(display_progress=True)
+```
+
+
+
+```python
+# View spike counts for each neuron × parameter combination
+Spikes.proj('spike_count')
+```
+
+
+### Compare Detection Thresholds
+
+
+```python
+# Pick one neuron to visualize
+neuron_key = {'mouse_id': 0, 'session_date': '2017-05-15', 'neuron_id': 0}
+activity = (Neuron & neuron_key).fetch1('activity')
+
+fig, axes = plt.subplots(2, 1, figsize=(12, 6), sharex=True)
+
+for ax, param_id in zip(axes, [1, 2]):
+    key = {**neuron_key, 'spike_param_id': param_id}
+    spike_times, spike_count = (Spikes & key).fetch1('spike_times', 'spike_count')
+    threshold = (SpikeParams & {'spike_param_id': param_id}).fetch1('threshold')
+    
+    ax.plot(activity, 'b-', alpha=0.7, label='Activity')
+    ax.axhline(threshold, color='r', linestyle='--', label=f'Threshold={threshold}')
+    ax.scatter(spike_times, activity[spike_times], color='red', s=20, zorder=5)
+    ax.set_title(f'Threshold={threshold}: {spike_count} spikes detected')
+    ax.set_ylabel('Activity')
+    ax.legend(loc='upper right')
+
+axes[1].set_xlabel('Time bin')
+plt.tight_layout()
+```
+
+
+### Average Waveform
+
+
+```python
+# Get waveforms for one neuron with threshold=0.5
+key = {'mouse_id': 100, 'session_date': '2017-05-25', 'neuron_id': 0, 'spike_param_id': 1}
+waveforms = (Spikes.Waveform & key).to_arrays('waveform')
+
+if len(waveforms) > 0:
+    waveform_matrix = np.vstack(waveforms)
+    
+    plt.figure(figsize=(8, 4))
+    # Plot individual waveforms (light)
+    for wf in waveform_matrix:
+        plt.plot(wf, 'b-', alpha=0.2)
+    # Plot mean waveform (bold)
+    plt.plot(waveform_matrix.mean(axis=0), 'r-', linewidth=2, label='Mean waveform')
+    plt.axvline(40, color='k', linestyle='--', alpha=0.5, label='Spike time')
+    plt.xlabel('Sample (relative to spike)')
+    plt.ylabel('Activity')
+    plt.title(f'Spike Waveforms (n={len(waveforms)})')
+    plt.legend()
+else:
+    print("No waveforms found for this key")
+```
+
+
+## Pipeline Diagram
+
+
+```python
+dj.Diagram(schema)
+```
+
+
+## Querying Results
+
+DataJoint makes it easy to query across the pipeline.
+
+
+```python
+# Find neurons with high spike counts (threshold=0.5)
+(Spikes & 'spike_param_id = 1' & 'spike_count > 20').proj('spike_count')
+```
+
+
+
+```python
+# Join with Mouse to see which mice have most spikes
+(Mouse * Session * Spikes & 'spike_param_id = 1').proj('spike_count')
+```
+
+
+## Summary
+
+This pipeline demonstrates key patterns for electrophysiology analysis:
+
+| Concept | Example | Purpose |
+|---------|---------|--------|
+| **Imported tables** | `Neuron` | Load data from files |
+| **Computed tables** | `ActivityStats`, `Spikes` | Derive results |
+| **Lookup tables** | `SpikeParams` | Parameterize analysis |
+| **Part tables** | `Waveform` | Store variable-length results |
+| **Multi-parent keys** | `Spikes` | Compute all Neuron × Param combinations |
+
+### Key Benefits
+
+1. **Parameter comparison**: Different thresholds stored alongside results
+2. **Automatic tracking**: `populate()` knows what's computed vs. pending
+3. **Cascading**: Delete a parameter set, all derived results cascade
+4. **Provenance**: Trace any spike back to its source recording
+
+
+```python
+# Cleanup: drop schema for re-running
+schema.drop(prompt=False)
+```
+
+
+---
+## File: tutorials/domain/electrophysiology/ephys-with-npy.ipynb
+
+# Electrophysiology Pipeline with Object Storage
+
+This tutorial builds an electrophysiology analysis pipeline using DataJoint with the `<npy@>` codec for efficient array storage. You'll learn to:
+
+- **Configure** object storage for neural data
+- **Import** neural recordings using `<npy@>` (lazy loading)
+- **Compute** activity statistics
+- **Detect spikes** using parameterized thresholds
+- **Extract waveforms** as stacked arrays
+- **Use memory mapping** for efficient random access
+- **Access files directly** without database queries
+
+## The Pipeline
+
+<img src="/images/ephys-npy-pipeline.svg" alt="Electrophysiology Pipeline" width="600">
+
+**Legend:** Green = Manual, Gray = Lookup, Blue = Imported, Red = Computed
+
+Each session records from neurons. We compute statistics, detect spikes with configurable thresholds, and extract spike waveforms.
+
+## Why `<npy@>` Instead of `<blob@>`?
+
+| Feature | `<npy@>` | `<blob@>` |
+|---------|----------|-----------|
+| **Lazy loading** | Yes - inspect shape/dtype without download | No - always downloads |
+| **Memory mapping** | Yes - random access via `mmap_mode` | No |
+| **Format** | Portable `.npy` files | DataJoint serialization |
+| **Bulk fetch** | Safe - returns references | Downloads everything |
+| **Direct access** | Yes - navigable file paths | No - hash-addressed |
+
+## Setup
+
+First, configure object storage for the `<npy@>` codec.
+
+
+```python
+import datajoint as dj
+import numpy as np
+import matplotlib.pyplot as plt
+from pathlib import Path
+import tempfile
+
+# Create a temporary directory for object storage
+STORE_PATH = tempfile.mkdtemp(prefix='dj_ephys_')
+
+# Configure object storage with partitioning by mouse_id, session_date, and neuron_id
+dj.config.stores['ephys'] = {
+    'protocol': 'file',
+    'location': STORE_PATH,
+    'partition_pattern': '{mouse_id}/{session_date}/{neuron_id}',  # Partition by subject, session, and neuron
+}
+
+schema = dj.Schema('tutorial_electrophysiology_npy')
+
+# Data directory (relative to this notebook)
+DATA_DIR = Path('./data')
+
+print(f"Store configured at: {STORE_PATH}")
+print("Partitioning: {mouse_id}/{session_date}/{neuron_id}")
+```
+
+
+### Partitioning by Subject, Session, and Neuron
+
+We've configured the store with `partition_pattern: '{mouse_id}/{session_date}/{neuron_id}'`. This organizes storage by the complete experimental hierarchy—grouping all data for each individual neuron together at the top of the directory structure.
+
+**Without partitioning:**
+```
+{store}/{schema}/{table}/{mouse_id=X}/{session_date=Y}/{neuron_id=Z}/file.npy
+```
+
+**With partitioning:**
+```
+{store}/{mouse_id=X}/{session_date=Y}/{neuron_id=Z}/{schema}/{table}/file.npy
+```
+
+Partitioning moves the specified primary key attributes to the front of the path, making it easy to:
+- **Browse by experimental hierarchy** - Navigate: subject → session → neuron
+- **Selective sync** - Copy all data for one neuron: `rsync mouse_id=100/session_date=2017-05-25/neuron_id=0/ backup/`
+- **Efficient queries** - Filesystem can quickly locate specific neurons
+- **Publication-ready** - Export complete hierarchies to data repositories
+
+The remaining primary key attributes (like `spike_param_id` in the Spikes table) stay in their normal position after the schema/table path.
+
+## Manual Tables: Experiment Metadata
+
+
+```python
+@schema
+class Mouse(dj.Manual):
+    definition = """
+    mouse_id : int32
+    ---
+    dob : date
+    sex : enum('M', 'F', 'unknown')
+    """
+
+
+@schema
+class Session(dj.Manual):
+    definition = """
+    -> Mouse
+    session_date : date
+    ---
+    experimenter : varchar(100)
+    """
+```
+
+
+### Insert Sample Data
+
+Our data files follow the naming convention `data_{mouse_id}_{session_date}.npy`.
+
+
+```python
+# Insert mice
+Mouse.insert([
+    {'mouse_id': 0, 'dob': '2017-03-01', 'sex': 'M'},
+    {'mouse_id': 5, 'dob': '2016-12-25', 'sex': 'F'},
+    {'mouse_id': 100, 'dob': '2017-05-12', 'sex': 'F'},
+], skip_duplicates=True)
+
+# Insert sessions (matching our data files)
+Session.insert([
+    {'mouse_id': 0, 'session_date': '2017-05-15', 'experimenter': 'Alice'},
+    {'mouse_id': 0, 'session_date': '2017-05-19', 'experimenter': 'Alice'},
+    {'mouse_id': 5, 'session_date': '2017-01-05', 'experimenter': 'Bob'},
+    {'mouse_id': 100, 'session_date': '2017-05-25', 'experimenter': 'Carol'},
+    {'mouse_id': 100, 'session_date': '2017-06-01', 'experimenter': 'Carol'},
+], skip_duplicates=True)
+
+Session()
+```
+
+
+## Imported Table: Neuron Activity with `<npy@>`
+
+Each data file contains recordings from one or more neurons. We import each neuron's activity trace using `<npy@ephys>` for schema-addressed object storage.
+
+
+```python
+@schema
+class Neuron(dj.Imported):
+    definition = """
+    -> Session
+    neuron_id : int16
+    ---
+    activity : <npy@ephys>    # neural activity trace (lazy loading)
+    """
+
+    def make(self, key):
+        # Construct filename from key
+        filename = f"data_{key['mouse_id']}_{key['session_date']}.npy"
+        filepath = DATA_DIR / filename
+        
+        # Load data (shape: n_neurons x n_timepoints)
+        data = np.load(filepath)
+        
+        # Insert one row per neuron
+        for neuron_id, activity in enumerate(data):
+            self.insert1({
+                **key,
+                'neuron_id': neuron_id,
+                'activity': activity
+            })
+        
+        print(f"Imported {len(data)} neuron(s) from {filename}")
+```
+
+
+
+```python
+Neuron.populate(display_progress=True)
+```
+
+
+
+```python
+Neuron()
+```
+
+
+### Lazy Loading with NpyRef
+
+When fetching `<npy@>` attributes, you get an `NpyRef` that provides metadata without downloading the array.
+
+
+```python
+# Fetch returns NpyRef, not the array
+key = {'mouse_id': 0, 'session_date': '2017-05-15', 'neuron_id': 0}
+ref = (Neuron & key).fetch1('activity')
+
+print(f"Type: {type(ref).__name__}")
+print(f"Shape: {ref.shape} (no download!)")
+print(f"Dtype: {ref.dtype}")
+print(f"Is loaded: {ref.is_loaded}")
+```
+
+
+
+```python
+# Explicitly load when ready
+activity = ref.load()
+print(f"Loaded: {activity.shape}, is_loaded: {ref.is_loaded}")
+```
+
+
+### Memory Mapping for Large Arrays
+
+For very large arrays, use `mmap_mode` to access data without loading it all into memory. This is especially efficient for local filesystem stores.
+
+
+```python
+# Memory-mapped loading - efficient for large arrays
+key = {'mouse_id': 0, 'session_date': '2017-05-15', 'neuron_id': 0}
+ref = (Neuron & key).fetch1('activity')
+
+# Load as memory-mapped array (read-only)
+mmap_arr = ref.load(mmap_mode='r')
+
+print(f"Type: {type(mmap_arr).__name__}")
+print(f"Shape: {mmap_arr.shape}")
+
+# Random access only reads the needed portion from disk
+slice_data = mmap_arr[100:200]
+print(f"Slice [100:200]: {slice_data[:5]}...")
+```
+
+
+### Visualize Neural Activity
+
+NpyRef works transparently with NumPy functions via `__array__`.
+
+
+```python
+fig, axes = plt.subplots(2, 3, figsize=(12, 6))
+
+for ax, key in zip(axes.ravel(), Neuron.keys()):
+    # fetch1 returns NpyRef, but plotting works via __array__
+    activity = (Neuron & key).fetch1('activity')
+    ax.plot(np.asarray(activity))  # Convert to array for plotting
+    ax.set_title(f"Mouse {key['mouse_id']}, {key['session_date']}")
+    ax.set_xlabel('Time bin')
+    ax.set_ylabel('Activity')
+
+# Hide unused subplot
+axes[1, 2].axis('off')
+plt.tight_layout()
+```
+
+
+## Computed Table: Activity Statistics
+
+For each neuron, compute basic statistics of the activity trace. NumPy functions work directly with NpyRef.
+
+
+```python
+@schema
+class ActivityStats(dj.Computed):
+    definition = """
+    -> Neuron
+    ---
+    mean_activity : float32
+    std_activity : float32
+    max_activity : float32
+    """
+
+    def make(self, key):
+        # fetch1 returns NpyRef, but np.mean/std/max work via __array__
+        activity = (Neuron & key).fetch1('activity')
+        
+        self.insert1({
+            **key,
+            'mean_activity': np.mean(activity),  # Auto-loads via __array__
+            'std_activity': np.std(activity),
+            'max_activity': np.max(activity)
+        })
+```
+
+
+
+```python
+ActivityStats.populate(display_progress=True)
+ActivityStats()
+```
+
+
+## Lookup Table: Spike Detection Parameters
+
+Spike detection depends on threshold choice. Using a Lookup table, we can run detection with multiple thresholds and compare results.
+
+
+```python
+@schema
+class SpikeParams(dj.Lookup):
+    definition = """
+    spike_param_id : int16
+    ---
+    threshold : float32    # spike detection threshold
+    """
+    
+    contents = [
+        {'spike_param_id': 1, 'threshold': 0.5},
+        {'spike_param_id': 2, 'threshold': 0.9},
+    ]
+
+SpikeParams()
+```
+
+
+## Computed Table: Spike Detection
+
+Detect spikes by finding threshold crossings. Store spike times and all waveforms as `<npy@>` arrays.
+
+
+```python
+@schema
+class Spikes(dj.Computed):
+    definition = """
+    -> Neuron
+    -> SpikeParams
+    ---
+    spike_times : <npy@ephys>    # indices of detected spikes
+    spike_count : uint32         # total number of spikes
+    waveforms : <npy@ephys>      # all waveforms stacked (n_spikes x window_size)
+    """
+
+    def make(self, key):
+        # Fetch inputs - activity is NpyRef
+        activity_ref = (Neuron & key).fetch1('activity')
+        threshold = (SpikeParams & key).fetch1('threshold')
+        
+        # Load activity for processing
+        activity = activity_ref.load()
+        
+        # Detect threshold crossings (rising edge)
+        above_threshold = (activity > threshold).astype(int)
+        rising_edge = np.diff(above_threshold) > 0
+        spike_times = np.where(rising_edge)[0] + 1  # +1 to get crossing point
+        
+        # Extract waveforms for all spikes
+        window = 40  # samples before and after spike
+        waveforms = []
+        for t in spike_times:
+            # Skip spikes too close to edges
+            if t < window or t >= len(activity) - window:
+                continue
+            waveforms.append(activity[t - window : t + window])
+        
+        # Stack into 2D array (n_spikes x window_size)
+        waveforms = np.vstack(waveforms) if waveforms else np.empty((0, 2 * window))
+        
+        # Insert entry with all data
+        self.insert1({
+            **key,
+            'spike_times': spike_times,
+            'spike_count': len(spike_times),
+            'waveforms': waveforms,  # All waveforms as single array
+        })
+```
+
+
+
+```python
+Spikes.populate(display_progress=True)
+```
+
+
+
+```python
+# View spike counts for each neuron x parameter combination
+Spikes.proj('spike_count')
+```
+
+
+### Compare Detection Thresholds
+
+
+```python
+# Pick one neuron to visualize
+neuron_key = {'mouse_id': 0, 'session_date': '2017-05-15', 'neuron_id': 0}
+activity = (Neuron & neuron_key).fetch1('activity').load()  # Explicit load
+
+fig, axes = plt.subplots(2, 1, figsize=(12, 6), sharex=True)
+
+for ax, param_id in zip(axes, [1, 2]):
+    key = {**neuron_key, 'spike_param_id': param_id}
+    spike_times_ref = (Spikes & key).fetch1('spike_times')
+    spike_times = spike_times_ref.load()  # Load spike times
+    spike_count = (Spikes & key).fetch1('spike_count')
+    threshold = (SpikeParams & {'spike_param_id': param_id}).fetch1('threshold')
+    
+    ax.plot(activity, 'b-', alpha=0.7, label='Activity')
+    ax.axhline(threshold, color='r', linestyle='--', label=f'Threshold={threshold}')
+    ax.scatter(spike_times, activity[spike_times], color='red', s=20, zorder=5)
+    ax.set_title(f'Threshold={threshold}: {spike_count} spikes detected')
+    ax.set_ylabel('Activity')
+    ax.legend(loc='upper right')
+
+axes[1].set_xlabel('Time bin')
+plt.tight_layout()
+```
+
+
+### Average Waveform
+
+
+```python
+# Get waveforms for one neuron with threshold=0.5
+key = {'mouse_id': 100, 'session_date': '2017-05-25', 'neuron_id': 0, 'spike_param_id': 1}
+
+# Fetch waveforms NpyRef directly from Spikes table
+waveforms_ref = (Spikes & key).fetch1('waveforms')
+
+# Load the waveform matrix
+waveform_matrix = waveforms_ref.load()
+
+if len(waveform_matrix) > 0:
+    plt.figure(figsize=(8, 4))
+    # Plot individual waveforms (light)
+    for wf in waveform_matrix:
+        plt.plot(wf, 'b-', alpha=0.2)
+    # Plot mean waveform (bold)
+    plt.plot(waveform_matrix.mean(axis=0), 'r-', linewidth=2, label='Mean waveform')
+    plt.axvline(40, color='k', linestyle='--', alpha=0.5, label='Spike time')
+    plt.xlabel('Sample (relative to spike)')
+    plt.ylabel('Activity')
+    plt.title(f'Spike Waveforms (n={len(waveform_matrix)})')
+    plt.legend()
+else:
+    print("No waveforms found for this key")
+```
+
+
+### Bulk Fetch with Lazy Loading
+
+Fetching many rows returns NpyRefs - inspect metadata before downloading.
+
+
+```python
+# Fetch all neurons - returns NpyRefs, NOT arrays
+all_neurons = Neuron.to_dicts()
+print(f"Fetched {len(all_neurons)} neurons\n")
+
+# Inspect metadata without downloading
+for neuron in all_neurons:
+    ref = neuron['activity']
+    print(f"Mouse {neuron['mouse_id']}, {neuron['session_date']}: "
+          f"shape={ref.shape}, loaded={ref.is_loaded}")
+```
+
+
+## Pipeline Diagram
+
+
+```python
+dj.Diagram(schema)
+```
+
+
+## Querying Results
+
+DataJoint makes it easy to query across the pipeline.
+
+
+```python
+# Find neurons with high spike counts (threshold=0.5)
+(Spikes & 'spike_param_id = 1' & 'spike_count > 20').proj('spike_count')
+```
+
+
+
+```python
+# Join with Mouse to see which mice have most spikes
+(Mouse * Session * Spikes & 'spike_param_id = 1').proj('spike_count')
+```
+
+
+## Summary
+
+This pipeline demonstrates key patterns for electrophysiology analysis with object storage:
+
+| Concept | Example | Purpose |
+|---------|---------|--------|
+| **Object storage** | `<npy@ephys>` | Store arrays in file/S3/MinIO |
+| **Lazy loading** | `NpyRef` | Inspect shape/dtype without download |
+| **Memory mapping** | `ref.load(mmap_mode='r')` | Random access to large arrays |
+| **Imported tables** | `Neuron` | Load data from files |
+| **Computed tables** | `ActivityStats`, `Spikes` | Derive results |
+| **Lookup tables** | `SpikeParams` | Parameterize analysis |
+| **Array attributes** | `waveforms` | Store multi-spike data as single array |
+
+### Key Benefits of `<npy@>`
+
+1. **Lazy loading**: Inspect array metadata without downloading
+2. **Memory mapping**: Random access to large arrays via `mmap_mode`
+3. **Safe bulk fetch**: Fetching 1000 rows doesn't download 1000 arrays
+4. **NumPy integration**: `np.mean(ref)` auto-downloads via `__array__`
+5. **Portable format**: `.npy` files readable by NumPy, MATLAB, etc.
+6. **Schema-addressed**: Files organized by schema/table/key
+7. **Direct access**: Navigate and load files without database queries
+
+## Direct File Access: Navigating the Store
+
+A key advantage of `<npy@>` is **schema-addressed storage**: files are organized in a predictable directory structure that mirrors your database schema. This means you can navigate and access data files directly—without querying the database.
+
+### Store Directory Structure with Partitioning
+
+This tutorial uses `partition_pattern: '{mouse_id}/{session_date}/{neuron_id}'` to organize files by the complete experimental hierarchy:
+
+```
+{store}/{mouse_id=X}/{session_date=Y}/{neuron_id=Z}/{schema}/{table}/{remaining_key}/{file}.npy
+```
+
+**Without partitioning**, the structure would be:
+```
+{store}/{schema}/{table}/{mouse_id=X}/{session_date=Y}/{neuron_id=Z}/{remaining_key}/{file}.npy
+```
+
+**Partitioning moves the experimental hierarchy to the top** of the path, creating a browsable structure that matches how you think about your data:
+1. Navigate to a subject (mouse_id=100)
+2. Navigate to a session (session_date=2017-05-25)
+3. Navigate to a neuron (neuron_id=0)
+4. See all data for that neuron organized by table
+
+This structure enables:
+- **Direct file access** for external tools (MATLAB, Julia, shell scripts)
+- **Browsable data** organized by subject/session/neuron
+- **Selective backup/sync** - Copy entire subjects, sessions, or individual neurons
+- **Debugging** by inspecting raw files in the experimental hierarchy
+
+
+```python
+# Explore the store directory structure
+from pathlib import Path
+
+print(f"Store location: {STORE_PATH}\n")
+print("Directory structure (one subject shown in full):")
+
+def print_tree(directory, prefix="", max_depth=7, current_depth=0, limit_items=True):
+    """Print directory tree with limited depth."""
+    if current_depth >= max_depth:
+        return
+    
+    try:
+        entries = sorted(Path(directory).iterdir())
+    except PermissionError:
+        return
+    
+    dirs = [e for e in entries if e.is_dir()]
+    files = [e for e in entries if e.is_file()]
+    
+    # At depth 0 (root), only show first subject in detail
+    if current_depth == 0 and limit_items:
+        dirs = dirs[:1]  # Only show first mouse_id
+    
+    # Show directories
+    for i, d in enumerate(dirs):
+        is_last_dir = (i == len(dirs) - 1) and len(files) == 0
+        connector = "└── " if is_last_dir else "├── "
+        print(f"{prefix}{connector}{d.name}/")
+        
+        extension = "    " if is_last_dir else "│   "
+        print_tree(d, prefix + extension, max_depth, current_depth + 1, limit_items=False)
+    
+    if current_depth == 0 and limit_items and len(sorted(Path(directory).iterdir(), key=lambda x: x.is_file())) > 1:
+        total_mice = len([e for e in Path(directory).iterdir() if e.is_dir()])
+        if total_mice > 1:
+            print(f"{prefix}└── ... and {total_mice - 1} more subjects (mouse_id=5, mouse_id=100)")
+    
+    # Show files
+    for i, f in enumerate(files):
+        is_last = i == len(files) - 1
+        connector = "└── " if is_last else "├── "
+        size_kb = f.stat().st_size / 1024
+        print(f"{prefix}{connector}{f.name} ({size_kb:.1f} KB)")
+
+print_tree(STORE_PATH)
+```
+
+
+
+```python
+# Get the actual path from an NpyRef
+key = {'mouse_id': 0, 'session_date': '2017-05-15', 'neuron_id': 0}
+ref = (Neuron & key).fetch1('activity')
+
+print(f"NpyRef path (relative): {ref.path}")
+print(f"Full path: {Path(STORE_PATH) / ref.path}\n")
+
+# Load directly with NumPy - bypass the database!
+direct_path = Path(STORE_PATH) / ref.path
+activity_direct = np.load(direct_path)
+print(f"Loaded array: shape={activity_direct.shape}, dtype={activity_direct.dtype}")
+print(f"First 5 values: {activity_direct[:5]}")
+```
+
+
+
+```python
+# Find all .npy files for a specific mouse using filesystem tools
+# This works without any database query!
+
+store_path = Path(STORE_PATH)
+all_npy_files = list(store_path.rglob("*.npy"))
+
+print(f"All .npy files in store ({len(all_npy_files)} total):\n")
+for f in sorted(all_npy_files)[:8]:
+    rel_path = f.relative_to(STORE_PATH)
+    size_kb = f.stat().st_size / 1024
+    print(f"  {rel_path} ({size_kb:.1f} KB)")
+if len(all_npy_files) > 8:
+    print(f"  ... and {len(all_npy_files) - 8} more files")
+```
+
+
+### Use Cases for Direct Access
+
+**External tools**: Load data in MATLAB, Julia, or R without DataJoint:
+```matlab
+% MATLAB - use the path from NpyRef or navigate the store
+activity = readNPY('store/schema/table/key_hash/activity.npy');
+```
+
+**Shell scripting**: Process files with command-line tools:
+```bash
+# List all .npy files in store
+find $STORE -name "*.npy"
+
+# Backup the entire store
+rsync -av $STORE/ backup/
+```
+
+**Disaster recovery**: If the database is lost, the store contains all array data in standard `.npy` format. The path structure and JSON metadata in the database can help reconstruct mappings.
+
+### Publishing to Data Repositories
+
+Many scientific data repositories accept **structured file-folder hierarchies**—exactly what `<npy@>` provides. The schema-addressed storage format makes your data publication-ready:
+
+| Repository | Accepted Formats | Schema-Addressed Benefit |
+|------------|-----------------|-------------------------|
+| [DANDI](https://dandiarchive.org) | NWB, folders | Export subject/session hierarchy |
+| [OpenNeuro](https://openneuro.org) | BIDS folders | Map to BIDS-like structure |
+| [Figshare](https://figshare.com) | Any files/folders | Upload store directly |
+| [Zenodo](https://zenodo.org) | Any files/folders | Archive with DOI |
+| [OSF](https://osf.io) | Any files/folders | Version-controlled sharing |
+
+**Export for publication**:
+```python
+# Export one subject's data for publication
+subject_dir = Path(STORE_PATH) / "schema" / "table" / "objects" / "mouse_id=100"
+
+# Copy to publication directory
+import shutil
+shutil.copytree(subject_dir, "publication_data/mouse_100/")
+
+# The resulting structure is self-documenting:
+# publication_data/
+#   mouse_100/
+#     session_date=2017-05-25/
+#       neuron_id=0/
+#         activity_xyz.npy
+#         spike_times_abc.npy
+#         waveforms_def.npy
+```
+
+**Key advantages for publishing**:
+
+1. **Self-documenting paths**: Primary key values are in folder names—no lookup table needed
+2. **Standard format**: `.npy` files are readable by NumPy, MATLAB, Julia, R, and most analysis tools
+3. **Selective export**: Copy only specific subjects, sessions, or tables
+4. **Reproducibility**: Published data has the same structure as your working pipeline
+5. **Metadata preservation**: Path encodes experimental metadata (subject, session, parameters)
+
+
+```python
+# Cleanup: drop schema and remove temporary store
+schema.drop(prompt=False)
+import shutil
+shutil.rmtree(STORE_PATH, ignore_errors=True)
+```
+
+
+---
+## File: tutorials/examples/blob-detection.ipynb
+
+# Blob Detection Pipeline
+
+This tutorial introduces DataJoint through a real image analysis pipeline that detects bright blobs in astronomical and biological images. By the end, you'll understand:
+
+- **Schemas** — Namespaces that group related tables
+- **Table types** — Manual, Lookup, and Computed tables
+- **Dependencies** — How tables relate through foreign keys
+- **Computation** — Automatic population of derived data
+- **Master-Part** — Atomic insertion of hierarchical results
+
+## The Problem
+
+We have images and want to detect bright spots (blobs) in them. Different detection parameters work better for different images, so we need to:
+
+1. Store our images
+2. Define parameter sets to try
+3. Run detection for each image × parameter combination
+4. Store and visualize results
+5. Select the best parameters for each image
+
+This is a **computational workflow** — a series of steps where each step depends on previous results. DataJoint makes these workflows reproducible and manageable.
+
+## Setup
+
+First, let's import our tools and create a schema (database namespace) for this project.
+
+
+```python
+import datajoint as dj
+import matplotlib.pyplot as plt
+from skimage import data
+from skimage.feature import blob_doh
+from skimage.color import rgb2gray
+
+# Create a schema - this is our database namespace
+schema = dj.Schema('tutorial_blobs')
+```
+
+
+## Manual Tables: Storing Raw Data
+
+A **Manual table** stores data that users enter directly — it's the starting point of your pipeline. Here we define an `Image` table to store our sample images.
+
+The `definition` string specifies:
+- **Primary key** (above `---`): attributes that uniquely identify each row
+- **Secondary attributes** (below `---`): additional data for each row
+
+
+```python
+@schema
+class Image(dj.Manual):
+    definition = """
+    # Images for blob detection
+    image_id : uint8
+    ---
+    image_name : varchar(100)
+    image : <blob>              # serialized numpy array
+    """
+```
+
+
+Now let's insert two sample images from scikit-image:
+
+
+```python
+# Insert sample images
+Image.insert([
+    {'image_id': 1, 'image_name': 'Hubble Deep Field', 
+     'image': rgb2gray(data.hubble_deep_field())},
+    {'image_id': 2, 'image_name': 'Human Mitosis', 
+     'image': data.human_mitosis() / 255.0},
+], skip_duplicates=True)
+
+Image()
+```
+
+
+
+```python
+# Visualize the images
+fig, axes = plt.subplots(1, 2, figsize=(10, 5))
+for ax, row in zip(axes, Image()):
+    ax.imshow(row['image'], cmap='gray_r')
+    ax.set_title(row['image_name'])
+    ax.axis('off')
+plt.tight_layout()
+```
+
+
+## Lookup Tables: Parameter Sets
+
+A **Lookup table** stores reference data that doesn't change often — things like experimental protocols, parameter configurations, or categorical options.
+
+For blob detection, we'll try different parameter combinations to find what works best for each image type.
+
+
+```python
+@schema
+class DetectionParams(dj.Lookup):
+    definition = """
+    # Blob detection parameter sets
+    params_id : uint8
+    ---
+    min_sigma : float32         # minimum blob size
+    max_sigma : float32         # maximum blob size  
+    threshold : float32         # detection sensitivity
+    """
+    
+    # Pre-populate with parameter sets to try
+    contents = [
+        {'params_id': 1, 'min_sigma': 2.0, 'max_sigma': 6.0, 'threshold': 0.001},
+        {'params_id': 2, 'min_sigma': 3.0, 'max_sigma': 8.0, 'threshold': 0.002},
+        {'params_id': 3, 'min_sigma': 4.0, 'max_sigma': 20.0, 'threshold': 0.01},
+    ]
+
+DetectionParams()
+```
+
+
+## Computed Tables: Automatic Processing
+
+A **Computed table** automatically derives data from other tables. You define:
+
+1. **Dependencies** (using `->`) — which tables provide input
+2. **`make()` method** — how to compute results for one input combination
+
+DataJoint then handles:
+- Determining what needs to be computed
+- Running computations (optionally in parallel)
+- Tracking what's done vs. pending
+
+### Master-Part Structure
+
+Our detection produces multiple blobs per image. We use a **master-part** structure:
+- **Master** (`Detection`): One row per job, stores summary (blob count)
+- **Part** (`Detection.Blob`): One row per blob, stores details (x, y, radius)
+
+Both are inserted atomically — if anything fails, the whole transaction rolls back.
+
+
+```python
+@schema
+class Detection(dj.Computed):
+    definition = """
+    # Blob detection results
+    -> Image                    # depends on Image
+    -> DetectionParams          # depends on DetectionParams
+    ---
+    num_blobs : uint16          # number of blobs detected
+    """
+    
+    class Blob(dj.Part):
+        definition = """
+        # Individual detected blobs
+        -> master
+        blob_idx : uint16
+        ---
+        x : float32             # x coordinate
+        y : float32             # y coordinate  
+        radius : float32        # blob radius
+        """
+    
+    def make(self, key):
+        # Fetch the image and parameters
+        img = (Image & key).fetch1('image')
+        params = (DetectionParams & key).fetch1()
+        
+        # Run blob detection
+        blobs = blob_doh(
+            img,
+            min_sigma=params['min_sigma'],
+            max_sigma=params['max_sigma'],
+            threshold=params['threshold']
+        )
+        
+        # Insert master row
+        self.insert1({**key, 'num_blobs': len(blobs)})
+        
+        # Insert part rows (all blobs for this detection)
+        self.Blob.insert([
+            {**key, 'blob_idx': i, 'x': x, 'y': y, 'radius': r}
+            for i, (x, y, r) in enumerate(blobs)
+        ])
+```
+
+
+## Viewing the Schema
+
+DataJoint can visualize the relationships between tables:
+
+
+```python
+dj.Diagram(schema)
+```
+
+
+The diagram shows:
+- **Green** = Manual tables (user-entered data)
+- **Gray** = Lookup tables (reference data)
+- **Red** = Computed tables (derived data)
+- **Edges** = Dependencies (foreign keys), always flow top-to-bottom
+
+## Running the Pipeline
+
+Call `populate()` to run all pending computations. DataJoint automatically determines what needs to be computed: every combination of `Image` × `DetectionParams` that doesn't already have a `Detection` result.
+
+
+```python
+# Run all pending computations
+Detection.populate(display_progress=True)
+```
+
+
+
+```python
+# View results summary
+Detection()
+```
+
+
+We computed 6 results: 2 images × 3 parameter sets. Each shows how many blobs were detected.
+
+## Visualizing Results
+
+Let's see how different parameters affect detection:
+
+
+```python
+fig, axes = plt.subplots(2, 3, figsize=(12, 8))
+
+for ax, key in zip(axes.ravel(),
+                   Detection.keys(order_by='image_id, params_id')):
+    # Get image and detection info in one fetch
+    name, img, num_blobs = (Detection * Image & key).fetch1(
+        'image_name', 'image', 'num_blobs')
+    
+    ax.imshow(img, cmap='gray_r')
+    
+    # Get all blob coordinates in one query
+    x, y, r = (Detection.Blob & key).to_arrays('x', 'y', 'radius')
+    for xi, yi, ri in zip(x, y, r):
+        circle = plt.Circle((yi, xi), ri * 1.2,
+                            color='red', fill=False, alpha=0.6)
+        ax.add_patch(circle)
+    
+    ax.set_title(f"{name}\nParams {key['params_id']}: {num_blobs} blobs",
+                 fontsize=10)
+    ax.axis('off')
+
+plt.tight_layout()
+```
+
+
+## Querying Results
+
+DataJoint's query language makes it easy to explore results:
+
+
+```python
+# Find detections with fewer than 300 blobs
+Detection & 'num_blobs < 300'
+```
+
+
+
+```python
+# Join to see image names with blob counts
+(Image * Detection).proj('image_name', 'num_blobs')
+```
+
+
+## Storing Selections
+
+After reviewing the results, we can record which parameter set works best for each image. This is another Manual table that references our computed results:
+
+
+```python
+@schema
+class SelectedDetection(dj.Manual):
+    definition = """
+    # Best detection for each image
+    -> Image
+    ---
+    -> Detection
+    """
+
+# Select params 3 for Hubble (fewer, larger blobs)
+# Select params 1 for Mitosis (many small spots)
+SelectedDetection.insert([
+    {'image_id': 1, 'params_id': 3},
+    {'image_id': 2, 'params_id': 1},
+], skip_duplicates=True)
+
+SelectedDetection()
+```
+
+
+
+```python
+# View the final schema with selections
+dj.Diagram(schema)
+```
+
+
+## Key Concepts Recap
+
+| Concept | What It Does | Example |
+|---------|--------------|--------|
+| **Schema** | Groups related tables | `schema = dj.Schema('tutorial_blobs')` |
+| **Manual Table** | Stores user-entered data | `Image`, `SelectedDetection` |
+| **Lookup Table** | Stores reference/config data | `DetectionParams` |
+| **Computed Table** | Derives data automatically | `Detection` |
+| **Part Table** | Stores detailed results with master | `Detection.Blob` |
+| **Foreign Key** (`->`) | Creates dependency | `-> Image` |
+| **`populate()`** | Runs pending computations | `Detection.populate()` |
+| **Restriction** (`&`) | Filters rows | `Detection & 'num_blobs < 300'` |
+| **Join** (`*`) | Combines tables | `Image * Detection` |
+
+## Next Steps
+
+- [Schema Design](02-schema-design.ipynb) — Learn table types and relationships in depth
+- [Queries](04-queries.ipynb) — Master DataJoint's query operators
+- [Computation](05-computation.ipynb) — Build complex computational workflows
+
+
+```python
+# Cleanup: drop the schema for re-running the tutorial
+schema.drop(prompt=False)
+```
+
+
+---
+## File: tutorials/examples/fractal-pipeline.ipynb
+
+# Fractal Image Pipeline
+
+This tutorial demonstrates **computed tables** by building an image processing pipeline for Julia fractals.
+
+You'll learn:
+- **Manual tables**: Parameters you define (experimental configurations)
+- **Lookup tables**: Fixed reference data (processing methods)
+- **Computed tables**: Automatically generated results via `populate()`
+- **Many-to-many pipelines**: Processing every combination of inputs × methods
+
+
+```python
+import datajoint as dj
+import numpy as np
+from matplotlib import pyplot as plt
+
+schema = dj.Schema('tutorial_fractal')
+```
+
+
+## Julia Set Generator
+
+Julia sets are fractals generated by iterating $f(z) = z^2 + c$ for each point in the complex plane. Points that don't escape to infinity form intricate patterns.
+
+
+```python
+def julia(c, size=256, center=(0.0, 0.0), zoom=1.0, iters=256):
+    """Generate a Julia set image."""
+    x, y = np.meshgrid(
+        np.linspace(-1, 1, size) / zoom + center[0],
+        np.linspace(-1, 1, size) / zoom + center[1]
+    )
+    z = x + 1j * y
+    img = np.zeros(z.shape)
+    mask = np.ones(z.shape, dtype=bool)
+    for _ in range(iters):
+        z[mask] = z[mask] ** 2 + c
+        mask = np.abs(z) < 2
+        img += mask
+    return img
+```
+
+
+
+```python
+# Example fractal
+plt.imshow(julia(-0.4 + 0.6j), cmap='magma')
+plt.axis('off');
+```
+
+
+## Pipeline Architecture
+
+We'll build a pipeline with four tables:
+
+- **JuliaSpec** (Manual): Parameters we define for fractal generation
+- **JuliaImage** (Computed): Generated from specs
+- **DenoiseMethod** (Lookup): Fixed set of denoising algorithms
+- **Denoised** (Computed): Each image × each method
+
+After defining all tables, we'll visualize the schema with `dj.Diagram(schema)`.
+
+
+```python
+@schema
+class JuliaSpec(dj.Manual):
+    """Parameters for generating Julia fractals."""
+    definition = """
+    spec_id : uint8
+    ---
+    c_real : float64          # Real part of c
+    c_imag : float64          # Imaginary part of c  
+    noise_level = 50 : float64
+    """
+```
+
+
+
+```python
+@schema
+class JuliaImage(dj.Computed):
+    """Generated fractal images with noise."""
+    definition = """
+    -> JuliaSpec
+    ---
+    image : <blob>            # Generated fractal image
+    """
+    
+    def make(self, key):
+        spec = (JuliaSpec & key).fetch1()
+        img = julia(spec['c_real'] + 1j * spec['c_imag'])
+        img += np.random.randn(*img.shape) * spec['noise_level']
+        self.insert1({**key, 'image': img.astype(np.float32)})
+```
+
+
+
+```python
+from skimage import filters, restoration
+from skimage.morphology import disk
+
+@schema
+class DenoiseMethod(dj.Lookup):
+    """Image denoising algorithms."""
+    definition = """
+    method_id : uint8
+    ---
+    method_name : varchar(20)
+    params : <blob>
+    """
+    contents = [
+        [0, 'gaussian', {'sigma': 1.8}],
+        [1, 'median', {'radius': 3}],
+        [2, 'tv', {'weight': 20.0}],
+    ]
+```
+
+
+
+```python
+@schema
+class Denoised(dj.Computed):
+    """Denoised images: each image × each method."""
+    definition = """
+    -> JuliaImage
+    -> DenoiseMethod
+    ---
+    denoised : <blob>
+    """
+    
+    def make(self, key):
+        img = (JuliaImage & key).fetch1('image')
+        method, params = (DenoiseMethod & key).fetch1('method_name', 'params')
+        
+        if method == 'gaussian':
+            result = filters.gaussian(img, **params)
+        elif method == 'median':
+            result = filters.median(img, disk(params['radius']))
+        elif method == 'tv':
+            result = restoration.denoise_tv_chambolle(img, **params)
+        else:
+            raise ValueError(f"Unknown method: {method}")
+            
+        self.insert1({**key, 'denoised': result.astype(np.float32)})
+```
+
+
+
+```python
+dj.Diagram(schema)
+```
+
+
+## Running the Pipeline
+
+1. Insert specs into Manual table
+2. Call `populate()` on Computed tables
+
+
+```python
+# Define fractal parameters
+JuliaSpec.insert([
+    {'spec_id': 0, 'c_real': -0.4, 'c_imag': 0.6},
+    {'spec_id': 1, 'c_real': -0.74543, 'c_imag': 0.11301},
+    {'spec_id': 2, 'c_real': -0.1, 'c_imag': 0.651},
+    {'spec_id': 3, 'c_real': -0.835, 'c_imag': -0.2321},
+])
+JuliaSpec()
+```
+
+
+
+```python
+# Generate all fractal images
+JuliaImage.populate(display_progress=True)
+```
+
+
+
+```python
+# View generated images
+fig, axes = plt.subplots(1, 4, figsize=(12, 3))
+for ax, row in zip(axes, JuliaImage()):
+    ax.imshow(row['image'], cmap='magma')
+    ax.set_title(f"spec_id={row['spec_id']}")
+    ax.axis('off')
+plt.tight_layout()
+```
+
+
+
+```python
+# Apply all denoising methods to all images
+Denoised.populate(display_progress=True)
+```
+
+
+
+```python
+# 4 images × 3 methods = 12 results
+print(f"JuliaImage: {len(JuliaImage())} rows")
+print(f"DenoiseMethod: {len(DenoiseMethod())} rows")
+print(f"Denoised: {len(Denoised())} rows")
+```
+
+
+
+```python
+# Compare denoising methods on one image
+spec_id = 0
+original = (JuliaImage & {'spec_id': spec_id}).fetch1('image')
+
+fig, axes = plt.subplots(1, 4, figsize=(14, 3.5))
+axes[0].imshow(original, cmap='magma')
+axes[0].set_title('Original (noisy)')
+
+for ax, method_id in zip(axes[1:], [0, 1, 2]):
+    result = (Denoised & {'spec_id': spec_id, 'method_id': method_id}).fetch1('denoised')
+    method_name = (DenoiseMethod & {'method_id': method_id}).fetch1('method_name')
+    ax.imshow(result, cmap='magma')
+    ax.set_title(method_name)
+
+for ax in axes:
+    ax.axis('off')
+plt.tight_layout()
+```
+
+
+## Key Points
+
+| Table Type | Populated By | Use For |
+|------------|-------------|--------|
+| **Manual** | `insert()` | Experimental parameters, user inputs |
+| **Lookup** | `contents` attribute | Fixed reference data, method catalogs |
+| **Computed** | `populate()` | Derived results, processed outputs |
+
+The pipeline automatically:
+- Tracks dependencies (can't process an image that doesn't exist)
+- Skips already-computed results (idempotent)
+- Computes all combinations when multiple tables converge
+
+
+```python
+# Add a new spec — populate only computes what's missing
+JuliaSpec.insert1({'spec_id': 4, 'c_real': -0.7, 'c_imag': 0.27})
+
+JuliaImage.populate(display_progress=True)  # Only spec_id=4
+Denoised.populate(display_progress=True)    # Only spec_id=4 × 3 methods
+```
+
+
+
+```python
+# Cleanup
+schema.drop(prompt=False)
+```
+
+
+---
+## File: tutorials/examples/hotel-reservations.ipynb
+
+# Hotel Reservation System
+
+This example demonstrates how DataJoint's schema design enforces business rules automatically. You'll learn:
+
+- **Workflow dependencies** — Tables that enforce operational sequences
+- **Business rule enforcement** — Using referential integrity as validation
+- **Temporal data** — Room availability and pricing by date
+- **Error handling** — Converting database errors to domain exceptions
+
+## The Problem
+
+A hotel needs to enforce these business rules:
+
+1. Rooms have types (Deluxe, Suite) with varying prices by date
+2. Guests can only reserve rooms that are available
+3. Each room can have at most one reservation per night
+4. Guests must have a reservation before checking in
+5. Guests must check in before checking out
+
+Traditional approaches validate these rules in application code. With DataJoint, the **schema itself enforces them** through foreign keys and unique constraints.
+
+
+```python
+import datajoint as dj
+import datetime
+import random
+
+# Clean start
+schema = dj.Schema('tutorial_hotel')
+schema.drop(prompt=False)
+schema = dj.Schema('tutorial_hotel')
+```
+
+
+## Schema Design
+
+The schema forms a workflow: `Room → RoomAvailable → Reservation → CheckIn → CheckOut`
+
+Each arrow represents a foreign key dependency. You cannot insert a child record without a valid parent.
+
+
+```python
+@schema
+class Room(dj.Lookup):
+    definition = """
+    # Hotel rooms
+    room : uint8                    # room number
+    ---
+    room_type : enum('Deluxe', 'Suite')
+    """
+    contents = [
+        {'room': i, 'room_type': 'Suite' if i % 5 == 0 else 'Deluxe'}
+        for i in range(1, 21)  # 20 rooms
+    ]
+```
+
+
+
+```python
+@schema
+class RoomAvailable(dj.Manual):
+    definition = """
+    # Room availability and pricing by date
+    -> Room
+    date : date
+    ---
+    price : decimal(6, 2)           # price per night
+    """
+```
+
+
+
+```python
+@schema
+class Guest(dj.Manual):
+    definition = """
+    # Hotel guests
+    guest_id : uint32               # auto-assigned guest ID
+    ---
+    guest_name : varchar(60)
+    index(guest_name)
+    """
+```
+
+
+
+```python
+@schema
+class Reservation(dj.Manual):
+    definition = """
+    # Room reservations (one per room per night)
+    -> RoomAvailable
+    ---
+    -> Guest
+    credit_card : varchar(80)       # encrypted card info
+    """
+```
+
+
+
+```python
+@schema
+class CheckIn(dj.Manual):
+    definition = """
+    # Check-in records (requires reservation)
+    -> Reservation
+    """
+```
+
+
+
+```python
+@schema
+class CheckOut(dj.Manual):
+    definition = """
+    # Check-out records (requires check-in)
+    -> CheckIn
+    """
+```
+
+
+
+```python
+dj.Diagram(schema)
+```
+
+
+## How the Schema Enforces Rules
+
+| Business Rule | Schema Enforcement |
+|---------------|--------------------|
+| Room must exist | `Reservation -> RoomAvailable -> Room` |
+| Room must be available on date | `Reservation -> RoomAvailable` |
+| One reservation per room/night | `RoomAvailable` is primary key of `Reservation` |
+| Must reserve before check-in | `CheckIn -> Reservation` |
+| Must check-in before check-out | `CheckOut -> CheckIn` |
+
+The database **rejects invalid operations** — no application code needed.
+
+## Populate Room Availability
+
+Make rooms available for the next 30 days with random pricing:
+
+
+```python
+random.seed(42)
+start_date = datetime.date.today()
+days = 30
+
+for day in range(days):
+    date = start_date + datetime.timedelta(days=day)
+    # Weekend prices are higher
+    is_weekend = date.weekday() >= 5
+    base_price = 200 if is_weekend else 150
+    
+    RoomAvailable.insert(
+        {
+            'room': room['room'],
+            'date': date,
+            'price': base_price + random.randint(-30, 50)
+        }
+        for room in Room.to_dicts()
+    )
+
+print(f"Created {len(RoomAvailable())} room-night records")
+RoomAvailable() & {'room': 1}
+```
+
+
+## Business Operations
+
+These functions wrap database operations and convert constraint violations into meaningful domain errors:
+
+
+```python
+# Domain-specific exceptions
+class HotelError(Exception):
+    pass
+
+class RoomNotAvailable(HotelError):
+    pass
+
+class RoomAlreadyReserved(HotelError):
+    pass
+
+class NoReservation(HotelError):
+    pass
+
+class NotCheckedIn(HotelError):
+    pass
+
+class AlreadyProcessed(HotelError):
+    pass
+```
+
+
+
+```python
+def reserve_room(room, date, guest_name, credit_card):
+    """
+    Make a reservation. Creates guest record if needed.
+    
+    Raises
+    ------
+    RoomNotAvailable
+        If room is not available on that date
+    RoomAlreadyReserved
+        If room is already reserved for that date
+    """
+    # Find or create guest
+    guests = list((Guest & {'guest_name': guest_name}).keys())
+    if guests:
+        guest_key = guests[0]
+    else:
+        guest_key = {'guest_id': random.randint(1, 2**31)}
+        Guest.insert1({**guest_key, 'guest_name': guest_name})
+    
+    try:
+        Reservation.insert1({
+            'room': room,
+            'date': date,
+            **guest_key,
+            'credit_card': credit_card
+        })
+    except dj.errors.DuplicateError:
+        raise RoomAlreadyReserved(
+            f"Room {room} already reserved for {date}") from None
+    except dj.errors.IntegrityError:
+        raise RoomNotAvailable(
+            f"Room {room} not available on {date}") from None
+```
+
+
+
+```python
+def check_in(room, date):
+    """
+    Check in a guest. Requires existing reservation.
+    
+    Raises
+    ------
+    NoReservation
+        If no reservation exists for this room/date
+    AlreadyProcessed
+        If guest already checked in
+    """
+    try:
+        CheckIn.insert1({'room': room, 'date': date})
+    except dj.errors.DuplicateError:
+        raise AlreadyProcessed(
+            f"Room {room} already checked in for {date}") from None
+    except dj.errors.IntegrityError:
+        raise NoReservation(
+            f"No reservation for room {room} on {date}") from None
+```
+
+
+
+```python
+def check_out(room, date):
+    """
+    Check out a guest. Requires prior check-in.
+    
+    Raises
+    ------
+    NotCheckedIn
+        If guest hasn't checked in
+    AlreadyProcessed
+        If guest already checked out
+    """
+    try:
+        CheckOut.insert1({'room': room, 'date': date})
+    except dj.errors.DuplicateError:
+        raise AlreadyProcessed(
+            f"Room {room} already checked out for {date}") from None
+    except dj.errors.IntegrityError:
+        raise NotCheckedIn(
+            f"Room {room} not checked in for {date}") from None
+```
+
+
+## Demo: Business Rule Enforcement
+
+Let's see the schema enforce our business rules:
+
+
+```python
+# Successful reservation
+tomorrow = start_date + datetime.timedelta(days=1)
+reserve_room(1, tomorrow, 'Alice Smith', '4111-1111-1111-1111')
+print(f"Reserved room 1 for {tomorrow}")
+
+Reservation()
+```
+
+
+
+```python
+# Try to double-book the same room — fails!
+try:
+    reserve_room(1, tomorrow, 'Bob Jones', '5555-5555-5555-5555')
+except RoomAlreadyReserved as e:
+    print(f"Blocked: {e}")
+```
+
+
+
+```python
+# Try to reserve unavailable date — fails!
+far_future = start_date + datetime.timedelta(days=365)
+try:
+    reserve_room(1, far_future, 'Carol White', '6666-6666-6666-6666')
+except RoomNotAvailable as e:
+    print(f"Blocked: {e}")
+```
+
+
+
+```python
+# Try to check in without reservation — fails!
+try:
+    check_in(2, tomorrow)  # Room 2 has no reservation
+except NoReservation as e:
+    print(f"Blocked: {e}")
+```
+
+
+
+```python
+# Successful check-in (has reservation)
+check_in(1, tomorrow)
+print(f"Checked in room 1 for {tomorrow}")
+
+CheckIn()
+```
+
+
+
+```python
+# Try to check out without checking in — fails!
+# First make a reservation for room 3
+reserve_room(3, tomorrow, 'David Brown', '7777-7777-7777-7777')
+
+try:
+    check_out(3, tomorrow)  # Reserved but not checked in
+except NotCheckedIn as e:
+    print(f"Blocked: {e}")
+```
+
+
+
+```python
+# Successful check-out (was checked in)
+check_out(1, tomorrow)
+print(f"Checked out room 1 for {tomorrow}")
+
+CheckOut()
+```
+
+
+## Useful Queries
+
+The workflow structure enables powerful queries:
+
+
+```python
+# Available rooms (not reserved) for tomorrow
+available = (RoomAvailable & {'date': tomorrow}) - Reservation
+print(f"Available rooms for {tomorrow}: {len(available)}")
+available
+```
+
+
+
+```python
+# Guests currently checked in (checked in but not out)
+currently_in = (CheckIn - CheckOut) * Reservation * Guest
+currently_in.proj('guest_name', 'room', 'date')
+```
+
+
+
+```python
+# Reservations without check-in (no-shows or upcoming)
+not_checked_in = Reservation - CheckIn
+(not_checked_in * Guest).proj('guest_name', 'room', 'date')
+```
+
+
+
+```python
+# Revenue by room type using aggr
+dj.U('room_type').aggr(
+    Room * RoomAvailable * Reservation,
+    total_revenue='SUM(price)',
+    reservations='COUNT(*)'
+)
+```
+
+
+## Key Concepts
+
+| Concept | How It's Used |
+|---------|---------------|
+| **Workflow Dependencies** | `CheckOut -> CheckIn -> Reservation -> RoomAvailable` |
+| **Unique Constraints** | One reservation per room/night (primary key) |
+| **Referential Integrity** | Can't reserve unavailable room, can't check in without reservation |
+| **Error Translation** | Database exceptions → domain-specific errors |
+
+The schema **is** the business logic. Application code just translates errors.
+
+## Next Steps
+
+- [University Database](university.ipynb) — Academic records with many-to-many relationships
+- [Languages & Proficiency](languages.ipynb) — International standards and lookup tables
+- [Data Entry](../basics/03-data-entry.ipynb) — Insert patterns and transactions
+
+
+```python
+# Cleanup
+schema.drop(prompt=False)
+```
+
+
+---
+## File: tutorials/examples/languages.ipynb
+
+# Languages and Proficiency
+
+This example demonstrates many-to-many relationships using an association table with international standards. You'll learn:
+
+- **Many-to-many relationships** — People speak multiple languages; languages have multiple speakers
+- **Lookup tables** — Standardized reference data (ISO language codes, CEFR levels)
+- **Association tables** — Linking entities with additional attributes
+- **Complex queries** — Aggregations, filtering, and joins
+
+## International Standards
+
+This example uses two widely-adopted standards:
+
+- **ISO 639-1** — Two-letter language codes (`en`, `es`, `ja`)
+- **CEFR** — Common European Framework of Reference for language proficiency (A1–C2)
+
+Using international standards ensures data consistency and enables integration with external systems.
+
+
+```python
+import datajoint as dj
+import numpy as np
+from faker import Faker
+
+dj.config['display.limit'] = 8
+
+# Clean start
+schema = dj.Schema('tutorial_languages')
+schema.drop(prompt=False)
+schema = dj.Schema('tutorial_languages')
+```
+
+
+## Lookup Tables
+
+Lookup tables store standardized reference data that rarely changes. The `contents` attribute pre-populates them when the schema is created.
+
+
+```python
+@schema
+class Language(dj.Lookup):
+    definition = """
+    # ISO 639-1 language codes
+    lang_code : char(2)             # two-letter code (en, es, ja)
+    ---
+    language : varchar(30)          # full name
+    native_name : varchar(50)       # name in native script
+    """
+    contents = [
+        ('ar', 'Arabic', 'العربية'),
+        ('de', 'German', 'Deutsch'),
+        ('en', 'English', 'English'),
+        ('es', 'Spanish', 'Español'),
+        ('fr', 'French', 'Français'),
+        ('hi', 'Hindi', 'हिन्दी'),
+        ('ja', 'Japanese', '日本語'),
+        ('ko', 'Korean', '한국어'),
+        ('pt', 'Portuguese', 'Português'),
+        ('ru', 'Russian', 'Русский'),
+        ('zh', 'Chinese', '中文'),
+    ]
+```
+
+
+
+```python
+@schema
+class CEFRLevel(dj.Lookup):
+    definition = """
+    # CEFR proficiency levels
+    cefr_level : char(2)            # A1, A2, B1, B2, C1, C2
+    ---
+    level_name : varchar(20)        # descriptive name
+    category : enum('Basic', 'Independent', 'Proficient')
+    description : varchar(100)      # can-do summary
+    """
+    contents = [
+        ('A1', 'Beginner', 'Basic',
+         'Can use familiar everyday expressions'),
+        ('A2', 'Elementary', 'Basic',
+         'Can communicate in simple routine tasks'),
+        ('B1', 'Intermediate', 'Independent',
+         'Can deal with most travel situations'),
+        ('B2', 'Upper Intermediate', 'Independent',
+         'Can interact with fluency and spontaneity'),
+        ('C1', 'Advanced', 'Proficient',
+         'Can express ideas fluently for professional use'),
+        ('C2', 'Mastery', 'Proficient',
+         'Can understand virtually everything'),
+    ]
+```
+
+
+
+```python
+print("Languages:")
+print(Language())
+print("\nCEFR Levels:")
+print(CEFRLevel())
+```
+
+
+## Entity and Association Tables
+
+- **Person** — The main entity
+- **Proficiency** — Association table linking Person, Language, and CEFRLevel
+
+The association table's primary key includes both Person and Language, creating the many-to-many relationship.
+
+
+```python
+@schema
+class Person(dj.Manual):
+    definition = """
+    # People with language skills
+    person_id : int32               # unique identifier
+    ---
+    name : varchar(60)
+    date_of_birth : date
+    """
+```
+
+
+
+```python
+@schema
+class Proficiency(dj.Manual):
+    definition = """
+    # Language proficiency (many-to-many: person <-> language)
+    -> Person
+    -> Language
+    ---
+    -> CEFRLevel
+    """
+```
+
+
+
+```python
+dj.Diagram(schema)
+```
+
+
+**Reading the diagram:**
+- **Gray tables** (Language, CEFRLevel) are Lookup tables
+- **Green table** (Person) is Manual
+- **Solid lines** indicate foreign keys in the primary key (many-to-many)
+- **Dashed line** indicates foreign key in secondary attributes (reference)
+
+## Populate Sample Data
+
+
+```python
+np.random.seed(42)
+fake = Faker()
+fake.seed_instance(42)
+
+# Generate 200 people
+n_people = 200
+Person.insert(
+    {
+        'person_id': i,
+        'name': fake.name(),
+        'date_of_birth': fake.date_of_birth(
+            minimum_age=18, maximum_age=70)
+    }
+    for i in range(n_people)
+)
+
+print(f"Created {len(Person())} people")
+Person()
+```
+
+
+
+```python
+# Assign random language proficiencies
+lang_keys = list(Language.keys())
+cefr_keys = list(CEFRLevel.keys())
+
+# More people at intermediate levels than extremes
+cefr_weights = [0.08, 0.12, 0.20, 0.25, 0.20, 0.15]
+avg_languages = 2.5
+
+for person_key in Person.keys():
+    n_langs = np.random.poisson(avg_languages)
+    if n_langs > 0:
+        selected_langs = np.random.choice(
+            len(lang_keys), min(n_langs, len(lang_keys)), replace=False)
+        Proficiency.insert(
+            {
+                **person_key,
+                **lang_keys[i],
+                **np.random.choice(cefr_keys, p=cefr_weights)
+            }
+            for i in selected_langs
+        )
+
+print(f"Created {len(Proficiency())} proficiency records")
+Proficiency()
+```
+
+
+## Query Examples
+
+### Finding Speakers
+
+
+```python
+# Proficient English speakers (C1 or C2)
+proficient_english = (
+    Person.proj('name') & 
+    (Proficiency & {'lang_code': 'en'} & 'cefr_level >= "C1"')
+)
+print(f"Proficient English speakers: {len(proficient_english)}")
+proficient_english
+```
+
+
+
+```python
+# People who speak BOTH English AND Spanish
+bilingual = (
+    Person.proj('name') & 
+    (Proficiency & {'lang_code': 'en'}) & 
+    (Proficiency & {'lang_code': 'es'})
+)
+print(f"English + Spanish speakers: {len(bilingual)}")
+bilingual
+```
+
+
+
+```python
+# People who speak English OR Spanish
+either = (
+    Person.proj('name') & 
+    (Proficiency & 'lang_code in ("en", "es")')
+)
+print(f"English or Spanish speakers: {len(either)}")
+either
+```
+
+
+### Aggregations
+
+
+```python
+# People who speak 4+ languages
+polyglots = Person.aggr(
+    Proficiency,
+    'name',
+    n_languages='COUNT(lang_code)',
+    languages='GROUP_CONCAT(lang_code)'
+) & 'n_languages >= 4'
+
+print(f"Polyglots (4+ languages): {len(polyglots)}")
+polyglots
+```
+
+
+
+```python
+# Top 5 polyglots
+top_polyglots = Person.aggr(
+    Proficiency,
+    'name',
+    n_languages='COUNT(lang_code)'
+) & dj.Top(5, order_by='n_languages DESC')
+
+top_polyglots
+```
+
+
+
+```python
+# Number of speakers per language
+speakers_per_lang = Language.aggr(
+    Proficiency,
+    'language',
+    n_speakers='COUNT(person_id)'
+)
+speakers_per_lang
+```
+
+
+
+```python
+# CEFR level distribution for English
+english_levels = CEFRLevel.aggr(
+    Proficiency & {'lang_code': 'en'},
+    'level_name',
+    n_speakers='COUNT(person_id)'
+)
+english_levels
+```
+
+
+### Joining Tables
+
+
+```python
+# Full profile: person + language + proficiency details
+full_profile = (
+    Person * Proficiency * Language * CEFRLevel
+).proj('name', 'language', 'level_name', 'category')
+
+# Show profile for person_id=0
+full_profile & {'person_id': 0}
+```
+
+
+
+```python
+# Find people with C1+ proficiency in multiple languages
+advanced_polyglots = Person.aggr(
+    Proficiency & 'cefr_level >= "C1"',
+    'name',
+    n_advanced='COUNT(*)'
+) & 'n_advanced >= 2'
+
+print(f"Advanced in 2+ languages: {len(advanced_polyglots)}")
+advanced_polyglots
+```
+
+
+## Key Concepts
+
+| Pattern | Implementation |
+|---------|----------------|
+| **Many-to-many** | `Proficiency` links `Person` and `Language` |
+| **Lookup tables** | `Language` and `CEFRLevel` with `contents` |
+| **Association data** | `cefr_level` stored in the association table |
+| **Standards** | ISO 639-1 codes, CEFR levels |
+
+### Benefits of Lookup Tables
+
+1. **Data consistency** — Only valid codes can be used
+2. **Rich metadata** — Full names, descriptions stored once
+3. **Easy updates** — Change "Español" to "Spanish" in one place
+4. **Self-documenting** — `Language()` shows all valid options
+
+## Next Steps
+
+- [University Database](university.ipynb) — Academic records
+- [Hotel Reservations](hotel-reservations.ipynb) — Workflow dependencies
+- [Queries Tutorial](../basics/04-queries.ipynb) — Query operators in depth
+
+
+```python
+# Cleanup
+schema.drop(prompt=False)
+```
+
+
+---
+## File: tutorials/examples/university.ipynb
 
 # University Database
 
@@ -5299,7 +10581,8 @@ def generate_students(n=500):
             'first_name': name[0],
             'last_name': name[-1],
             'sex': sex,
-            'date_of_birth': fake.date_between(start_date='-35y', end_date='-17y'),
+            'date_of_birth': fake.date_between(
+                start_date='-35y', end_date='-17y'),
             'home_city': fake.city(),
             'home_state': fake.state_abbr()
         }
@@ -5323,7 +10606,10 @@ Department.insert([
 students = Student.keys()
 depts = Department.keys()
 StudentMajor.insert(
-    {**s, **random.choice(depts), 'declare_date': fake.date_between(start_date='-4y')}
+    {
+        **s, **random.choice(depts),
+        'declare_date': fake.date_between(start_date='-4y')
+    }
     for s in students if random.random() < 0.75
 )
 print(f"{len(StudentMajor())} students declared majors")
@@ -5367,11 +10653,12 @@ Term.insert(
 for course in Course.keys():
     for term in Term.keys():
         for sec in 'abc'[:random.randint(1, 3)]:
-            if random.random() < 0.7:  # Not every course offered every term
+            if random.random() < 0.7:  # Not every course every term
                 Section.insert1({
                     **course, **term,
                     'section': sec,
-                    'auditorium': f"{random.choice('ABCDEF')}{random.randint(100, 400)}"
+                    'auditorium': f"{random.choice('ABCDEF')}"
+                                  f"{random.randint(100, 400)}"
                 }, skip_duplicates=True)
 
 print(f"{len(Section())} sections created")
@@ -5389,8 +10676,10 @@ for student in Student.keys():
         # Take 2-4 courses per term
         available = (Section & term).keys()
         if available:
-            for section in random.sample(available, k=min(random.randint(2, 4), len(available))):
-                Enroll.insert1({**student, **section}, skip_duplicates=True)
+            n_courses = min(random.randint(2, 4), len(available))
+            for section in random.sample(available, k=n_courses):
+                Enroll.insert1(
+                    {**student, **section}, skip_duplicates=True)
 
 print(f"{len(Enroll())} enrollments")
 ```
@@ -5765,957 +11054,6 @@ schema.drop(prompt=False)
 
 
 ---
-## File: tutorials/08-fractal-pipeline.ipynb
-
-# Fractal Image Pipeline
-
-This tutorial demonstrates **computed tables** by building an image processing pipeline for Julia fractals.
-
-You'll learn:
-- **Manual tables**: Parameters you define (experimental configurations)
-- **Lookup tables**: Fixed reference data (processing methods)
-- **Computed tables**: Automatically generated results via `populate()`
-- **Many-to-many pipelines**: Processing every combination of inputs × methods
-
-
-```python
-import datajoint as dj
-import numpy as np
-from matplotlib import pyplot as plt
-
-schema = dj.Schema('tutorial_fractal')
-```
-
-
-## Julia Set Generator
-
-Julia sets are fractals generated by iterating $f(z) = z^2 + c$ for each point in the complex plane. Points that don't escape to infinity form intricate patterns.
-
-
-```python
-def julia(c, size=256, center=(0.0, 0.0), zoom=1.0, iters=256):
-    """Generate a Julia set image."""
-    x, y = np.meshgrid(
-        np.linspace(-1, 1, size) / zoom + center[0],
-        np.linspace(-1, 1, size) / zoom + center[1]
-    )
-    z = x + 1j * y
-    img = np.zeros(z.shape)
-    mask = np.ones(z.shape, dtype=bool)
-    for _ in range(iters):
-        z[mask] = z[mask] ** 2 + c
-        mask = np.abs(z) < 2
-        img += mask
-    return img
-```
-
-
-
-```python
-# Example fractal
-plt.imshow(julia(-0.4 + 0.6j), cmap='magma')
-plt.axis('off');
-```
-
-
-## Pipeline Architecture
-
-We'll build a pipeline with four tables:
-
-- **JuliaSpec** (Manual): Parameters we define for fractal generation
-- **JuliaImage** (Computed): Generated from specs
-- **DenoiseMethod** (Lookup): Fixed set of denoising algorithms
-- **Denoised** (Computed): Each image × each method
-
-After defining all tables, we'll visualize the schema with `dj.Diagram(schema)`.
-
-
-```python
-@schema
-class JuliaSpec(dj.Manual):
-    """Parameters for generating Julia fractals."""
-    definition = """
-    spec_id : uint8
-    ---
-    c_real : float64          # Real part of c
-    c_imag : float64          # Imaginary part of c  
-    noise_level = 50 : float64
-    """
-```
-
-
-
-```python
-@schema
-class JuliaImage(dj.Computed):
-    """Generated fractal images with noise."""
-    definition = """
-    -> JuliaSpec
-    ---
-    image : <blob>            # Generated fractal image
-    """
-    
-    def make(self, key):
-        spec = (JuliaSpec & key).fetch1()
-        img = julia(spec['c_real'] + 1j * spec['c_imag'])
-        img += np.random.randn(*img.shape) * spec['noise_level']
-        self.insert1({**key, 'image': img.astype(np.float32)})
-```
-
-
-
-```python
-from skimage import filters, restoration
-from skimage.morphology import disk
-
-@schema
-class DenoiseMethod(dj.Lookup):
-    """Image denoising algorithms."""
-    definition = """
-    method_id : uint8
-    ---
-    method_name : varchar(20)
-    params : <blob>
-    """
-    contents = [
-        [0, 'gaussian', {'sigma': 1.8}],
-        [1, 'median', {'radius': 3}],
-        [2, 'tv', {'weight': 20.0}],
-    ]
-```
-
-
-
-```python
-@schema
-class Denoised(dj.Computed):
-    """Denoised images: each image × each method."""
-    definition = """
-    -> JuliaImage
-    -> DenoiseMethod
-    ---
-    denoised : <blob>
-    """
-    
-    def make(self, key):
-        img = (JuliaImage & key).fetch1('image')
-        method, params = (DenoiseMethod & key).fetch1('method_name', 'params')
-        
-        if method == 'gaussian':
-            result = filters.gaussian(img, **params)
-        elif method == 'median':
-            result = filters.median(img, disk(params['radius']))
-        elif method == 'tv':
-            result = restoration.denoise_tv_chambolle(img, **params)
-        else:
-            raise ValueError(f"Unknown method: {method}")
-            
-        self.insert1({**key, 'denoised': result.astype(np.float32)})
-```
-
-
-
-```python
-dj.Diagram(schema)
-```
-
-
-## Running the Pipeline
-
-1. Insert specs into Manual table
-2. Call `populate()` on Computed tables
-
-
-```python
-# Define fractal parameters
-JuliaSpec.insert([
-    {'spec_id': 0, 'c_real': -0.4, 'c_imag': 0.6},
-    {'spec_id': 1, 'c_real': -0.74543, 'c_imag': 0.11301},
-    {'spec_id': 2, 'c_real': -0.1, 'c_imag': 0.651},
-    {'spec_id': 3, 'c_real': -0.835, 'c_imag': -0.2321},
-])
-JuliaSpec()
-```
-
-
-
-```python
-# Generate all fractal images
-JuliaImage.populate(display_progress=True)
-```
-
-
-
-```python
-# View generated images
-fig, axes = plt.subplots(1, 4, figsize=(12, 3))
-for ax, row in zip(axes, JuliaImage()):
-    ax.imshow(row['image'], cmap='magma')
-    ax.set_title(f"spec_id={row['spec_id']}")
-    ax.axis('off')
-plt.tight_layout()
-```
-
-
-
-```python
-# Apply all denoising methods to all images
-Denoised.populate(display_progress=True)
-```
-
-
-
-```python
-# 4 images × 3 methods = 12 results
-print(f"JuliaImage: {len(JuliaImage())} rows")
-print(f"DenoiseMethod: {len(DenoiseMethod())} rows")
-print(f"Denoised: {len(Denoised())} rows")
-```
-
-
-
-```python
-# Compare denoising methods on one image
-spec_id = 0
-original = (JuliaImage & {'spec_id': spec_id}).fetch1('image')
-
-fig, axes = plt.subplots(1, 4, figsize=(14, 3.5))
-axes[0].imshow(original, cmap='magma')
-axes[0].set_title('Original (noisy)')
-
-for ax, method_id in zip(axes[1:], [0, 1, 2]):
-    result = (Denoised & {'spec_id': spec_id, 'method_id': method_id}).fetch1('denoised')
-    method_name = (DenoiseMethod & {'method_id': method_id}).fetch1('method_name')
-    ax.imshow(result, cmap='magma')
-    ax.set_title(method_name)
-
-for ax in axes:
-    ax.axis('off')
-plt.tight_layout()
-```
-
-
-## Key Points
-
-| Table Type | Populated By | Use For |
-|------------|-------------|--------|
-| **Manual** | `insert()` | Experimental parameters, user inputs |
-| **Lookup** | `contents` attribute | Fixed reference data, method catalogs |
-| **Computed** | `populate()` | Derived results, processed outputs |
-
-The pipeline automatically:
-- Tracks dependencies (can't process an image that doesn't exist)
-- Skips already-computed results (idempotent)
-- Computes all combinations when multiple tables converge
-
-
-```python
-# Add a new spec — populate only computes what's missing
-JuliaSpec.insert1({'spec_id': 4, 'c_real': -0.7, 'c_imag': 0.27})
-
-JuliaImage.populate(display_progress=True)  # Only spec_id=4
-Denoised.populate(display_progress=True)    # Only spec_id=4 × 3 methods
-```
-
-
-
-```python
-# Cleanup
-schema.drop(prompt=False)
-```
-
-
----
-## File: tutorials/advanced/custom-codecs.ipynb
-
-# Custom Codecs
-
-This tutorial covers extending DataJoint's type system. You'll learn:
-
-- **Codec basics** — Encoding and decoding
-- **Creating codecs** — Domain-specific types
-- **Codec chaining** — Composing codecs
-
-
-```python
-import datajoint as dj
-import numpy as np
-
-schema = dj.Schema('tutorial_codecs')
-```
-
-
-## Creating a Custom Codec
-
-
-```python
-import networkx as nx
-
-class GraphCodec(dj.Codec):
-    """Store NetworkX graphs."""
-    
-    name = "graph"  # Use as <graph>
-    
-    def get_dtype(self, is_external: bool) -> str:
-        return "<blob>"
-    
-    def encode(self, value, *, key=None, store_name=None):
-        return {'nodes': list(value.nodes(data=True)), 'edges': list(value.edges(data=True))}
-    
-    def decode(self, stored, *, key=None):
-        g = nx.Graph()
-        g.add_nodes_from(stored['nodes'])
-        g.add_edges_from(stored['edges'])
-        return g
-    
-    def validate(self, value):
-        if not isinstance(value, nx.Graph):
-            raise TypeError(f"Expected nx.Graph")
-```
-
-
-
-```python
-@schema
-class Connectivity(dj.Manual):
-    definition = """
-    conn_id : int
-    ---
-    network : <graph>
-    """
-```
-
-
-
-```python
-# Create and insert
-g = nx.Graph()
-g.add_edges_from([(1, 2), (2, 3), (1, 3)])
-Connectivity.insert1({'conn_id': 1, 'network': g})
-
-# Fetch
-result = (Connectivity & {'conn_id': 1}).fetch1('network')
-print(f"Type: {type(result)}")
-print(f"Edges: {list(result.edges())}")
-```
-
-
-## Codec Structure
-
-```python
-class MyCodec(dj.Codec):
-    name = "mytype"  # Use as <mytype>
-    
-    def get_dtype(self, is_external: bool) -> str:
-        return "<blob>"  # Storage type
-    
-    def encode(self, value, *, key=None, store_name=None):
-        return serializable_data
-    
-    def decode(self, stored, *, key=None):
-        return python_object
-    
-    def validate(self, value):  # Optional
-        pass
-```
-
-## Example: Spike Train
-
-
-```python
-from dataclasses import dataclass
-
-@dataclass
-class SpikeTrain:
-    times: np.ndarray
-    unit_id: int
-    quality: str
-
-class SpikeTrainCodec(dj.Codec):
-    name = "spike_train"
-    
-    def get_dtype(self, is_external: bool) -> str:
-        return "<blob>"
-    
-    def encode(self, value, *, key=None, store_name=None):
-        return {'times': value.times, 'unit_id': value.unit_id, 'quality': value.quality}
-    
-    def decode(self, stored, *, key=None):
-        return SpikeTrain(times=stored['times'], unit_id=stored['unit_id'], quality=stored['quality'])
-```
-
-
-
-```python
-@schema
-class Unit(dj.Manual):
-    definition = """
-    unit_id : int
-    ---
-    spikes : <spike_train>
-    """
-
-train = SpikeTrain(times=np.sort(np.random.uniform(0, 100, 50)), unit_id=1, quality='good')
-Unit.insert1({'unit_id': 1, 'spikes': train})
-
-result = (Unit & {'unit_id': 1}).fetch1('spikes')
-print(f"Type: {type(result)}, Spikes: {len(result.times)}")
-```
-
-
-
-```python
-schema.drop(prompt=False)
-```
-
-
----
-## File: tutorials/advanced/distributed.ipynb
-
-# Distributed Computing
-
-This tutorial covers running computations across multiple workers. You'll learn:
-
-- **Jobs 2.0** — DataJoint's job coordination system
-- **Multi-process** — Parallel workers on one machine
-- **Multi-machine** — Cluster-scale computation
-- **Error handling** — Recovery and monitoring
-
-
-```python
-import datajoint as dj
-import numpy as np
-import time
-
-schema = dj.Schema('tutorial_distributed')
-
-# Clean up from previous runs
-schema.drop(prompt=False)
-schema = dj.Schema('tutorial_distributed')
-```
-
-
-## Setup
-
-
-```python
-@schema
-class Experiment(dj.Manual):
-    definition = """
-    exp_id : int
-    ---
-    n_samples : int
-    """
-
-@schema
-class Analysis(dj.Computed):
-    definition = """
-    -> Experiment
-    ---
-    result : float64
-    compute_time : float32
-    """
-
-    def make(self, key):
-        start = time.time()
-        n = (Experiment & key).fetch1('n_samples')
-        result = float(np.mean(np.random.randn(n) ** 2))
-        time.sleep(0.1)
-        self.insert1({**key, 'result': result, 'compute_time': time.time() - start})
-```
-
-
-
-```python
-Experiment.insert([{'exp_id': i, 'n_samples': 10000} for i in range(20)])
-print(f"To compute: {len(Analysis.key_source - Analysis)}")
-```
-
-
-## Direct vs Distributed Mode
-
-**Direct mode** (default): No coordination, suitable for single worker.
-
-**Distributed mode** (`reserve_jobs=True`): Workers coordinate via jobs table.
-
-
-```python
-# Distributed mode
-Analysis.populate(reserve_jobs=True, max_calls=5, display_progress=True)
-```
-
-
-## The Jobs Table
-
-
-```python
-# Refresh job queue
-result = Analysis.jobs.refresh()
-print(f"Added: {result['added']}")
-
-# Check status
-for status, count in Analysis.jobs.progress().items():
-    print(f"{status}: {count}")
-```
-
-
-## Multi-Process and Multi-Machine
-
-The `processes=N` parameter spawns multiple worker processes on one machine. However, this requires table classes to be defined in importable Python modules (not notebooks), because multiprocessing needs to pickle and transfer the class definitions to worker processes.
-
-For production use, define your tables in a module and run workers as scripts:
-
-```python
-# pipeline.py - Define your tables
-import datajoint as dj
-schema = dj.Schema('my_pipeline')
-
-@schema
-class Analysis(dj.Computed):
-    definition = """..."""
-    def make(self, key): ...
-```
-
-```python
-# worker.py - Run workers
-from pipeline import Analysis
-
-# Single machine, 4 processes
-Analysis.populate(reserve_jobs=True, processes=4)
-
-# Or run this script on multiple machines
-while True:
-    result = Analysis.populate(reserve_jobs=True, max_calls=100, suppress_errors=True)
-    if result['success_count'] == 0:
-        break
-```
-
-In this notebook, we'll demonstrate distributed coordination with a single process:
-
-
-```python
-# Complete remaining jobs with distributed coordination
-Analysis.populate(reserve_jobs=True, display_progress=True)
-print(f"Computed: {len(Analysis())}")
-```
-
-
-## Error Handling
-
-
-```python
-# View errors
-print(f"Errors: {len(Analysis.jobs.errors)}")
-
-# Retry failed jobs
-Analysis.jobs.errors.delete()
-Analysis.populate(reserve_jobs=True, suppress_errors=True)
-```
-
-
-## Quick Reference
-
-| Option | Description |
-|--------|-------------|
-| `reserve_jobs=True` | Enable coordination |
-| `processes=N` | N worker processes |
-| `max_calls=N` | Limit jobs per run |
-| `suppress_errors=True` | Continue on errors |
-
-
-```python
-schema.drop(prompt=False)
-```
-
-
----
-## File: tutorials/advanced/json-type.ipynb
-
-# JSON Data Type
-
-This tutorial covers the `json` data type in DataJoint, which allows storing semi-structured data within tables. You'll learn:
-
-- When to use the JSON type
-- Defining tables with JSON attributes
-- Inserting JSON data
-- Querying and filtering JSON fields
-- Projecting JSON subfields
-
-## Prerequisites
-
-- **MySQL 8.0+** with `JSON_VALUE` function support
-- Percona is fully compatible
-- MariaDB is **not supported** (different `JSON_VALUE` syntax)
-
-
-```python
-import datajoint as dj
-```
-
-
-## Table Definition
-
-For this exercise, let's imagine we work for an awesome company that is organizing a fun RC car race across various teams in the company. Let's see which team has the fastest car! 🏎️
-
-This establishes 2 important entities: a `Team` and a `Car`. Normally the entities are mapped to their own dedicated table, however, let's assume that `Team` is well-structured but `Car` is less structured than we'd prefer. In other words, the structure for what makes up a *car* is varying too much between entries (perhaps because users of the pipeline haven't agreed yet on the definition? 🤷).
-
-This would make it a good use-case to keep `Team` as a table but make `Car` a `json` type defined within the `Team` table.
-
-Let's begin.
-
-
-```python
-import datajoint as dj
-
-# Clean up any existing schema from previous runs
-schema = dj.Schema('tutorial_json', create_tables=False)
-schema.drop()
-
-# Create fresh schema
-schema = dj.Schema('tutorial_json')
-```
-
-
-
-```python
-@schema
-class Team(dj.Lookup):
-    definition = """
-    # A team within a company
-    name: varchar(40)  # team name
-    ---
-    car=null: json  # A car belonging to a team (null to allow registering first but specifying car later)
-    
-    unique index(car.length:decimal(4, 1))  # Add an index if this key is frequently accessed
-    """
-```
-
-
-## Insert
-
-Let's suppose that engineering is first up to register their car.
-
-
-```python
-Team.insert1(
-    {
-        "name": "engineering",
-        "car": {
-            "name": "Rever",
-            "length": 20.5,
-            "inspected": True,
-            "tire_pressure": [32, 31, 33, 34],
-            "headlights": [
-                {
-                    "side": "left",
-                    "hyper_white": None,
-                },
-                {
-                    "side": "right",
-                    "hyper_white": None,
-                },
-            ],
-        },
-    }
-)
-```
-
-
-Next, business and marketing teams are up and register their cars.
-
-A few points to notice below:
-- The person signing up on behalf of marketing does not know the specifics of the car during registration but another team member will be updating this soon before the race.
-- Notice how the `business` and `engineering` teams appear to specify the same property but refer to it as `safety_inspected` and `inspected` respectfully.
-
-
-```python
-Team.insert(
-    [
-        {
-            "name": "marketing",
-            "car": None,
-        },
-        {
-            "name": "business",
-            "car": {
-                "name": "Chaching",
-                "length": 100,
-                "safety_inspected": False,
-                "tire_pressure": [34, 30, 27, 32],
-                "headlights": [
-                    {
-                        "side": "left",
-                        "hyper_white": True,
-                    },
-                    {
-                        "side": "right",
-                        "hyper_white": True,
-                    },
-                ],
-            },
-        },
-    ]
-)
-```
-
-
-We can preview the table data much like normal but notice how the value of `car` behaves like other BLOB-like attributes.
-
-
-```python
-Team()
-```
-
-
-## Restriction
-
-Now let's see what kinds of queries we can form to demostrate how we can query this pipeline.
-
-
-```python
-# Which team has a `car` equal to 100 inches long?
-Team & {"car.length": 100}
-```
-
-
-
-```python
-# Which team has a `car` less than 50 inches long?
-Team & "car->>'$.length' < 50"
-```
-
-
-
-```python
-# Any team that has had their car inspected?
-Team & [{"car.inspected:unsigned": True}, {"car.safety_inspected:unsigned": True}]
-```
-
-
-
-```python
-# Which teams do not have hyper white lights for their first head light?
-Team & {"car.headlights[0].hyper_white": None}
-```
-
-
-Notice that the previous query will satisfy the `None` check if it experiences any of the following scenarious:
-- if entire record missing (`marketing` satisfies this)
-- JSON key is missing
-- JSON value is set to JSON `null` (`engineering` satisfies this)
-
-## Projection
-
-Projections can be quite useful with the `json` type since we can extract out just what we need. This allows greater query flexibility but more importantly, for us to be able to fetch only what is pertinent.
-
-
-```python
-# Only interested in the car names and the length but let the type be inferred
-q_untyped = Team.proj(
-    car_name="car.name",
-    car_length="car.length",
-)
-q_untyped
-```
-
-
-
-```python
-q_untyped.to_dicts()
-```
-
-
-
-```python
-# Nevermind, I'll specify the type explicitly
-q_typed = Team.proj(
-    car_name="car.name",
-    car_length="car.length:float",
-)
-q_typed
-```
-
-
-
-```python
-q_typed.to_dicts()
-```
-
-
-## Describe
-
-Lastly, the `.describe()` function on the `Team` table can help us generate the table's definition. This is useful if we are connected directly to the pipeline without the original source.
-
-
-```python
-rebuilt_definition = Team.describe()
-print(rebuilt_definition)
-```
-
-
-## Cleanup
-
-Finally, let's clean up what we created in this tutorial.
-
-
-```python
-schema.drop(prompt=False)
-```
-
-
-
-```python
-
-```
-
-
----
-## File: tutorials/advanced/migration.ipynb
-
-# Schema Migration
-
-This tutorial covers evolving existing pipelines. You'll learn:
-
-- **Schema changes** — Adding and modifying columns
-- **The alter() method** — Syncing definitions with database
-- **Migration patterns** — Safe evolution strategies
-- **Limitations** — What cannot be changed
-
-
-```python
-import datajoint as dj
-import numpy as np
-
-schema = dj.Schema('tutorial_migration')
-```
-
-
-## Initial Schema
-
-
-```python
-@schema
-class Subject(dj.Manual):
-    definition = """
-    subject_id : varchar(16)
-    ---
-    species : varchar(32)
-    """
-
-Subject.insert([
-    {'subject_id': 'M001', 'species': 'mouse'},
-    {'subject_id': 'M002', 'species': 'mouse'},
-])
-Subject()
-```
-
-
-## Adding a Column
-
-Update definition, then call `alter()`:
-
-
-```python
-# Update definition
-Subject.definition = """
-subject_id : varchar(16)
----
-species : varchar(32)
-weight = null : float32   # New column
-"""
-
-# Apply change
-Subject.alter(prompt=False)
-Subject()
-```
-
-
-## Modifying Column Type
-
-
-```python
-# Widen varchar
-Subject.definition = """
-subject_id : varchar(16)
----
-species : varchar(100)    # Was 32
-weight = null : float32
-"""
-
-Subject.alter(prompt=False)
-print(Subject.describe())
-```
-
-
-## What Can Be Altered
-
-| Change | Supported |
-|--------|----------|
-| Add columns | Yes |
-| Drop columns | Yes |
-| Modify types | Yes |
-| Rename columns | Yes |
-| **Primary keys** | **No** |
-| **Foreign keys** | **No** |
-| **Indexes** | **No** |
-
-## Migration Pattern for Unsupported Changes
-
-For primary key or foreign key changes:
-
-```python
-# 1. Create new table
-@schema
-class SubjectNew(dj.Manual):
-    definition = """...new structure..."""
-
-# 2. Migrate data
-for row in Subject().to_dicts():
-    SubjectNew.insert1(transform(row))
-
-# 3. Update dependents
-# 4. Drop old table
-# 5. Rename if needed
-```
-
-## DataJoint 2.0 Migration
-
-Upgrading from 0.x:
-
-| 0.x | 2.0 |
-|-----|-----|
-| `longblob` | `<blob>` |
-| `blob@store` | `<blob@store>` |
-| `attach` | `<attach>` |
-| `schema.jobs` | `Table.jobs` |
-
-
-```python
-# Migrate blob columns
-from datajoint.migrate import analyze_blob_columns, migrate_blob_columns
-
-# Find columns needing migration
-# results = analyze_blob_columns(schema)
-
-# Apply (adds codec markers)
-# migrate_blob_columns(schema, dry_run=False)
-```
-
-
-## Best Practices
-
-1. **Test in development first**
-2. **Backup before migration**
-3. **Plan primary keys carefully** — they can't change
-4. **Use versioned migration scripts** for production
-
-
-```python
-schema.drop(prompt=False)
-```
-
-
----
 ## File: tutorials/index.md
 
 # Tutorials
@@ -6724,25 +11062,112 @@ Learn DataJoint by building real pipelines.
 
 These tutorials guide you through building data pipelines step by step. Each tutorial
 is a Jupyter notebook that you can run interactively. Start with the basics and
-progress to advanced topics.
+progress to domain-specific and advanced topics.
 
-## Getting Started
+## Quick Start
 
-1. [Getting Started](01-getting-started.ipynb) — Your first DataJoint pipeline
-2. [Schema Design](02-schema-design.ipynb) — Tables, keys, and relationships
-3. [Data Entry](03-data-entry.ipynb) — Inserting and managing data
-4. [Queries](04-queries.ipynb) — Operators and fetching results
-5. [Computation](05-computation.ipynb) — Imported and Computed tables
-6. [Object-Augmented Schemas](06-object-storage.ipynb) — Blobs, attachments, and object storage
-7. [University Database](07-university.ipynb) — A complete example pipeline
-8. [Fractal Pipeline](08-fractal-pipeline.ipynb) — Iterative computation patterns
+Install DataJoint:
+
+```bash
+pip install datajoint
+```
+
+Configure database credentials in your project (see [Configuration](../reference/configuration.md)):
+
+```bash
+# Create datajoint.json for non-sensitive settings
+echo '{"database": {"host": "localhost", "port": 3306}}' > datajoint.json
+
+# Create secrets directory for credentials
+mkdir -p .secrets
+echo "root" > .secrets/database.user
+echo "password" > .secrets/database.password
+```
+
+Define and populate a simple pipeline:
+
+```python
+import datajoint as dj
+
+schema = dj.Schema('my_pipeline')
+
+@schema
+class Subject(dj.Manual):
+    definition = """
+    subject_id : uint16
+    ---
+    name : varchar(100)
+    date_of_birth : date
+    """
+
+@schema
+class Session(dj.Manual):
+    definition = """
+    -> Subject
+    session_idx : uint8
+    ---
+    session_date : date
+    """
+
+@schema
+class SessionAnalysis(dj.Computed):
+    definition = """
+    -> Session
+    ---
+    result : float64
+    """
+
+    def make(self, key):
+        # Compute result for this session
+        self.insert1({**key, 'result': 42.0})
+
+# Insert data
+Subject.insert1({'subject_id': 1, 'name': 'M001', 'date_of_birth': '2026-01-15'})
+Session.insert1({'subject_id': 1, 'session_idx': 1, 'session_date': '2026-01-06'})
+
+# Run computations
+SessionAnalysis.populate()
+```
+
+Continue learning with the structured tutorials below.
+
+## Basics
+
+Core concepts for getting started with DataJoint:
+
+1. [First Pipeline](basics/01-first-pipeline.ipynb) — Tables, queries, and the four core operations
+2. [Schema Design](basics/02-schema-design.ipynb) — Primary keys, relationships, and table tiers
+3. [Data Entry](basics/03-data-entry.ipynb) — Inserting and managing data
+4. [Queries](basics/04-queries.ipynb) — Operators and fetching results
+5. [Computation](basics/05-computation.ipynb) — Imported and Computed tables
+6. [Object Storage](basics/06-object-storage.ipynb) — Blobs, attachments, and external stores
+
+## Examples
+
+Complete pipelines demonstrating DataJoint patterns:
+
+- [University Database](examples/university.ipynb) — Academic records with students, courses, and grades
+- [Hotel Reservations](examples/hotel-reservations.ipynb) — Booking system with rooms, guests, and reservations
+- [Languages & Proficiency](examples/languages.ipynb) — Language skills tracking with many-to-many relationships
+- [Fractal Pipeline](examples/fractal-pipeline.ipynb) — Iterative computation and parameter sweeps
+- [Blob Detection](examples/blob-detection.ipynb) — Image processing with automated computation
+
+## Domain Tutorials
+
+Real-world scientific pipelines:
+
+- [Calcium Imaging](domain/calcium-imaging/calcium-imaging.ipynb) — Import TIFF movies, segment cells, extract fluorescence traces
+- [Electrophysiology](domain/electrophysiology/electrophysiology.ipynb) — Import recordings, detect spikes, extract waveforms
+- [Allen CCF](domain/allen-ccf/allen-ccf.ipynb) — Brain atlas with hierarchical region ontology
 
 ## Advanced Topics
 
+Extending DataJoint for specialized use cases:
+
+- [SQL Comparison](advanced/sql-comparison.ipynb) — DataJoint for SQL users
 - [JSON Data Type](advanced/json-type.ipynb) — Semi-structured data in tables
 - [Distributed Computing](advanced/distributed.ipynb) — Multi-process and cluster workflows
 - [Custom Codecs](advanced/custom-codecs.ipynb) — Extending the type system
-- [Schema Migration](advanced/migration.ipynb) — Evolving existing pipelines
 
 ## Running the Tutorials
 
@@ -7008,7 +11433,7 @@ test_schema = dj.Schema('test_' + schema.database)
 ## See Also
 
 - [Define Tables](define-tables.md) — Table definition syntax
-- [Migrate from 0.x](migrate-from-0x.md) — Version migration
+- [Migrate to v2.0](migrate-to-v20.md) — Version migration
 
 
 ---
@@ -7375,7 +11800,7 @@ For serverless environments (AWS Lambda, Cloud Functions) or when you need expli
 import datajoint as dj
 
 with dj.Connection(host, user, password) as conn:
-    schema = dj.schema('my_schema', connection=conn)
+    schema = dj.Schema('my_schema', connection=conn)
     MyTable().insert(data)
 # Connection automatically closed when exiting the block
 ```
@@ -7385,7 +11810,7 @@ The connection closes automatically even if an exception occurs:
 ```python
 try:
     with dj.Connection(**creds) as conn:
-        schema = dj.schema('my_schema', connection=conn)
+        schema = dj.Schema('my_schema', connection=conn)
         MyTable().insert(data)
         raise SomeError()
 except SomeError:
@@ -7408,17 +11833,28 @@ conn.close()
 ---
 ## File: how-to/configure-storage.md
 
-# Configure Object Storage
+# Configure Object Stores
 
-Set up S3, MinIO, or filesystem storage for your Object-Augmented Schema.
+Set up S3, MinIO, or filesystem storage for DataJoint's Object-Augmented Schema (OAS).
 
-> **Tip:** [DataJoint.com](https://datajoint.com) provides pre-configured object storage integrated with your database—no setup required.
+> **Tip:** [DataJoint.com](https://datajoint.com) provides pre-configured object stores integrated with your database—no setup required.
 
 ## Overview
 
-An Object-Augmented Schema (OAS) integrates relational tables with object storage as a single system. Large data objects (arrays, files, Zarr datasets) are stored in object storage while maintaining full referential integrity with the relational database.
+DataJoint's Object-Augmented Schema (OAS) integrates relational tables with object storage as a single coherent system. Large data objects (arrays, files, Zarr datasets) are stored in file systems or cloud storage while maintaining full referential integrity with the relational database.
 
-Object storage is configured per-project and can include multiple named stores for different data types or storage tiers.
+**Storage models:**
+
+- **Hash-addressed** and **schema-addressed** storage are **integrated** into the OAS. DataJoint manages paths, lifecycle, integrity, garbage collection, transaction safety, and deduplication.
+- **Filepath** storage stores only path strings. DataJoint provides no lifecycle management, garbage collection, transaction safety, or deduplication. Users control file creation, organization, and lifecycle.
+
+Storage is configured per-project using named stores. Each store can be used for:
+
+- **Hash-addressed storage** (`<blob@>`, `<attach@>`) — content-addressed with deduplication using `_hash/` section
+- **Schema-addressed storage** (`<object@>`, `<npy@>`) — key-based paths with streaming access using `_schema/` section
+- **Filepath storage** (`<filepath@>`) — user-managed paths anywhere in the store **except** `_hash/` and `_schema/` (reserved for DataJoint)
+
+Multiple stores can be configured for different data types or storage tiers. One store is designated as the default.
 
 ## Configuration Methods
 
@@ -7429,33 +11865,44 @@ DataJoint loads configuration in priority order:
 3. **Config file** (`datajoint.json`)
 4. **Defaults** (lowest priority)
 
-## File System Store
+## Single Store Configuration
+
+### File System Store
 
 For local or network-mounted storage:
 
 ```json
 {
-  "object_storage": {
-    "project_name": "my_project",
-    "protocol": "file",
-    "location": "/data/datajoint-store"
+  "stores": {
+    "default": "main",
+    "main": {
+      "protocol": "file",
+      "location": "/data/my-project/production"
+    }
   }
 }
 ```
 
-## S3 Store
+Paths will be:
+
+- Hash: `/data/my-project/production/_hash/{schema}/{hash}`
+- Schema: `/data/my-project/production/_schema/{schema}/{table}/{key}/`
+
+### S3 Store
 
 For Amazon S3 or S3-compatible storage:
 
 ```json
 {
-  "object_storage": {
-    "project_name": "my_project",
-    "protocol": "s3",
-    "endpoint": "s3.amazonaws.com",
-    "bucket": "my-bucket",
-    "location": "dj/objects",
-    "secure": true
+  "stores": {
+    "default": "main",
+    "main": {
+      "protocol": "s3",
+      "endpoint": "s3.amazonaws.com",
+      "bucket": "my-bucket",
+      "location": "my-project/production",
+      "secure": true
+    }
   }
 }
 ```
@@ -7464,58 +11911,68 @@ Store credentials separately in `.secrets/`:
 
 ```
 .secrets/
-├── object_storage.access_key
-└── object_storage.secret_key
+├── stores.main.access_key
+└── stores.main.secret_key
 ```
 
-Or use environment variables:
+Paths will be:
 
-```bash
-export DJ_OBJECT_STORAGE_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
-export DJ_OBJECT_STORAGE_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-```
+- Hash: `s3://my-bucket/my-project/production/_hash/{schema}/{hash}`
+- Schema: `s3://my-bucket/my-project/production/_schema/{schema}/{table}/{key}/`
 
-## MinIO Store
+### MinIO Store
 
 MinIO uses the S3 protocol with a custom endpoint:
 
 ```json
 {
-  "object_storage": {
-    "project_name": "my_project",
-    "protocol": "s3",
-    "endpoint": "minio.example.com:9000",
-    "bucket": "datajoint",
-    "location": "dj/objects",
-    "secure": false
+  "stores": {
+    "default": "main",
+    "main": {
+      "protocol": "s3",
+      "endpoint": "minio.example.com:9000",
+      "bucket": "datajoint",
+      "location": "lab-data",
+      "secure": false
+    }
   }
 }
 ```
 
-## Named Stores
+## Multiple Stores Configuration
 
 Define multiple stores for different data types or storage tiers:
 
 ```json
 {
-  "object_storage": {
-    "project_name": "my_project",
-    "protocol": "file",
-    "location": "/data/default",
-    "stores": {
-      "raw": {
-        "protocol": "file",
-        "location": "/data/raw"
-      },
-      "archive": {
-        "protocol": "s3",
-        "endpoint": "s3.amazonaws.com",
-        "bucket": "archive-bucket",
-        "location": "dj/archive"
-      }
+  "stores": {
+    "default": "main",
+    "main": {
+      "protocol": "file",
+      "location": "/data/my-project/main",
+      "partition_pattern": "subject_id/session_date"
+    },
+    "raw": {
+      "protocol": "file",
+      "location": "/data/my-project/raw",
+      "subfolding": [2, 2]
+    },
+    "archive": {
+      "protocol": "s3",
+      "endpoint": "s3.amazonaws.com",
+      "bucket": "archive-bucket",
+      "location": "my-project/long-term"
     }
   }
 }
+```
+
+Store credentials in `.secrets/`:
+
+```
+.secrets/
+├── stores.archive.access_key
+└── stores.archive.secret_key
 ```
 
 Use named stores in table definitions:
@@ -7526,9 +11983,25 @@ class Recording(dj.Manual):
     definition = """
     recording_id : uuid
     ---
-    raw_data : <blob@raw>         # Uses 'raw' store
-    processed : <blob@archive>    # Uses 'archive' store
+    raw_data : <blob@raw>         # Hash: _hash/{schema}/{hash}
+    zarr_scan : <object@raw>      # Schema: _schema/{schema}/{table}/{key}/
+    summary : <blob@>             # Uses default store (main)
+    old_data : <blob@archive>     # Archive store, hash-addressed
     """
+```
+
+Notice that `<blob@raw>` and `<object@raw>` both use the "raw" store, just different `_hash` and `_schema` sections.
+
+**Example paths with partitioning:**
+
+For a Recording with `subject_id=042`, `session_date=2024-01-15` in the main store:
+```
+/data/my-project/main/_schema/subject_id=042/session_date=2024-01-15/experiment/Recording/recording_id=uuid-value/zarr_scan.x8f2a9b1.zarr
+```
+
+Without those attributes, it follows normal structure:
+```
+/data/my-project/main/_schema/experiment/Recording/recording_id=uuid-value/zarr_scan.x8f2a9b1.zarr
 ```
 
 ## Verify Configuration
@@ -7537,26 +12010,87 @@ class Recording(dj.Manual):
 import datajoint as dj
 
 # Check default store
-spec = dj.config.get_object_store_spec()
+spec = dj.config.get_store_spec()  # Uses stores.default
 print(spec)
 
 # Check named store
-spec = dj.config.get_object_store_spec("archive")
+spec = dj.config.get_store_spec("archive")
 print(spec)
+
+# List all configured stores
+print(dj.config.stores.keys())
 ```
 
 ## Configuration Options
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `project_name` | Yes | Unique identifier for your project |
-| `protocol` | Yes | `file`, `s3`, `gcs`, or `azure` |
-| `location` | Yes | Base path or prefix within bucket |
-| `bucket` | S3/GCS | Bucket name |
-| `endpoint` | S3 | S3 endpoint URL |
-| `secure` | No | Use HTTPS (default: true) |
-| `access_key` | S3 | Access key ID |
-| `secret_key` | S3 | Secret access key |
+| `stores.default` | Yes | Name of the default store |
+| `stores.<name>.protocol` | Yes | `file`, `s3`, `gcs`, or `azure` |
+| `stores.<name>.location` | Yes | Base path or prefix (includes project context) |
+| `stores.<name>.bucket` | S3/GCS | Bucket name |
+| `stores.<name>.endpoint` | S3 | S3 endpoint URL |
+| `stores.<name>.secure` | No | Use HTTPS (default: true) |
+| `stores.<name>.access_key` | S3 | Access key ID (store in `.secrets/`) |
+| `stores.<name>.secret_key` | S3 | Secret access key (store in `.secrets/`) |
+| `stores.<name>.subfolding` | No | Hash-addressed hierarchy: `[2, 2]` for 2-level nesting (default: no subfolding) |
+| `stores.<name>.partition_pattern` | No | Schema-addressed path partitioning: `"subject_id/session_date"` (default: no partitioning) |
+| `stores.<name>.token_length` | No | Random token length for schema-addressed filenames (default: `8`) |
+
+## Subfolding (Hash-Addressed Storage Only)
+
+Hash-addressed storage (`<blob@>`, `<attach@>`) stores content using a Base32-encoded hash as the filename. By default, all files are stored in a flat directory structure:
+
+```
+_hash/{schema}/abcdefghijklmnopqrstuvwxyz
+```
+
+Some filesystems perform poorly with large directories (thousands of files). Subfolding creates a directory hierarchy to distribute files:
+
+```json
+{
+  "stores": {
+    "default": "main",
+    "main": {
+      "protocol": "file",
+      "location": "/data/store",
+      "project_name": "my_project",
+      "subfolding": [2, 2]
+    }
+  }
+}
+```
+
+With `[2, 2]` subfolding, hash-addressed paths become:
+
+```
+_hash/{schema}/ab/cd/abcdefghijklmnopqrstuvwxyz
+```
+
+Schema-addressed storage (`<object@>`, `<npy@>`) does not use subfolding—it uses key-based paths:
+
+```
+{location}/_schema/{partition}/{schema}/{table}/{key}/{field_name}.{token}.{ext}
+```
+
+### Filesystem Recommendations
+
+| Filesystem | Subfolding Needed | Notes |
+|------------|-------------------|-------|
+| ext3 | Yes | Limited directory indexing |
+| FAT32/exFAT | Yes | Linear directory scans |
+| NFS | Yes | Network latency amplifies directory lookups |
+| CIFS/SMB | Yes | Windows network shares |
+| ext4 | No | HTree indexing handles large directories |
+| XFS | No | B+ tree directories scale well |
+| ZFS | No | Efficient directory handling |
+| Btrfs | No | B-tree based |
+| S3/MinIO | No | Object storage uses hash-based lookups |
+| GCS | No | Object storage |
+| Azure Blob | No | Object storage |
+
+**Recommendation:** Use `[2, 2]` for network-mounted filesystems and legacy systems.
+Modern local filesystems and cloud object storage work well without subfolding.
 
 ## URL Representation
 
@@ -7580,6 +12114,98 @@ This unified approach enables:
 - **Consistent internal handling** across all storage types
 - **Seamless switching** between local and cloud storage
 - **Integration with fsspec** for streaming access
+
+## Customizing Storage Sections
+
+Each store is divided into sections for different storage types. By default, DataJoint uses `_hash/` for hash-addressed storage and `_schema/` for schema-addressed storage. You can customize the path prefix for each section using the `*_prefix` configuration parameters to map DataJoint to existing storage layouts:
+
+```json
+{
+  "stores": {
+    "legacy": {
+      "protocol": "file",
+      "location": "/data/existing_storage",
+      "hash_prefix": "content_addressed",
+      "schema_prefix": "structured_data",
+      "filepath_prefix": "raw_files"
+    }
+  }
+}
+```
+
+**Requirements:**
+
+- Sections must be mutually exclusive (path prefixes cannot nest)
+- The `hash_prefix` and `schema_prefix` sections are reserved for DataJoint-managed storage
+- The `filepath_prefix` is optional (`null` = unrestricted, or set a required prefix)
+
+**Example with hierarchical layout:**
+
+```json
+{
+  "stores": {
+    "organized": {
+      "protocol": "s3",
+      "endpoint": "s3.amazonaws.com",
+      "bucket": "neuroscience-data",
+      "location": "lab-project-2024",
+      "hash_prefix": "managed/blobs",      // Path prefix for hash section
+      "schema_prefix": "managed/arrays",    // Path prefix for schema section
+      "filepath_prefix": "imported"         // Path prefix for filepath section
+    }
+  }
+}
+```
+
+Storage section paths become:
+
+- Hash: `s3://neuroscience-data/lab-project-2024/managed/blobs/{schema}/{hash}`
+- Schema: `s3://neuroscience-data/lab-project-2024/managed/arrays/{schema}/{table}/{key}/`
+- Filepath: `s3://neuroscience-data/lab-project-2024/imported/{user_path}`
+
+## Reserved Sections and Filepath Storage
+
+DataJoint reserves sections within each store for managed storage. These sections are defined by prefix configuration parameters:
+
+- **Hash-addressed section** (configured via `hash_prefix`, default: `_hash/`) — Content-addressed storage for `<blob@>` and `<attach@>` with deduplication
+- **Schema-addressed section** (configured via `schema_prefix`, default: `_schema/`) — Key-based storage for `<object@>` and `<npy@>` with streaming access
+
+### User-Managed Filepath Storage
+
+The `<filepath@>` codec stores paths to files that you manage. DataJoint does not manage lifecycle (no garbage collection), integrity (no transaction safety), or deduplication for filepath storage. You can reference existing files or create new ones—DataJoint simply stores the path string. Files can be anywhere in the store **except** the reserved sections:
+
+```python
+@schema
+class RawData(dj.Manual):
+    definition = """
+    session_id : int
+    ---
+    recording : <filepath@acquisition>  # User-managed file path
+    """
+
+# Valid paths (user-managed)
+table.insert1({'session_id': 1, 'recording': 'subject01/session001/data.bin'})  # Existing or new file
+table.insert1({'session_id': 2, 'recording': 'raw/experiment_2024/data.nwb'})  # Existing or new file
+
+# Invalid paths (reserved for DataJoint - will raise ValueError)
+# These use the default prefixes (_hash and _schema)
+table.insert1({'session_id': 3, 'recording': '_hash/abc123...'})      # Error!
+table.insert1({'session_id': 4, 'recording': '_schema/myschema/...'}) # Error!
+
+# If you configured custom prefixes like "content_addressed", those would also be blocked
+# table.insert1({'session_id': 5, 'recording': 'content_addressed/file.dat'})  # Error!
+```
+
+**Key characteristics of `<filepath@>`:**
+
+- Stores path string only (DataJoint does not manage the files)
+- No lifecycle management: no garbage collection, no transaction safety, no deduplication
+- User controls file creation, organization, and deletion
+- Can reference existing files or create new ones
+- Returns ObjectRef for lazy access on fetch
+- Validates file exists on insert
+- Cannot use reserved sections (configured by `hash_prefix` and `schema_prefix`)
+- Can be restricted to specific prefix using `filepath_prefix` configuration
 
 ## See Also
 
@@ -7612,7 +12238,7 @@ class GraphCodec(dj.Codec):
 
     name = "graph"  # Used as <graph> in definitions
 
-    def get_dtype(self, is_external: bool) -> str:
+    def get_dtype(self, is_store: bool) -> str:
         return "<blob>"  # Delegate to blob for serialization
 
     def encode(self, value, *, key=None, store_name=None):
@@ -7640,26 +12266,26 @@ class Connectivity(dj.Manual):
 
 ## Required Methods
 
-### `get_dtype(is_external)`
+### `get_dtype(is_store)`
 
 Return the storage type:
 
-- `is_external=False`: Internal storage (in database)
-- `is_external=True`: Object storage (with `@`)
+- `is_store=False`: Inline storage (in database column)
+- `is_store=True`: Object store (with `@` modifier)
 
 ```python
-def get_dtype(self, is_external: bool) -> str:
-    if is_external:
-        return "<hash>"  # Content-addressed external
-    return "bytes"       # Database blob
+def get_dtype(self, is_store: bool) -> str:
+    if is_store:
+        return "<hash>"  # Hash-addressed storage
+    return "bytes"       # Inline database blob
 ```
 
 Common return values:
 
 - `"bytes"` — Binary in database
 - `"json"` — JSON in database
-- `"<blob>"` — Chain to blob codec
-- `"<hash>"` — Content-addressed storage
+- `"<blob>"` — Chain to blob codec (hash-addressed when `@`)
+- `"<hash>"` — Hash-addressed storage
 
 ### `encode(value, *, key=None, store_name=None)`
 
@@ -7703,7 +12329,7 @@ Codecs can delegate to other codecs:
 class ImageCodec(dj.Codec):
     name = "image"
 
-    def get_dtype(self, is_external: bool) -> str:
+    def get_dtype(self, is_store: bool) -> str:
         return "<blob>"  # Chain to blob codec
 
     def encode(self, value, *, key=None, store_name=None):
@@ -7716,24 +12342,44 @@ class ImageCodec(dj.Codec):
         return Image.fromarray(stored)
 ```
 
-## External-Only Codec
+## Store-Only Codecs
 
-Some codecs require external storage:
+Some codecs require object storage (@ modifier):
 
 ```python
 class ZarrCodec(dj.Codec):
     name = "zarr"
 
-    def get_dtype(self, is_external: bool) -> str:
-        if not is_external:
-            raise DataJointError("<zarr> requires @store")
-        return "<object>"  # Path-addressed storage
+    def get_dtype(self, is_store: bool) -> str:
+        if not is_store:
+            raise DataJointError("<zarr> requires @ (store only)")
+        return "<object>"  # Schema-addressed storage
 
     def encode(self, path, *, key=None, store_name=None):
         return path  # Path to zarr directory
 
     def decode(self, stored, *, key=None):
         return stored  # Returns ObjectRef for lazy access
+```
+
+For custom file formats, consider inheriting from `SchemaCodec`:
+
+```python
+class ParquetCodec(dj.SchemaCodec):
+    """Store DataFrames as Parquet files."""
+    name = "parquet"
+
+    # get_dtype inherited: requires @, returns "json"
+
+    def encode(self, df, *, key=None, store_name=None):
+        schema, table, field, pk = self._extract_context(key)
+        path, _ = self._build_path(schema, table, field, pk, ext=".parquet")
+        backend = self._get_backend(store_name)
+        # ... upload parquet file
+        return {"path": path, "store": store_name, "shape": list(df.shape)}
+
+    def decode(self, stored, *, key=None):
+        return ParquetRef(stored, self._get_backend(stored.get("store")))
 ```
 
 ## Auto-Registration
@@ -7769,8 +12415,8 @@ class MedicalImageCodec(dj.Codec):
 
     name = "medimage"
 
-    def get_dtype(self, is_external: bool) -> str:
-        return "<blob@>" if is_external else "<blob>"
+    def get_dtype(self, is_store: bool) -> str:
+        return "<blob@>" if is_store else "<blob>"
 
     def encode(self, image, *, key=None, store_name=None):
         return {
@@ -8329,7 +12975,7 @@ print(f"Deleted {count} subjects")
 
 ## See Also
 
-- [Model Relationships](model-relationships.md) — Foreign key patterns
+- [Model Relationships](model-relationships.ipynb) — Foreign key patterns
 - [Insert Data](insert-data.md) — Adding data to tables
 - [Run Computations](run-computations.md) — Recomputing after changes
 
@@ -8520,7 +13166,7 @@ class Scan(dj.Manual):
 ## See Also
 
 - [Define Tables](define-tables.md) — Table definition syntax
-- [Model Relationships](model-relationships.md) — Foreign key patterns
+- [Model Relationships](model-relationships.ipynb) — Foreign key patterns
 
 
 ---
@@ -8852,6 +13498,227 @@ All output methods accept:
 
 
 ---
+## File: how-to/garbage-collection.md
+
+# Clean Up External Storage
+
+Remove orphaned data from object storage after deleting database rows.
+
+## Why Garbage Collection?
+
+When you delete rows from tables with external storage (`<blob@>`, `<attach@>`,
+`<object@>`, `<npy@>`), the database records are removed but the external files
+remain. This is by design:
+
+- **Hash-addressed storage** (`<blob@>`, `<attach@>`) uses deduplication—the
+  same content may be referenced by multiple rows
+- **Schema-addressed storage** (`<object@>`, `<npy@>`) stores each row's data
+  at a unique path, but immediate deletion could cause issues with concurrent
+  operations
+
+Run garbage collection periodically to reclaim storage space.
+
+## Basic Usage
+
+```python
+import datajoint as dj
+
+# Scan for orphaned items (dry run)
+stats = dj.gc.scan(schema1, schema2)
+print(dj.gc.format_stats(stats))
+
+# Remove orphaned items
+stats = dj.gc.collect(schema1, schema2, dry_run=False)
+print(dj.gc.format_stats(stats))
+```
+
+## Scan Before Collecting
+
+Always scan first to see what would be deleted:
+
+```python
+# Check what's orphaned
+stats = dj.gc.scan(my_schema)
+
+print(f"Hash-addressed orphaned: {stats['hash_orphaned']}")
+print(f"Schema paths orphaned: {stats['schema_paths_orphaned']}")
+print(f"Total bytes: {stats['orphaned_bytes'] / 1e6:.1f} MB")
+```
+
+## Dry Run Mode
+
+The default `dry_run=True` reports what would be deleted without deleting:
+
+```python
+# Safe: shows what would be deleted
+stats = dj.gc.collect(my_schema, dry_run=True)
+print(dj.gc.format_stats(stats))
+
+# After review, actually delete
+stats = dj.gc.collect(my_schema, dry_run=False)
+```
+
+## Multiple Schemas
+
+If your data spans multiple schemas, scan all of them together:
+
+```python
+# Important: include ALL schemas that might share storage
+stats = dj.gc.collect(
+    schema_raw,
+    schema_processed,
+    schema_analysis,
+    dry_run=False
+)
+```
+
+!!! note "Per-schema deduplication"
+    Hash-addressed storage is deduplicated **within** each schema. Different
+    schemas have independent storage, so you only need to scan schemas that
+    share the same database.
+
+## Named Stores
+
+If you use multiple named stores, specify which to clean:
+
+```python
+# Clean specific store
+stats = dj.gc.collect(my_schema, store_name='archive', dry_run=False)
+
+# Or clean default store
+stats = dj.gc.collect(my_schema, dry_run=False)  # uses default store
+```
+
+## Verbose Mode
+
+See detailed progress:
+
+```python
+stats = dj.gc.collect(
+    my_schema,
+    dry_run=False,
+    verbose=True  # logs each deletion
+)
+```
+
+## Understanding the Statistics
+
+```python
+stats = dj.gc.scan(my_schema)
+
+# Hash-addressed storage (<blob@>, <attach@>, <hash@>)
+stats['hash_referenced']      # Items still in database
+stats['hash_stored']          # Items in storage
+stats['hash_orphaned']        # Unreferenced (can be deleted)
+stats['hash_orphaned_bytes']  # Size of orphaned items
+
+# Schema-addressed storage (<object@>, <npy@>)
+stats['schema_paths_referenced']  # Paths still in database
+stats['schema_paths_stored']      # Paths in storage
+stats['schema_paths_orphaned']    # Unreferenced paths
+stats['schema_paths_orphaned_bytes']
+
+# Totals
+stats['referenced']   # Total referenced items
+stats['stored']       # Total stored items
+stats['orphaned']     # Total orphaned items
+stats['orphaned_bytes']
+```
+
+## Scheduled Collection
+
+Run GC periodically in production:
+
+```python
+# In a cron job or scheduled task
+import datajoint as dj
+from myproject import schema1, schema2, schema3
+
+stats = dj.gc.collect(
+    schema1, schema2, schema3,
+    dry_run=False,
+    verbose=True
+)
+
+if stats['errors'] > 0:
+    logging.warning(f"GC completed with {stats['errors']} errors")
+else:
+    logging.info(f"GC freed {stats['bytes_freed'] / 1e6:.1f} MB")
+```
+
+## How Storage Addressing Works
+
+DataJoint uses two storage patterns:
+
+### Hash-Addressed (`<blob@>`, `<attach@>`, `<hash@>`)
+
+```
+_hash/
+  {schema}/
+    ab/
+      cd/
+        abcdefghij...  # Content identified by Base32-encoded MD5 hash
+```
+
+- Duplicate content shares storage within each schema
+- Paths are stored in metadata—safe from config changes
+- Cannot delete until no rows reference the content
+- GC compares stored paths against filesystem
+
+### Schema-Addressed (`<object@>`, `<npy@>`)
+
+```
+myschema/
+  mytable/
+    primary_key_values/
+      attribute_name/
+        data.zarr/
+        data.npy
+```
+
+- Each row has unique path based on schema structure
+- Paths mirror database organization
+- GC removes paths not referenced by any row
+
+## Troubleshooting
+
+### "At least one schema must be provided"
+
+```python
+# Wrong
+dj.gc.scan()
+
+# Right
+dj.gc.scan(my_schema)
+```
+
+### Storage not decreasing
+
+Check that you're scanning all schemas:
+
+```python
+# List all schemas that use this store
+# Make sure to include them all in the scan
+```
+
+### Permission errors
+
+Ensure your storage credentials allow deletion:
+
+```python
+# Check store configuration
+spec = dj.config.get_object_store_spec('mystore')
+# Verify write/delete permissions
+```
+
+## See Also
+
+- [Manage Large Data](manage-large-data.md) — Storage patterns and streaming
+- [Configure Object Storage](configure-storage.md) — Storage setup
+- [Delete Data](delete-data.md) — Row deletion with cascades
+
+
+---
 ## File: how-to/handle-errors.md
 
 # Handle Errors
@@ -9070,7 +13937,7 @@ they assume you understand the basics and focus on getting things done.
 ## Schema Design
 
 - [Define Tables](define-tables.md) — Table definition syntax
-- [Model Relationships](model-relationships.md) — Foreign key patterns
+- [Model Relationships](model-relationships.ipynb) — Foreign key patterns
 - [Design Primary Keys](design-primary-keys.md) — Key selection strategies
 
 ## Project Management
@@ -9095,11 +13962,12 @@ they assume you understand the basics and focus on getting things done.
 
 - [Use Object Storage](use-object-storage.md) — When and how
 - [Create Custom Codecs](create-custom-codec.md) — Domain-specific types
-- [Manage Large Data](manage-large-data.md) — Blobs, objects, garbage collection
+- [Manage Large Data](manage-large-data.md) — Blobs, streaming, efficiency
+- [Clean Up External Storage](garbage-collection.md) — Garbage collection
 
 ## Maintenance
 
-- [Migrate from 0.x](migrate-from-0x.md) — Upgrading existing pipelines
+- [Migrate to v2.0](migrate-to-v20.md) — Upgrading existing pipelines
 - [Alter Tables](alter-tables.md) — Schema evolution
 - [Backup and Restore](backup-restore.md) — Data protection
 
@@ -9261,6 +14129,12 @@ if Subject.validate(rows):
 
 Install DataJoint Python and set up your environment.
 
+!!! warning "DataJoint 2.0+ Required"
+
+    This documentation is for **DataJoint 2.0 and later**. The PyPI and conda releases for DataJoint 2.0 are currently in preparation.
+
+    **If you install now, you may get an older version (0.14.x).** After installation, verify you have version 2.0 or later before following the tutorials and guides.
+
 ## Basic Installation
 
 ```bash
@@ -9282,18 +14156,34 @@ pip install datajoint[all]
 
 ## Development Installation
 
+To install the latest pre-release version:
+
 ```bash
-git clone https://github.com/datajoint/datajoint-python.git
+git clone -b pre/v2.0 https://github.com/datajoint/datajoint-python.git
 cd datajoint-python
 pip install -e ".[dev]"
 ```
 
 ## Verify Installation
 
+**Important:** Check that you have DataJoint 2.0 or later:
+
 ```python
 import datajoint as dj
 print(dj.__version__)
 ```
+
+**Expected output:** `2.0.0` or higher
+
+!!! danger "Version Mismatch"
+
+    If you see version `0.14.x` or lower, you have the legacy version of DataJoint. This documentation will not match your installed version.
+
+    **Options:**
+
+    1. **Upgrade to 2.0 (pre-release):** Install from the `pre/v2.0` branch (see Development Installation above)
+    2. **Use legacy documentation:** Visit [datajoint.github.io/datajoint-python](https://datajoint.github.io/datajoint-python)
+    3. **Migrate existing pipeline:** Follow the [Migration Guide](migrate-to-v20.md)
 
 ## Database Server
 
@@ -9364,8 +14254,8 @@ Work effectively with blobs and object storage.
 | Data Size | Recommended | Syntax |
 |-----------|-------------|--------|
 | < 1 MB | Database | `<blob>` |
-| 1 MB - 1 GB | Object storage | `<blob@>` |
-| > 1 GB | Path-addressed | `<object@>` |
+| 1 MB - 1 GB | Hash-addressed | `<blob@>` |
+| > 1 GB | Schema-addressed | `<object@>`, `<npy@>` |
 
 ## Streaming Large Results
 
@@ -9447,7 +14337,7 @@ with dj.conn().transaction:
 
 ## Content Deduplication
 
-`<blob@>` and `<attach@>` automatically deduplicate:
+`<blob@>` and `<attach@>` automatically deduplicate within each schema:
 
 ```python
 # Same array inserted twice
@@ -9455,20 +14345,32 @@ data = np.random.randn(1000, 1000)
 Table.insert1({'id': 1, 'data': data})
 Table.insert1({'id': 2, 'data': data})  # References same storage
 
-# Only one copy exists in object storage
+# Only one copy exists in object storage (per schema)
 ```
+
+Deduplication is per-schema—identical content in different schemas is stored separately.
+This enables independent garbage collection per schema.
 
 ## Storage Cleanup
 
-Remove orphaned objects after deletes:
+External storage items are not automatically deleted with rows. Run garbage
+collection periodically:
 
 ```python
+import datajoint as dj
+
 # Objects are NOT automatically deleted with rows
 (MyTable & old_data).delete()
 
-# Run garbage collection periodically
-# (Implementation depends on your storage backend)
+# Scan for orphaned items
+stats = dj.gc.scan(my_schema)
+print(dj.gc.format_stats(stats))
+
+# Remove orphaned items
+stats = dj.gc.collect(my_schema, dry_run=False)
 ```
+
+See [Clean Up External Storage](garbage-collection.md) for details.
 
 ## Monitor Storage Usage
 
@@ -9557,59 +14459,46 @@ A production DataJoint pipeline typically involves:
 - **Shared infrastructure** — Database server, object storage, code repository
 - **Coordination** — Between code, database, and storage permissions
 
-This guide outlines the key considerations. For a fully managed solution, [request a DataJoint Platform account](https://www.datajoint.com/sign-up).
+This guide covers practical project organization. For conceptual background on pipeline architecture and the DAG structure, see [Data Pipelines](../explanation/data-pipelines.md).
 
-## Pipeline Architecture
+For a fully managed solution, [request a DataJoint Platform account](https://www.datajoint.com/sign-up).
 
-A DataJoint pipeline integrates three core components:
+## Project Structure
 
-![DataJoint Platform Architecture](../images/dj-platform.png)
-
-**Core components:**
-
-- **Code Repository** — Version-controlled pipeline definitions, analysis code, configuration
-- **Relational Database** — Metadata store, system of record, integrity enforcement
-- **Object Store** — Scalable storage for large scientific data (images, recordings, videos)
-
-## Pipeline as a DAG
-
-A DataJoint pipeline forms a **Directed Acyclic Graph (DAG)** at two levels:
-
-![Pipeline DAG Structure](../images/pipeline-illustration.png)
-
-**Nodes** represent Python modules, which correspond to database schemas.
-
-**Edges** represent:
-
-- Python import dependencies between modules
-- Bundles of foreign key references between schemas
-
-This dual structure ensures that both code dependencies and data dependencies flow in the same direction.
-
-## Schema Organization
-
-Each schema corresponds to a dedicated Python module:
-
-![Schema Structure](../images/schema-illustration.png)
-
-### One Module Per Schema
+Use a modern Python project layout with source code under `src/`:
 
 ```
 my_pipeline/
-├── __init__.py
-├── subject.py          # subject schema
-├── session.py          # session schema
-├── ephys.py            # ephys schema
-├── imaging.py          # imaging schema
-├── analysis.py         # analysis schema
-└── utils/
-    └── __init__.py
+├── datajoint.json          # Shared settings (committed)
+├── .secrets/               # Local credentials (gitignored)
+│   ├── database.password
+│   └── storage.credentials
+├── .gitignore
+├── pyproject.toml          # Package metadata and dependencies
+├── README.md
+├── src/
+│   └── my_pipeline/
+│       ├── __init__.py
+│       ├── subject.py      # subject schema
+│       ├── session.py      # session schema
+│       ├── ephys.py        # ephys schema
+│       ├── imaging.py      # imaging schema
+│       ├── analysis.py     # analysis schema
+│       └── utils/
+│           └── __init__.py
+├── tests/
+│   ├── conftest.py
+│   └── test_ephys.py
+└── docs/
+    └── ...
 ```
+
+### One Module Per Schema
 
 Each module defines and binds to its schema:
 
 ```python
-# my_pipeline/ephys.py
+# src/my_pipeline/ephys.py
 import datajoint as dj
 from . import session  # Import dependency
 
@@ -9654,30 +14543,11 @@ class MultiModalAnalysis(dj.Computed):
     """
 ```
 
-### DAG Constraints
-
-> **All foreign key relationships within a schema MUST form a DAG.**
->
-> **Dependencies between schemas (foreign keys + imports) MUST also form a DAG.**
-
-This ensures unidirectional flow of data and computational dependencies throughout the pipeline.
-
 ## Repository Configuration
 
 ### Shared Settings
 
-Store non-secret configuration in the repository:
-
-```
-my_pipeline/
-├── datajoint.json        # Shared settings (commit this)
-├── .secrets/             # Local secrets (gitignore)
-│   ├── database.password
-│   └── object_storage.secret_key
-├── .gitignore
-└── src/
-    └── my_pipeline/
-```
+Store non-secret configuration in `datajoint.json` at the project root:
 
 **datajoint.json** (committed):
 ```json
@@ -9686,37 +14556,77 @@ my_pipeline/
     "host": "db.example.com",
     "port": 3306
   },
-  "object_storage": {
-    "project_name": "my_lab_pipeline",
-    "protocol": "s3",
-    "endpoint": "s3.example.com",
-    "bucket": "my-lab-data",
-    "location": "datajoint"
+  "stores": {
+    "main": {
+      "protocol": "s3",
+      "endpoint": "s3.example.com",
+      "bucket": "my-org-data",
+      "location": "my_pipeline"
+    }
   }
 }
 ```
 
-**.gitignore**:
+### Credentials Management
+
+Credentials are stored locally and never committed:
+
+**Option 1: `.secrets/` directory**
 ```
 .secrets/
-*.pyc
-__pycache__/
+├── database.user
+├── database.password
+├── storage.access_key
+└── storage.secret_key
 ```
 
-### User-Specific Credentials
-
-Each team member provides their own credentials:
-
+**Option 2: Environment variables**
 ```bash
-# Set via environment
 export DJ_USER=alice
 export DJ_PASS=alice_password
-export DJ_OBJECT_STORAGE_ACCESS_KEY=alice_key
-export DJ_OBJECT_STORAGE_SECRET_KEY=alice_secret
+export DJ_STORES__MAIN__ACCESS_KEY=...
+export DJ_STORES__MAIN__SECRET_KEY=...
+```
 
-# Or via .secrets/ directory
-echo "alice" > .secrets/database.user
-echo "alice_password" > .secrets/database.password
+### Essential `.gitignore`
+
+```gitignore
+# Credentials
+.secrets/
+
+# Python
+__pycache__/
+*.pyc
+*.egg-info/
+dist/
+build/
+
+# Environment
+.env
+.venv/
+
+# IDE
+.idea/
+.vscode/
+```
+
+### `pyproject.toml` Example
+
+```toml
+[project]
+name = "my-pipeline"
+version = "1.0.0"
+requires-python = ">=3.10"
+dependencies = [
+    "datajoint>=2.0",
+    "numpy",
+]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-cov"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
 ```
 
 ## Database Access Control
@@ -9826,7 +14736,7 @@ A DataJoint project creates a structured storage pattern:
 Initialize schemas in dependency order:
 
 ```python
-# my_pipeline/__init__.py
+# src/my_pipeline/__init__.py
 from . import subject   # No dependencies
 from . import session   # Depends on subject
 from . import ephys     # Depends on session
@@ -9849,7 +14759,7 @@ def initialize():
 Track schema versions with your code:
 
 ```python
-# my_pipeline/version.py
+# src/my_pipeline/version.py
 __version__ = "1.2.0"
 
 SCHEMA_VERSIONS = {
@@ -9906,278 +14816,2406 @@ These challenges grow with team size and pipeline complexity. The [DataJoint Pla
 
 ## See Also
 
+- [Data Pipelines](../explanation/data-pipelines.md) — Conceptual overview and architecture
 - [Configure Object Storage](configure-storage.md) — Storage setup
 - [Distributed Computing](distributed-computing.md) — Multi-worker pipelines
-- [Model Relationships](model-relationships.md) — Foreign key patterns
+- [Model Relationships](model-relationships.ipynb) — Foreign key patterns
 
 
 ---
-## File: how-to/migrate-from-0x.md
+## File: how-to/migrate-to-v20.md
 
-# Migrate from 0.x
+# Migrate to DataJoint 2.0
 
-Upgrade existing pipelines from DataJoint 0.x to DataJoint 2.0.
+Upgrade existing pipelines from legacy DataJoint (pre-2.0) to DataJoint 2.0.
 
-DataJoint jumped from version 0.14 directly to 2.0 to communicate the significance of this release. See [What's New in DataJoint 2.0](../explanation/whats-new-2.md) for a summary of major features.
+> **This guide is optimized for AI coding assistants.** Point your AI agent at this
+> document and it will execute the migration with your oversight.
 
-## Configuration Changes
+## Requirements
 
-### Config File
+### System Requirements
 
-Replace `dj_local_conf.json` with `datajoint.json`:
+| Component | Legacy (pre-2.0) | DataJoint 2.0 |
+|-----------|-----------------|---------------|
+| **Python** | 3.8+ | **3.10+** |
+| **MySQL** | 5.7+ | **8.0+** |
+| **Character encoding** | (varies) | **UTF-8 (utf8mb4)** |
+| **Collation** | (varies) | **utf8mb4_bin** |
 
+**Action required:** Upgrade your Python environment and MySQL server before installing DataJoint 2.0.
+
+**Character encoding and collation:** DataJoint 2.0 standardizes on UTF-8 encoding with binary collation (case-sensitive comparisons). This is configured **server-wide** and is assumed by DataJoint:
+
+- **MySQL:** `utf8mb4` character set with `utf8mb4_bin` collation
+- **PostgreSQL (future):** `UTF8` encoding with `C` collation
+
+Like timezone handling, encoding is infrastructure configuration, not part of the data model. Ensure your MySQL server is configured with these defaults before migration.
+
+### License Change
+
+DataJoint 2.0 is licensed under **Apache 2.0** (previously LGPL-2.1).
+
+- More permissive for commercial and academic use
+- Compatible with broader ecosystem of tools
+- Clearer patent grant provisions
+
+No action required—the new license is more permissive.
+
+### Future Backend Support
+
+DataJoint 2.0 introduces portable type aliases (`uint32`, `float64`, etc.) that prepare the codebase for **PostgreSQL backend compatibility** in a future release. Migration to core types ensures your schemas will work seamlessly when Postgres support is available.
+
+### Before You Start: Testing Recommendation
+
+**⚡ Want AI agents to automate Phases I-II for you?**
+
+Create unit and integration tests for your pipeline against a QA database before
+starting migration. This enables AI agents to perform most migration work
+automatically, reducing manual effort by 50-80%.
+
+→ **See [Recommendation: Create Tests Before Migration](#recommendation-create-tests-before-migration)** for details.
+
+**Why this matters:**
+
+- **With tests:** Agents migrate code → run tests → fix failures → verify automatically
+- **Without tests:** Manual verification at every step, higher risk, more time
+
+Tests provide immediate ROI during migration and ongoing value for development.
+
+---
+
+## What's New in 2.0
+
+### 3-Tier Column Type System
+
+DataJoint 2.0 introduces a unified type system with three tiers:
+
+| Tier | Description | Examples | Migration |
+|------|-------------|----------|-----------|
+| **Native** | Raw MySQL types | `int unsigned`, `tinyint` | Auto-converted to core types |
+| **Core** | Standardized portable types | `uint32`, `float64`, `varchar(100)`, `json` | Phase I |
+| **Codec** | Serialization to blob or storage | `<blob>`, `<blob@store>`, `<npy@>` | Phase I-III |
+
+**Learn more:** [Type System Concept](../explanation/type-system.md) · [Type System Reference](../reference/specs/type-system.md)
+
+### Codecs
+
+DataJoint 2.0 makes serialization **explicit** with codecs. In pre-2.0, `longblob` automatically serialized Python objects; in 2.0, you explicitly choose `<blob>`.
+
+#### Migration: Legacy → 2.0
+
+| pre-2.0 (Implicit) | 2.0 (Explicit) | Storage | Migration |
+|-------------------|----------------|---------|-----------|
+| `longblob` | `<blob>` | In-table | Phase I code, Phase III data |
+| `mediumblob` | `<blob>` | In-table | Phase I code, Phase III data |
+| `attach` | `<attach>` | In-table | Phase I code, Phase III data |
+| `blob@store` | `<blob@store>` | In-store (hash) | Phase I code, Phase III data |
+| `attach@store` | `<attach@store>` | In-store (hash) | Phase I code, Phase III data |
+| `filepath@store` | `<filepath@store>` | In-store (filepath) | Phase I code, Phase III data |
+
+#### New in 2.0: Schema-Addressed Storage
+
+These codecs are NEW—there's no legacy equivalent to migrate:
+
+| Codec | Description | Storage | Adoption |
+|-------|-------------|---------|----------|
+| `<npy@store>` | NumPy arrays with lazy loading | In-store (schema) | Phase IV (optional) |
+| `<object@store>` | Zarr, HDF5, custom formats | In-store (schema) | Phase IV (optional) |
+
+**Key principles:**
+
+- All **legacy codec** conversions happen in Phase I (code) and Phase III (data)
+- **New codecs** (`<npy@>`, `<object@>`) are adopted in Phase IV for new features or enhanced workflows
+- Schema-addressed storage organizes data by table structure—no migration needed, just new functionality
+
+**Learn more:** [Codec API Reference](../reference/specs/codec-api.md) · [Custom Codecs](../explanation/custom-codecs.md)
+
+### Unified Stores Configuration
+
+DataJoint 2.0 replaces `external.*` with unified `stores.*` configuration:
+
+**pre-2.0 (legacy):**
 ```json
 {
-  "database": {
-    "host": "localhost",
-    "user": "datajoint",
-    "port": 3306
-  },
-  "object_storage": {
-    "project_name": "my_project",
+  "external": {
     "protocol": "file",
-    "location": "/data/store"
+    "location": "/data/external"
   }
 }
 ```
 
-### Secrets
-
-Move credentials to `.secrets/` directory:
-
+**2.0 (unified stores):**
+```json
+{
+  "stores": {
+    "default": "main",
+    "main": {
+      "protocol": "file",
+      "location": "/data/stores"
+    }
+  }
+}
 ```
-.secrets/
-├── database.password
-├── object_storage.access_key
-└── object_storage.secret_key
-```
 
-### Environment Variables
+**Learn more:** [Configuration Reference](../reference/configuration.md) · [Configure Object Storage](configure-storage.md)
 
-New prefix pattern:
+### Query API Changes
 
-| 0.x | 2.0 |
-|-----|-----|
-| `DJ_HOST` | `DJ_HOST` (unchanged) |
-| `DJ_USER` | `DJ_USER` (unchanged) |
-| `DJ_PASS` | `DJ_PASS` (unchanged) |
-| — | `DJ_OBJECT_STORAGE_*` |
-| — | `DJ_JOBS_*` |
+| pre-2.0 | 2.0 | Phase |
+|--------|-----|-------|
+| `table.fetch()` | `table.to_arrays()` or `table.to_dicts()` | I |
+| `table.fetch(..., format="frame")` | `table.to_pandas(...)` | I |
+| `table.fetch1()` | `table.fetch1()` (unchanged) | — |
+| `table.fetch1('KEY')` | `table.keys()` | I |
+| `(table & key)._update('attr', val)` | `table.update1({**key, 'attr': val})` | I |
+| `table1 @ table2` | `table1 * table2` (natural join with semantic checks) | I |
+| `a.join(b, left=True)` | Consider `a.extend(b)` | I |
+| `dj.U('attr') & table` | Unchanged (correct pattern) | — |
+| `dj.U('attr') * table` | `table` (was a hack to change primary key) | I |
+| `dj.ERD(schema)` | `dj.Diagram(schema)` | I |
+| `table.insert([(1, 'a'), (2, 'b')])` | Must use dicts/DataFrames (no positional tuples) | I |
 
-## Type System Changes
+**Learn more:** [Fetch API Reference](../reference/specs/fetch-api.md) · [Query Operators Reference](../reference/operators.md) · [Semantic Matching](../reference/specs/semantic-matching.md)
 
-### Blob Types
+---
 
-Update blob syntax:
+## Migration Overview
+
+| Phase | Goal | Code Changes | Schema/Store Changes | Production Impact |
+|-------|------|--------------|----------------------|-------------------|
+| **I** | Branch & code migration | All API updates, type syntax, **all codecs** (in-table and in-store) | Empty `_v2` schemas + test stores | **None** |
+| **II** | Test compatibility | — | Populate `_v2` schemas with sample data, test equivalence | **None** |
+| **III** | Migrate production data | — | Multiple migration options | **Varies** |
+| **IV** | Adopt new features | Optional enhancements | Optional | Running on 2.0 |
+
+**Key principles:**
+
+- Phase I implements ALL code changes including in-store codecs (using test stores)
+- Production runs on pre-2.0 undisturbed through Phase II
+- Phase III is data migration only—the code is already complete
+
+**Timeline:**
+
+- **Phase I:** ~1-4 hours (with AI assistance)
+- **Phase II:** ~1-2 days
+- **Phase III:** ~1-7 days (depends on data size and option chosen)
+- **Phase IV:** Ongoing feature adoption
+
+---
+
+## Recommendation: Create Tests Before Migration
+
+**Highly recommended for automated, agent-driven migration.**
+
+If you create unit and integration tests for your pipeline before starting
+Phase I, AI coding agents can perform most of the migration work automatically,
+substantially reducing manual effort.
+
+### Why Tests Enable Automated Migration
+
+**With tests:**
+
+1. **Phase I automation** - Agent can:
+   - Migrate code to 2.0 API
+   - Run tests to verify correctness
+   - Fix failures iteratively
+   - Complete migration with high confidence
+
+2. **Phase II automation** - Agent can:
+   - Populate `_v2` schemas with test data
+   - Run tests against both legacy and v2 pipelines
+   - Verify equivalence automatically
+   - Generate validation reports
+
+3. **Phase III guidance** - Agent can:
+   - Run tests after data migration
+   - Catch issues immediately
+   - Guide production cutover with confidence
+
+**Without tests:**
+
+- Manual verification at each step
+- Higher risk of missed issues
+- More time-intensive validation
+- Uncertainty about correctness
+
+### What Tests to Create
+
+Create tests against a **QA database and object store** (separate from
+production):
+
+**Unit tests:**
+
+- Table definitions compile correctly
+- Schema relationships are valid
+- Populate methods work for individual tables
+- Query patterns return expected results
+
+**Integration tests:**
+
+- End-to-end pipeline execution
+- Data flows through computed tables correctly
+- External file references work (if using `<filepath@>`)
+- Object storage operations work (if using in-store codecs)
+
+**Example test structure:**
 
 ```python
-# 0.x syntax
-definition = """
-data : longblob
-data_external : blob@store
-"""
+# tests/test_tables.py
+import pytest
+import datajoint as dj
+from my_pipeline import Mouse, Session, Neuron
 
-# 2.0 syntax
-definition = """
-data : <blob>
-data_external : <blob@store>
-"""
+@pytest.fixture
+def test_schema():
+    """Use QA database for testing."""
+    dj.config['database.host'] = 'qa-db.example.com'
+    schema = dj.schema('test_pipeline')
+    yield schema
+    schema.drop()  # Cleanup after test
+
+def test_mouse_insert(test_schema):
+    """Test manual table insertion."""
+    Mouse.insert1({'mouse_id': 0, 'dob': '2024-01-01', 'sex': 'M'})
+    assert len(Mouse()) == 1
+
+def test_session_populate(test_schema):
+    """Test session insertion and relationships."""
+    Mouse.insert1({'mouse_id': 0, 'dob': '2024-01-01', 'sex': 'M'})
+    Session.insert1({
+        'mouse_id': 0,
+        'session_date': '2024-06-01',
+        'experimenter': 'Alice'
+    })
+    assert len(Session() & 'mouse_id=0') == 1
+
+def test_neuron_computation(test_schema):
+    """Test computed table populate."""
+    # Insert upstream data
+    Mouse.insert1({'mouse_id': 0, 'dob': '2024-01-01', 'sex': 'M'})
+    Session.insert1({
+        'mouse_id': 0,
+        'session_date': '2024-06-01',
+        'experimenter': 'Alice'
+    })
+
+    # Populate computed table
+    Neuron.populate()
+
+    # Verify results
+    assert len(Neuron()) > 0
+
+def test_query_patterns(test_schema):
+    """Test common query patterns."""
+    # Setup data
+    Mouse.insert1({'mouse_id': 0, 'dob': '2024-01-01', 'sex': 'M'})
+
+    # Test fetch
+    mice = Mouse.fetch(as_dict=True)
+    assert len(mice) == 1
+
+    # Test restriction
+    male_mice = Mouse & 'sex="M"'
+    assert len(male_mice) == 1
 ```
 
-### Attach Types
+**Integration test example:**
 
 ```python
-# 0.x
-attachment : attach
+# tests/test_pipeline.py
+def test_full_pipeline(test_schema):
+    """Test complete pipeline execution."""
+    # 1. Insert manual data
+    Mouse.insert([
+        {'mouse_id': 0, 'dob': '2024-01-01', 'sex': 'M'},
+        {'mouse_id': 1, 'dob': '2024-01-15', 'sex': 'F'},
+    ])
 
-# 2.0
-attachment : <attach>
-attachment_ext : <attach@store>
+    Session.insert([
+        {'mouse_id': 0, 'session_date': '2024-06-01', 'experimenter': 'Alice'},
+        {'mouse_id': 1, 'session_date': '2024-06-03', 'experimenter': 'Bob'},
+    ])
+
+    # 2. Populate computed tables
+    Neuron.populate()
+    Analysis.populate()
+
+    # 3. Verify data flows correctly
+    assert len(Mouse()) == 2
+    assert len(Session()) == 2
+    assert len(Neuron()) > 0
+    assert len(Analysis()) > 0
+
+    # 4. Test queries work
+    alice_sessions = Session & 'experimenter="Alice"'
+    assert len(alice_sessions) == 1
 ```
 
-### Filepath Types
+### How to Use Tests with AI Agents
 
-```python
-# 0.x (copy-based)
-file : filepath@store
-
-# 2.0 (ObjectRef-based)
-file : <filepath@store>
-```
-
-## Jobs System Changes
-
-### Per-Table Jobs
-
-Jobs are now per-table instead of per-schema:
-
-```python
-# 0.x: schema-level ~jobs table
-schema.jobs
-
-# 2.0: per-table ~~table_name
-MyTable.jobs
-MyTable.jobs.pending
-MyTable.jobs.errors
-```
-
-### Jobs Configuration
-
-```python
-# 2.0 job settings
-dj.config.jobs.auto_refresh = True
-dj.config.jobs.keep_completed = True
-dj.config.jobs.stale_timeout = 3600
-dj.config.jobs.version_method = "git"
-```
-
-## Query Changes
-
-### Universal Set
-
-```python
-# 0.x
-dj.U() * expression
-
-# 2.0
-dj.U() & expression
-```
-
-### Natural Join
-
-```python
-# 0.x: @ operator for natural join
-A @ B
-
-# 2.0: explicit method
-A.join(B, semantic_check=False)
-```
-
-### Semantic Matching
-
-2.0 uses lineage-based matching by default:
-
-```python
-# Attributes matched by lineage, not just name
-result = A * B  # Semantic join (default)
-
-# Force name-only matching
-result = A.join(B, semantic_check=False)
-```
-
-## Migration Steps
-
-### 1. Update Configuration
+Once tests are created, an AI agent can:
 
 ```bash
-# Move config file
-mv dj_local_conf.json datajoint.json
+# Agent workflow for Phase I
+1. git checkout -b pre/v2.0
+2. Update schema declarations to _v2
+3. Convert table definitions to 2.0 syntax
+4. Convert API calls (fetch → to_dicts, etc.)
+5. Run: pytest tests/
+6. Fix any failures iteratively
+7. Repeat 5-6 until all tests pass
+8. Phase I complete automatically!
 
-# Create secrets directory
-mkdir .secrets
-echo "password" > .secrets/database.password
-chmod 600 .secrets/database.password
+# Agent workflow for Phase II
+1. Populate _v2 schemas with test data
+2. Run tests against _v2 schemas
+3. Compare with legacy results
+4. Generate validation report
+5. Phase II complete automatically!
 ```
 
-### 2. Update Table Definitions
+### Investment vs. Return
 
-Run migration analysis:
+**Time investment:**
+
+- Creating tests: ~1-3 days
+- QA database setup: ~1-2 hours
+
+**Time saved:**
+
+- Phase I: ~50-75% reduction (mostly automated)
+- Phase II: ~80% reduction (fully automated validation)
+- Phase III: Higher confidence, faster debugging
+
+**Net benefit:** Tests pay for themselves during migration and provide ongoing
+value for future development.
+
+### When to Skip Tests
+
+Skip test creation if:
+
+- Pipeline is very simple (few tables, no computation)
+- One-time migration with no ongoing development
+- Team has extensive manual testing procedures already
+- Time pressure requires starting migration immediately
+
+**Note:** Even minimal tests (just table insertion and populate) provide
+significant value for automated migration.
+
+---
+
+## Phase I: Branch and Code Migration
+
+**Goal:** Implement complete 2.0 API in code using test schemas and test stores.
+
+**End state:**
+
+- All Python code uses 2.0 API patterns (fetch, types, codecs)
+- All codecs implemented (in-table `<blob>`, `<attach>` AND in-store `<blob@>`, legacy only)
+- Code points to `schema_v2` databases (empty) and test object stores
+- Production continues on main branch with pre-2.0 undisturbed
+
+**What's NOT migrated yet:** Production data and production stores (Phase III)
+
+### Step 1: Pin Legacy DataJoint on Main Branch
+
+Ensure production code stays on pre-2.0:
+
+```bash
+git checkout main
+
+# Pin legacy version in requirements
+echo "datajoint<2.0.0" > requirements.txt
+
+git add requirements.txt
+git commit -m "chore: pin legacy datajoint for production"
+git push origin main
+```
+
+**Why:** This prevents accidental upgrades to 2.0 in production.
+
+### Step 2: Create Migration Branch
+
+```bash
+# Create feature branch
+git checkout -b pre/v2.0
+
+# Install DataJoint 2.0
+pip install --upgrade pip
+pip install "datajoint>=2.0.0"
+
+# Update requirements
+echo "datajoint>=2.0.0" > requirements.txt
+
+git add requirements.txt
+git commit -m "chore: upgrade to datajoint 2.0"
+```
+
+### Step 3: Update Schema Declarations
+
+**Critical early step:** Update all `dj.schema()` calls to use `_v2` suffix
+for parallel testing and validation.
+
+**Why do this first:**
+
+- Creates parallel schemas alongside production (e.g., `my_pipeline_v2`)
+- Allows testing 2.0 code without affecting production schemas
+- Enables side-by-side validation in Phase II
+- Production schemas remain untouched on `main` branch
+
+#### Find All Schema Declarations
+
+```bash
+# Find all schema() calls in your codebase
+grep -rn "dj.schema\|dj.Schema" --include="*.py" .
+
+# Example output:
+# pipeline/session.py:5:schema = dj.schema('my_pipeline')
+# pipeline/analysis.py:8:schema = dj.schema('my_pipeline')
+# pipeline/ephys.py:3:schema = dj.schema('ephys_pipeline')
+```
+
+#### Update Schema Names
+
+**For each schema declaration, add `_v2` suffix:**
 
 ```python
-from datajoint.migrate import analyze_blob_columns
+# BEFORE (production, on main branch)
+schema = dj.schema('my_pipeline')
 
-# Find columns needing migration
-results = analyze_blob_columns(schema)
-for table, columns in results:
-    print(f"{table}: {columns}")
+# AFTER (testing, on pre/v2.0 branch)
+schema = dj.schema('my_pipeline_v2')
 ```
 
-Update definitions:
+**Multiple schemas example:**
 
 ```python
-# Old
-data : longblob
+# BEFORE
+session_schema = dj.schema('sessions')
+analysis_schema = dj.schema('analysis')
+ephys_schema = dj.schema('ephys')
 
-# New
-data : <blob>
+# AFTER
+session_schema = dj.schema('sessions_v2')
+analysis_schema = dj.schema('analysis_v2')
+ephys_schema = dj.schema('ephys_v2')
 ```
 
-### 3. Update Blob Column Metadata
+#### AI Agent Prompt: Update Schema Declarations
 
-Add codec markers to existing columns:
+---
+
+**🤖 AI Agent Prompt: Phase I - Update Schema Declarations with _v2
+Suffix**
+
+```
+You are updating DataJoint schema declarations for 2.0 migration testing.
+
+TASK: Add _v2 suffix to all dj.schema() calls for parallel testing.
+
+CONTEXT:
+- Branch: pre/v2.0 (just created)
+- Production schemas on main branch remain unchanged
+- _v2 schemas will be empty until table definitions are converted
+- This enables side-by-side testing without affecting production
+
+STEPS:
+
+1. Find all schema declarations:
+   grep -rn "dj.schema\|dj.Schema" --include="*.py" .
+
+2. For EACH schema declaration, add _v2 suffix:
+   OLD: schema = dj.schema('my_pipeline')
+   NEW: schema = dj.schema('my_pipeline_v2')
+
+3. Preserve all other arguments:
+   OLD: schema = dj.schema('sessions', locals())
+   NEW: schema = dj.schema('sessions_v2', locals())
+
+   OLD: schema = dj.schema('analysis', create_schema=True)
+   NEW: schema = dj.schema('analysis_v2', create_schema=True)
+
+4. Update any string references to schema names:
+   OLD: conn.query("USE my_pipeline")
+   NEW: conn.query("USE my_pipeline_v2")
+
+   OLD: if schema_name == 'my_pipeline':
+   NEW: if schema_name == 'my_pipeline_v2':
+
+NAMING CONVENTION:
+
+- my_pipeline → my_pipeline_v2
+- sessions → sessions_v2
+- ephys_pipeline → ephys_pipeline_v2
+- lab.mouse → lab.mouse_v2
+
+VERIFICATION:
+
+After updating, verify:
+- All dj.schema() calls have _v2 suffix
+- No hard-coded schema names without _v2 suffix
+- No duplicate schema names (each should be unique)
+
+COMMIT:
+
+git add -A
+git commit -m "feat(phase-i): add _v2 suffix to all schema declarations
+
+- Update all dj.schema() calls to use _v2 suffix
+- Enables parallel testing without affecting production schemas
+- Production schemas on main branch remain unchanged
+
+Schemas updated:
+- my_pipeline → my_pipeline_v2
+- [list other schemas...]"
+```
+
+---
+
+#### Verify Schema Name Changes
 
 ```python
-from datajoint.migrate import migrate_blob_columns
+import datajoint as dj
 
-# Dry run
-migrate_blob_columns(schema, dry_run=True)
+# Test connection (should work before any tables created)
+conn = dj.conn()
+print("✓ Connected to database")
 
-# Apply
-migrate_blob_columns(schema, dry_run=False)
+# At this point, _v2 schemas don't exist yet
+# They will be created in Step 5 when table definitions are applied
 ```
 
-### 4. Update Jobs Code
+#### Commit Schema Declaration Changes
+
+```bash
+git add -A
+git commit -m "feat(phase-i): add _v2 suffix to all schema declarations
+
+- Update all dj.schema() calls to use _v2 suffix
+- Enables parallel testing without affecting production schemas
+- Next: configure stores and convert table definitions"
+```
+
+**Next steps:**
+
+- Step 4: Configure object stores (if applicable)
+- Step 5: Convert table definitions to 2.0 syntax
+- When table definitions are applied, `_v2` schemas will be created
+
+### Step 4: Configure DataJoint 2.0
+
+Create new configuration files for 2.0.
+
+**Note:** Schema declarations already updated in Step 3 with `_v2` suffix.
+Now configure database connection and stores.
+
+#### Background: Configuration Changes
+
+DataJoint 2.0 uses:
+
+- **`.secrets/datajoint.json`** for credentials (gitignored)
+- **`datajoint.json`** for non-sensitive settings (checked in)
+- **`stores.*`** instead of `external.*`
+
+**Learn more:** [Configuration Reference](../reference/configuration.md)
+
+#### Create Configuration Files
+
+```bash
+# Create .secrets directory
+mkdir -p .secrets
+echo ".secrets/" >> .gitignore
+
+# Create template
+python -c "import datajoint as dj; dj.config.save_template()"
+```
+
+**Edit `.secrets/datajoint.json`:**
+```json
+{
+  "database.host": "your-database-host",
+  "database.user": "your-username",
+  "database.password": "your-password"
+}
+```
+
+**Edit `datajoint.json`:**
+```json
+{
+  "loglevel": "INFO",
+  "safemode": true,
+  "display.limit": 12,
+  "display.width": 100,
+  "display.show_tuple_count": true
+}
+```
+
+#### Verify Connection
 
 ```python
-# Old
-schema.jobs
+import datajoint as dj
 
-# New
-for table in [Table1, Table2, Table3]:
-    print(f"{table.__name__}: {table.jobs.progress()}")
+# Test connection
+conn = dj.conn()
+print(f"Connected to {conn.conn_info['host']}")
 ```
 
-### 5. Update Queries
+### Step 5: Configure Test Object Stores (If Applicable)
 
-Search for deprecated patterns:
+**Skip this step if:** Your legacy pipeline uses only in-table storage (`longblob`, `mediumblob`, `blob`, `attach`). You can skip to Step 6.
+
+**Configure test stores if:** Your legacy pipeline uses pre-2.0 in-store formats:
+
+- `blob@store` (hash-addressed blobs in object store)
+- `attach@store` (hash-addressed attachments in object store)
+- `filepath@store` (filepath references to external files)
+
+**Note:** `<npy@>` and `<object@>` are NEW in 2.0 (schema-addressed storage). They have no legacy equivalent and don't need migration. Adopt them in Phase IV for new features.
+
+#### Background: pre-2.0 Implicit vs 2.0 Explicit Codecs
+
+**pre-2.0 implicit serialization:**
+
+- `longblob` → automatic Python object serialization (pickle)
+- `mediumblob` → automatic Python object serialization (pickle)
+- `blob` → automatic Python object serialization (pickle)
+- No explicit codec choice - serialization was built-in
+
+**2.0 explicit codecs:**
+
+- `<blob>` → explicit Python object serialization (same behavior, now explicit)
+- `<attach>` → explicit file attachment (was separate feature)
+- Legacy in-store formats converted to explicit `<blob@>`, `<attach@>`, `<filepath@>` syntax
+
+#### Background: Unified Stores
+
+2.0 uses **unified stores** configuration:
+
+- Single `stores.*` config for all storage types (hash-addressed + schema-addressed + filepath)
+- Named stores with `default` pointer
+- Supports multiple stores with different backends
+
+**Learn more:** [Configure Object Storage](configure-storage.md) · [Object Store Configuration Spec](../reference/specs/object-store-configuration.md)
+
+#### Configure Test Stores
+
+**Edit `datajoint.json` to use test directories:**
+```json
+{
+  "stores": {
+    "default": "main",
+    "main": {
+      "protocol": "file",
+      "location": "/data/v2_test_stores/main"
+    }
+  }
+}
+```
+
+**Note:** Use separate test locations (e.g., `/data/v2_test_stores/`) to avoid conflicts with production stores.
+
+**For multiple test stores:**
+```json
+{
+  "stores": {
+    "default": "main",
+    "filepath_default": "raw_data",
+    "main": {
+      "protocol": "file",
+      "location": "/data/v2_test_stores/main"
+    },
+    "raw_data": {
+      "protocol": "file",
+      "location": "/data/v2_test_stores/raw"
+    }
+  }
+}
+```
+
+**For cloud storage (using test bucket/prefix):**
+```json
+{
+  "stores": {
+    "default": "s3_store",
+    "s3_store": {
+      "protocol": "s3",
+      "endpoint": "s3.amazonaws.com",
+      "bucket": "my-datajoint-test-bucket",
+      "location": "v2-test"
+    }
+  }
+}
+```
+
+**Store credentials in `.secrets/stores.s3_store.access_key` and
+`.secrets/stores.s3_store.secret_key`:**
+```bash
+echo "YOUR_ACCESS_KEY" > .secrets/stores.s3_store.access_key
+echo "YOUR_SECRET_KEY" > .secrets/stores.s3_store.secret_key
+```
+
+#### AI Agent Prompt: Configure and Test Stores
+
+---
+
+**🤖 AI Agent Prompt: Phase I - Configure Test Stores and Verify Codecs**
+
+```
+You are configuring test object stores for DataJoint 2.0 migration.
+
+TASK: Set up test stores and verify all in-store codecs work correctly
+before migrating production data.
+
+CONTEXT:
+- Phase I uses TEST stores (separate from production)
+- Testing verifies codecs work with legacy schema structure
+- File organization must match expectations
+- Production data migration happens in Phase III
+
+STEPS:
+
+1. Configure test stores in datajoint.json:
+   - Use test locations (e.g., /data/v2_test_stores/)
+   - For cloud: use test bucket or prefix (e.g., "v2-test")
+   - Configure hash_prefix, schema_prefix, filepath_prefix if needed
+
+2. Store credentials in .secrets/ directory:
+   - Create .secrets/stores.<name>.access_key (S3/GCS/Azure)
+   - Create .secrets/stores.<name>.secret_key (S3)
+   - Verify .secrets/ is gitignored
+
+3. Test ALL in-store codecs from legacy schema:
+   - <blob@store> (hash-addressed blob storage)
+   - <attach@store> (hash-addressed attachments)
+   - <filepath@store> (filepath references)
+
+4. Create test table with all three codecs:
+   ```python
+   @schema
+   class StoreTest(dj.Manual):
+       definition = """
+       test_id : int
+       ---
+       blob_data : <blob@>
+       attach_data : <attach@>
+       filepath_data : <filepath@>
+       """
+   ```
+
+5. Insert test data and verify:
+   - Insert sample data for each codec
+   - Fetch data back successfully
+   - Verify files appear at expected paths
+
+6. Understand hash-addressed storage structure:
+   {location}/{hash_prefix}/{schema_name}/{hash}[.ext]
+
+   With subfolding [2, 2]:
+   {location}/{hash_prefix}/{schema_name}/{h1}{h2}/{h3}{h4}/{hash}[.ext]
+
+   Properties:
+   - Immutable (content-addressed)
+   - Deduplicated (same content → same path)
+   - Integrity (hash validates content)
+
+7. Verify file organization meets expectations:
+   - Check files exist at {location}/{hash_prefix}/{schema}/
+   - Verify subfolding structure if configured
+   - Confirm filepath references work correctly
+
+8. Clean up test:
+   - Delete test data
+   - Drop test schema
+   - Verify no errors during cleanup
+
+HASH-ADDRESSED STORAGE:
+
+Understanding the hash-addressed section is critical for migration:
+
+- Path format: {location}/{hash_prefix}/{schema}/{hash}
+- Hash computed from serialized content (Blake2b)
+- Hash encoded as base32 (lowercase, no padding)
+- Subfolding splits hash into directory levels
+- Same content always produces same path (deduplication)
+
+Example with hash_prefix="_hash", subfolding=[2,2]:
+  /data/store/_hash/my_schema/ab/cd/abcdef123456...
+
+Learn more: Object Store Configuration Spec
+(../reference/specs/object-store-configuration.md#hash-addressed-storage)
+
+VERIFICATION:
+
+- [ ] Test stores configured in datajoint.json
+- [ ] Credentials stored in .secrets/ (not committed)
+- [ ] Connection to test stores successful
+- [ ] <blob@> codec tested and working
+- [ ] <attach@> codec tested and working
+- [ ] <filepath@> codec tested and working
+- [ ] Files appear at expected locations
+- [ ] Hash-addressed structure understood
+- [ ] Test cleanup successful
+
+REPORT:
+
+Test results for store configuration:
+- Store names: [list configured stores]
+- Store protocol: [file/s3/gcs/azure]
+- Store location: [test path/bucket]
+- Hash prefix: [configured value]
+- Codecs tested: [blob@, attach@, filepath@]
+- Files verified at: [example paths]
+- Issues found: [any errors or unexpected behavior]
+
+COMMIT MESSAGE:
+"feat(phase-i): configure test stores and verify codecs
+
+- Configure test stores with [protocol] at [location]
+- Store credentials in .secrets/ directory
+- Test all in-store codecs: blob@, attach@, filepath@
+- Verify hash-addressed file organization
+- Confirm codecs work with legacy schema structure
+
+Test stores ready for table definition conversion."
+```
+
+---
+
+#### Test In-Store Codecs
+
+After configuring test stores, verify that in-store codecs work correctly
+and understand the file organization.
+
+**Create test table with all in-store codecs:**
 
 ```python
-# Find uses of @ operator
-grep -r " @ " *.py
+import datajoint as dj
+import numpy as np
 
-# Find dj.U() * pattern
-grep -r "dj.U() \*" *.py
+# Create test schema
+schema = dj.schema('test_stores_v2')
+
+@schema
+class StoreTest(dj.Manual):
+    definition = """
+    test_id : int
+    ---
+    blob_data : <blob@>          # Hash-addressed blob
+    attach_data : <attach@>      # Hash-addressed attachment
+    filepath_data : <filepath@>  # Filepath reference
+    """
+
+# Test data
+test_blob = {'key': 'value', 'array': [1, 2, 3]}
+test_attach = {'metadata': 'test attachment'}
+
+# For filepath, create test file first
+import tempfile
+import os
+temp_dir = tempfile.gettempdir()
+test_file_path = 'test_data/sample.txt'
+full_path = os.path.join(
+    dj.config['stores']['default']['location'],
+    test_file_path
+)
+os.makedirs(os.path.dirname(full_path), exist_ok=True)
+with open(full_path, 'w') as f:
+    f.write('test content')
+
+# Insert test data
+StoreTest.insert1({
+    'test_id': 1,
+    'blob_data': test_blob,
+    'attach_data': test_attach,
+    'filepath_data': test_file_path
+})
+
+print("✓ Test data inserted successfully")
 ```
 
-## Compatibility Notes
+**Verify file organization:**
 
-### Semantic Matching
+```python
+# Fetch and verify
+result = (StoreTest & {'test_id': 1}).fetch1()
+print(f"✓ blob_data: {result['blob_data']}")
+print(f"✓ attach_data: {result['attach_data']}")
+print(f"✓ filepath_data: {result['filepath_data']}")
 
-2.0's semantic matching may change join behavior if:
+# Inspect hash-addressed file organization
+store_spec = dj.config.get_store_spec()
+hash_prefix = store_spec.get('hash_prefix', '_hash')
+location = store_spec['location']
 
-- Tables have attributes with same name but different lineage
-- You relied on name-only matching
+print(f"\nStore organization:")
+print(f"  Location: {location}")
+print(f"  Hash prefix: {hash_prefix}/")
+print(f"  Expected structure: {hash_prefix}/{{schema}}/{{hash}}")
+print(f"\nVerify files exist at:")
+print(f"  {location}/{hash_prefix}/test_stores_v2/")
+```
 
-Test joins carefully after migration.
+**Review hash-addressed storage structure:**
 
-### External Storage
+Hash-addressed storage (`<blob@>`, `<attach@>`) uses content-based paths:
 
-Object storage paths changed. If using external storage:
-1. Keep 0.x stores accessible during migration
-2. Re-insert data to new storage format if needed
-3. Or configure stores to use existing paths
+```
+{location}/{hash_prefix}/{schema_name}/{hash}[.ext]
+```
 
-### Database Compatibility
+With subfolding enabled (e.g., `[2, 2]`):
 
-2.0 is compatible with MySQL 5.7+ and PostgreSQL 12+.
-No database migration required for core functionality.
+```
+{location}/{hash_prefix}/{schema_name}/{h1}{h2}/{h3}{h4}/{hash}[.ext]
+```
+
+**Properties:**
+
+- **Immutable**: Content defines path, cannot be changed
+- **Deduplicated**: Identical content stored once
+- **Integrity**: Hash validates content on retrieval
+
+**Learn more:** [Object Store Configuration — Hash-Addressed Storage]
+(../reference/specs/object-store-configuration.md#hash-addressed-storage)
+
+**Cleanup test:**
+
+```python
+# Remove test data
+(StoreTest & {'test_id': 1}).delete()
+schema.drop()
+print("✓ Test cleanup complete")
+```
+
+### Step 6: Convert Table Definitions
+
+Update table definitions in topological order (tables before their dependents).
+
+**Note:** Schema declarations already updated to `_v2` suffix in Step 3.
+
+#### Background: Type Syntax Changes
+
+Convert ALL types and codecs in Phase I:
+
+**Integer and Float Types:**
+
+| pre-2.0 | 2.0 | Category |
+|--------|-----|----------|
+| `int unsigned` | `uint32` | Core type |
+| `int` | `int32` | Core type |
+| `smallint unsigned` | `uint16` | Core type |
+| `tinyint unsigned` | `uint8` | Core type |
+| `bigint unsigned` | `uint64` | Core type |
+| `float` | `float32` | Core type |
+| `double` | `float64` | Core type |
+
+**String, Date, and Structured Types:**
+
+| pre-2.0 | 2.0 | Notes |
+|--------|-----|-------|
+| `varchar(N)`, `char(N)` | Unchanged | Core types |
+| `date` | Unchanged | Core type |
+| `enum('a', 'b')` | Unchanged | Core type |
+| `bool`, `boolean` | `bool` | Core type (MySQL stores as tinyint(1)) |
+| `datetime` | `datetime` | Core type; UTC standard in 2.0 |
+| `timestamp` | `datetime` | **Ask user:** Review timezone convention, convert to UTC datetime |
+| `json` | `json` | Core type (was available but underdocumented) |
+| `uuid` | `uuid` | Core type (widely used in legacy) |
+| `text` | `varchar(N)` or keep as native | **Native type:** Consider migrating to `varchar(n)` |
+| `time` | `datetime` or keep as native | **Native type:** Consider using `datetime` |
+| `tinyint(1)` | `bool` or `uint8` | **Ask user:** was this boolean or small integer? |
+
+**Codecs:**
+
+| pre-2.0 | 2.0 | Category |
+|--------|-----|----------|
+| `longblob` | `<blob>` | Codec (in-table) |
+| `attach` | `<attach>` | Codec (in-table) |
+| `blob@store` | `<blob@store>` | Codec (in-store) |
+| `attach@store` | `<attach@store>` | Codec (in-store) |
+| `filepath@store` | `<filepath@store>` | Codec (in-store) |
+
+**Important Notes:**
+
+- **Core vs Native Types:** DataJoint 2.0 distinguishes **core types** (portable, standardized) from **native types** (backend-specific). Core types are preferred. Native types like `text` and `time` are allowed but discouraged—they may generate warnings and lack portability guarantees.
+
+- **Datetime/Timestamp:** DataJoint 2.0 adopts **UTC as the standard for all datetime storage**. The database stores UTC; timezones are handled by application front-ends and client APIs. For `timestamp` columns, review your existing timezone convention—you may need data conversion. We recommend adopting UTC throughout your pipeline and converting `timestamp` to `datetime`.
+
+- **Bool:** Legacy DataJoint supported `bool` and `boolean` types (MySQL stores as `tinyint(1)`). Keep as `bool` in 2.0. Only explicit `tinyint(1)` declarations need review:
+  - If used for boolean semantics (yes/no, active/inactive) → `bool`
+  - If used for small integers (counts, indices 0-255) → `uint8`
+
+- **Text Type:** `text` is a native MySQL type, not a core type. Consider migrating to `varchar(n)` with appropriate length. If your text truly needs unlimited length, you can keep `text` as a native type (will generate a warning).
+
+- **Time Type:** `time` is a native MySQL type with no core equivalent. We recommend migrating to `datetime` (which can represent both date and time components). If you only need time-of-day without date, you can keep `time` as a native type (will generate a warning).
+
+- **JSON:** Core type that was available in pre-2.0 but underdocumented. Many users serialized JSON into blobs. If you have custom JSON serialization in blobs, you can migrate to native `json` type (optional).
+
+- **Enum:** Core type—no changes needed.
+
+- **In-store codecs:** Code is converted in Phase I using test stores. Production data migration happens in Phase III.
+
+**Learn more:** [Type System Reference](../reference/specs/type-system.md) · [Definition Syntax](../reference/definition-syntax.md)
+
+#### AI Agent Prompt: Convert Table Definitions
+
+Use this prompt with your AI coding assistant:
+
+---
+
+**🤖 AI Agent Prompt: Phase I - Table Definition Conversion**
+
+```
+You are converting DataJoint pre-2.0 table definitions to 2.0 syntax.
+
+TASK: Update all table definitions in this repository to DataJoint 2.0 type syntax.
+
+CONTEXT:
+
+- We are on branch: pre/v2.0
+- Production (main branch) remains on pre-2.0
+- Schema declarations ALREADY updated with _v2 suffix (Step 3)
+- Now converting table definitions to match
+- Schemas will be created empty when definitions are applied
+
+SCOPE - PHASE I:
+
+1. Convert ALL type syntax to 2.0 core types
+2. Convert ALL legacy codecs (in-table AND in-store)
+   - In-table: longblob → <blob>, mediumblob → <blob>, attach → <attach>
+   - In-store (legacy only): blob@store → <blob@store>, attach@store → <attach@store>, filepath@store → <filepath@store>
+3. Code will use TEST stores configured in datajoint.json
+4. Do NOT add new 2.0 codecs (<npy@>, <object@>) - these are for Phase IV adoption
+5. Production data migration happens in Phase III (code is complete after Phase I)
+
+TYPE CONVERSIONS:
+
+Core Types (Integer and Float):
+  int unsigned → uint32
+  int → int32
+  smallint unsigned → uint16
+  smallint → int16
+  tinyint unsigned → uint8
+  tinyint → int8
+  bigint unsigned → uint64
+  bigint → int64
+  float → float32
+  double → float64
+  decimal(M,D) → decimal(M,D)  # unchanged
+
+Core Types (String and Date):
+  varchar(N) → varchar(N)  # unchanged (core type)
+  char(N) → char(N)  # unchanged (core type)
+  date → date  # unchanged (core type)
+  enum('a', 'b') → enum('a', 'b')  # unchanged (core type)
+  bool → bool  # unchanged (core type, MySQL stores as tinyint(1))
+  boolean → bool  # unchanged (core type, MySQL stores as tinyint(1))
+  datetime → datetime  # unchanged (core type)
+
+Core Types (Structured Data):
+  json → json  # unchanged (core type, was available but underdocumented in pre-2.0)
+  uuid → uuid  # unchanged (core type, widely used in pre-2.0)
+
+Native Types (Discouraged but Allowed):
+  text → Consider varchar(N) with appropriate length, or keep as native type
+  time → Consider datetime (can represent date+time), or keep as native type
+
+Special Cases - REQUIRE USER REVIEW:
+
+  tinyint(1) → ASK USER: bool or uint8?
+    Note: Legacy DataJoint had bool/boolean types. Only explicit tinyint(1) needs review.
+    - Boolean semantics (yes/no, active/inactive) → bool
+    - Small integer (counts, indices 0-255) → uint8
+    Example:
+      is_active : tinyint(1)  # Boolean semantics → bool
+      priority : tinyint(1)   # 0-10 scale → uint8
+      has_data : bool         # Already bool → keep as bool
+
+  timestamp → ASK USER about timezone convention, then convert to datetime
+    Example:
+      created_at : timestamp  # pre-2.0 (UNKNOWN timezone convention)
+      created_at : datetime   # 2.0 (UTC standard)
+
+IMPORTANT - Datetime and Timestamp Conversion:
+
+DataJoint 2.0 adopts UTC as the standard for all datetime storage (no timezone information).
+The database stores UTC; timezones are handled by application front-ends and client APIs.
+
+Conversion rules:
+
+- datetime → Keep as datetime (assume UTC, core type)
+- timestamp → ASK USER about timezone convention, then convert to datetime
+- date → Keep as date (core type)
+- time → ASK USER: recommend datetime (core type) or keep as time (native type)
+
+For EACH timestamp column, ASK THE USER:
+
+1. "What timezone convention was used for [column_name]?"
+   - UTC (no conversion needed)
+   - Server local time (requires conversion to UTC)
+   - Application local time (requires conversion to UTC)
+   - Mixed/unknown (requires data audit)
+
+2. "Does this use MySQL's auto-update behavior (ON UPDATE CURRENT_TIMESTAMP)?"
+   - If yes, may need to update table schema
+   - If no, application controls the value
+
+3. After clarifying, recommend:
+   - Convert type: timestamp → datetime
+   - If not already UTC: Add data conversion script to Phase III
+   - Update application code to store UTC times
+   - Handle timezone display in application front-ends and client APIs
+
+Example conversation:
+  AI: "I found timestamp column 'session_time'. What timezone was used?"
+  User: "Server time (US/Eastern)"
+  AI: "I recommend converting to UTC. I'll convert the type to datetime and add a
+       data conversion step in Phase III to convert US/Eastern times to UTC."
+
+Example:
+  # pre-2.0
+  session_time : timestamp    # Was storing US/Eastern
+  event_time : timestamp      # Already UTC
+
+  # 2.0 (after user confirmation)
+  session_time : datetime     # Converted to UTC in Phase III
+  event_time : datetime       # No data conversion needed
+
+IMPORTANT - Bool Type:
+
+Legacy DataJoint already supported bool and boolean types (MySQL stores as tinyint(1)).
+
+Conversion rules:
+
+- bool → Keep as bool (no change)
+- boolean → Keep as bool (no change)
+- tinyint(1) → ASK USER: was this boolean or small integer?
+
+Only explicit tinyint(1) declarations need review because:
+
+- Legacy had bool/boolean for true/false values
+- Some users explicitly used tinyint(1) for small integers (0-255)
+
+Example:
+  # pre-2.0
+  is_active : bool           # Already bool → no change
+  enabled : boolean          # Already boolean → bool
+  is_valid : tinyint(1)      # ASK: Boolean semantics? → bool
+  n_retries : tinyint(1)     # ASK: Small integer? → uint8
+
+  # 2.0
+  is_active : bool           # Unchanged
+  enabled : bool             # boolean → bool
+  is_valid : bool            # Boolean semantics
+  n_retries : uint8          # Small integer
+
+IMPORTANT - Enum Types:
+
+enum is a core type—no changes required.
+
+Example:
+  sex : enum('M', 'F', 'U')  # No change needed
+
+IMPORTANT - JSON Type:
+
+json is a core type that was available in pre-2.0 but underdocumented. Many users
+serialized JSON into blobs. If you have custom JSON serialization in blobs, you can
+migrate to native json type (optional migration, not required).
+
+Example:
+  # Optional: migrate blob with JSON to native json
+  config : longblob  # Contains serialized JSON
+  config : json      # Core JSON type (optional improvement)
+
+IMPORTANT - Native Types (text and time):
+
+text and time are NATIVE MySQL types, NOT core types. They are allowed but discouraged.
+
+For text:
+
+- ASK USER: What is the maximum expected length?
+- Recommend migrating to varchar(n) with appropriate length (core type)
+- Or keep as text (native type, will generate warning)
+
+For time:
+
+- ASK USER: Is this time-of-day only, or is date also relevant?
+- Recommend migrating to datetime (core type, can represent date+time)
+- Or keep as time (native type, will generate warning)
+
+Example:
+  # pre-2.0
+  description : text           # Native type
+  session_start : time         # Native type (time-of-day)
+
+  # 2.0 (recommended)
+  description : varchar(1000)  # Core type (after asking user about max length)
+  session_start : datetime     # Core type (if date is also relevant)
+
+  # 2.0 (alternative - keep native)
+  description : text           # Native type (if truly unlimited length needed)
+  session_start : time         # Native type (if only time-of-day needed)
+
+In-Table Codecs:
+  longblob → <blob>
+  attach → <attach>
+
+In-Store Codecs (LEGACY formats only - convert these):
+  blob@store → <blob@store>  # Add angle brackets
+  attach@store → <attach@store>  # Add angle brackets
+  filepath@store → <filepath@store>  # Add angle brackets
+
+IMPORTANT - Do NOT use these during migration (NEW in 2.0):
+  <npy@store>  # Schema-addressed storage - NEW feature
+  <object@store>  # Schema-addressed storage - NEW feature
+  # These have NO legacy equivalent
+  # Adopt in Phase IV AFTER migration is complete
+  # Do NOT convert existing attributes to these codecs
+
+SCHEMA DECLARATIONS:
+  OLD: schema = dj.schema('my_pipeline')
+  NEW: schema = dj.schema('my_pipeline_v2')
+
+PROCESS:
+1. Identify all Python files with DataJoint schemas
+2. For each schema:
+   a. Update schema declaration (add _v2 suffix)
+   b. Create schema on database (empty for now)
+3. For each table definition in TOPOLOGICAL ORDER:
+   a. Convert ALL type syntax (core types + all codecs)
+   b. Verify syntax is valid
+4. Test that all tables can be declared (run file to create tables)
+5. Verify in-store codecs work with test stores
+
+VERIFICATION:
+
+- All schema declarations use _v2 suffix
+- All native types converted to core types
+- All codecs converted (in-table AND in-store)
+- Test stores configured and accessible
+- No syntax errors
+- All tables create successfully (empty)
+
+EXAMPLE CONVERSION:
+
+# pre-2.0
+schema = dj.schema('neuroscience_pipeline')
+
+@schema
+class Recording(dj.Manual):
+    definition = """
+    recording_id : int unsigned
+    ---
+    sampling_rate : float
+    signal : blob@raw  # pre-2.0 in-store syntax
+    waveforms : blob@raw  # pre-2.0 in-store syntax
+    metadata : longblob  # pre-2.0 in-table
+    """
+
+# 2.0 (Phase I with test stores)
+schema = dj.schema('neuroscience_pipeline_v2')
+
+@schema
+class Recording(dj.Manual):
+    definition = """
+    recording_id : uint32
+    ---
+    sampling_rate : float32
+    signal : <blob@raw>  # Converted: blob@raw → <blob@raw>
+    waveforms : <blob@raw>  # Converted: blob@raw → <blob@raw>
+    metadata : <blob>  # Converted: longblob → <blob>
+    """
+
+# Phase I: Only convert existing legacy formats
+# Do NOT add new codecs like <npy@> during migration
+
+# If you want to adopt <npy@> later (Phase IV), that's a separate step:
+# - After migration is complete
+# - For new features or performance improvements
+# - Not required for migration
+
+REPORT:
+
+- Schemas converted: [list with _v2 suffix]
+- Tables converted: [count by schema]
+- Type conversions: [count by type]
+- Codecs converted:
+  - In-table: [count of <blob>, <attach>]
+  - In-store: [count of <blob@>, <npy@>, <filepath@>]
+- Tables created successfully: [list]
+- Test stores configured: [list store names]
+
+COMMIT MESSAGE FORMAT:
+"feat(phase-i): convert table definitions to 2.0 syntax
+
+- Update schema declarations to *_v2
+- Convert native types to core types (uint32, float64, etc.)
+- Convert all codecs (in-table + in-store)
+- Configure test stores for development/testing
+
+Tables converted: X
+Codecs converted: Y (in-table: Z, in-store: W)"
+```
+
+---
+
+### Step 7: Convert Query and Insert Code
+
+Update all DataJoint API calls to 2.0 patterns.
+
+#### Background: API Changes
+
+**Fetch API:**
+
+- `fetch()` → `to_arrays()` (recarray-like) or `to_dicts()` (list of dicts)
+- `fetch(..., format="frame")` → `to_pandas()` (pandas DataFrame)
+- `fetch('attr1', 'attr2')` → `to_arrays('attr1', 'attr2')` (returns tuple)
+- `fetch1()` → unchanged (still returns dict for single row)
+
+**Update Method:**
+
+- `(table & key)._update('attr', val)` → `table.update1({**key, 'attr': val})`
+
+**Join Operators:**
+
+- `table1 @ table2` → `table1 * table2` (natural join with semantic checks enabled)
+- `a.join(b, left=True)` → Consider `a.extend(b)`
+
+**Universal Set:**
+
+- `dj.U('attr') & table` → Unchanged (correct pattern for projecting attributes)
+- `dj.U('attr') * table` → `table` (was a hack to change primary key)
+
+**Visualization:**
+
+- `dj.ERD(schema)` → `dj.Diagram(schema)` (ERD deprecated)
+
+**Learn more:** [Fetch API Reference](../reference/specs/fetch-api.md) · [Query Operators](../reference/operators.md)
+
+#### AI Agent Prompt: Convert Query and Insert Code
+
+---
+
+**🤖 AI Agent Prompt: Phase I - Query and Insert Code Conversion**
+
+```
+You are converting DataJoint pre-2.0 query and insert code to 2.0 API.
+
+TASK: Update all query, fetch, and insert code to use DataJoint 2.0 API
+patterns.
+
+LEARN MORE: See Fetch API Reference (../reference/specs/fetch-api.md),
+Query Operators (../reference/operators.md), and Semantic Matching
+(../reference/specs/semantic-matching.md).
+
+CONTEXT:
+- Branch: pre/v2.0
+- Schema declarations already updated to _v2 suffix
+- Table definitions already converted
+- Production code on main branch unchanged
+
+API CONVERSIONS:
+
+1. Fetch API (always convert):
+   OLD: data = table.fetch()
+   NEW: data = table.to_arrays()  # recarray-like
+
+   OLD: data = table.fetch(as_dict=True)
+   NEW: data = table.to_dicts()  # list of dicts
+
+   OLD: data = table.fetch(format="frame")
+   NEW: data = table.to_pandas()  # pandas DataFrame
+
+   OLD: data = table.fetch('attr1', 'attr2')
+   NEW: data = table.to_arrays('attr1', 'attr2')  # returns tuple
+
+   OLD: row = table.fetch1()
+   NEW: row = table.fetch1()  # UNCHANGED
+
+   OLD: keys = table.fetch1('KEY')
+   NEW: keys = table.keys()  # Returns list of dicts with primary key values
+
+   OLD: keys, a, b = table.fetch("KEY", "a", "b")
+   NEW: a, b = table.to_arrays('a', 'b', include_key=True)
+   # Returns tuple with keys included
+
+2. Update Method (always convert):
+   OLD: (table & key)._update('attr', value)
+   NEW: table.update1({**key, 'attr': value})
+
+3. Join Operator (always convert):
+   OLD: result = table1 @ table2
+   NEW: result = table1 * table2  # Natural join WITH semantic checks
+
+   IMPORTANT: The @ operator bypassed semantic checks. The * operator
+   enables semantic checks by default. If semantic checks fail,
+   INVESTIGATE—this may reveal errors in your schema or data.
+
+   For left joins:
+   OLD: result = a.join(b, left=True)
+   NEW: result = a.extend(b)  # Consider using extend for left joins
+
+4. Universal Set (CHECK - distinguish correct from hack):
+   CORRECT (unchanged):
+   result = dj.U('attr') & table  # Projects specific attributes, unchanged
+
+   HACK (always refactor):
+   OLD: result = dj.U('attr') * table  # Was hack to change primary key
+   NEW: result = table  # Simply use table directly
+
+   Note: The * operator with dj.U() was a hack. Replace with just table.
+
+5. Insert (CHANGED - requires named keys):
+   OLD: table.insert([(1, 'Alice'), (2, 'Bob')])  # Positional tuples
+   NEW: table.insert([{'id': 1, 'name': 'Alice'},
+                      {'id': 2, 'name': 'Bob'}])  # Dicts
+
+   DataJoint 2.0 requires named key-value mappings for insert:
+   - Dicts (most common)
+   - DataFrames
+   - Other DataJoint queries
+
+   Positional tuples/lists are NO LONGER SUPPORTED.
+
+6. Delete (unchanged):
+   (table & key).delete()  # unchanged
+   (table & restriction).delete()  # unchanged
+
+PROCESS:
+1. Find all Python files with DataJoint code
+2. For each file:
+   a. Search for fetch patterns
+   b. Replace with 2.0 equivalents
+   c. Search for update patterns
+   d. Replace with update1()
+   e. Search for @ operator (replace with * for natural join)
+   f. Search for .join(x, left=True) patterns (consider .extend(x))
+   g. Search for dj.U() * patterns (replace with just table)
+   h. Verify dj.U() & patterns remain unchanged
+3. Run syntax checks
+4. Run existing tests if available
+5. If semantic checks fail after @ → * conversion, investigate schema/data
+
+VERIFICATION:
+
+- No .fetch() calls remaining (except fetch1)
+- No .fetch1('KEY') calls remaining (replaced with .keys())
+- No ._update() calls remaining
+- No @ operator between tables
+- dj.U() * patterns replaced with just table
+- dj.U() & patterns remain unchanged
+- All tests pass (if available)
+- Semantic check failures investigated and resolved
+
+COMMON PATTERNS:
+
+Pattern 1: Fetch all as dicts
+OLD: sessions = Session.fetch(as_dict=True)
+NEW: sessions = Session.to_dicts()
+
+Pattern 2: Fetch specific attributes
+OLD: mouse_ids, dobs = Mouse.fetch('mouse_id', 'dob')
+NEW: mouse_ids, dobs = Mouse.to_arrays('mouse_id', 'dob')
+
+Pattern 3: Fetch as pandas DataFrame
+OLD: df = Mouse.fetch(format="frame")
+NEW: df = Mouse.to_pandas()
+
+Pattern 4: Fetch single row
+OLD: row = (Mouse & key).fetch1()  # unchanged
+NEW: row = (Mouse & key).fetch1()  # unchanged
+
+Pattern 5: Update attribute
+OLD: (Session & key)._update('experimenter', 'Alice')
+NEW: Session.update1({**key, 'experimenter': 'Alice'})
+
+Pattern 6: Fetch primary keys
+OLD: keys = Mouse.fetch1('KEY')
+NEW: keys = Mouse.keys()
+
+Pattern 7: Fetch with keys included
+OLD: keys, weights, ages = Mouse.fetch("KEY", "weight", "age")
+NEW: weights, ages = Mouse.to_arrays('weight', 'age', include_key=True)
+
+Pattern 8: Natural join (now WITH semantic checks)
+OLD: result = Neuron @ Session
+NEW: result = Neuron * Session
+# Semantic checks enabled—may reveal schema errors
+
+Pattern 9: Left join
+OLD: result = Session.join(Experiment, left=True)
+NEW: result = Session.extend(Experiment)  # Consider using extend
+
+Pattern 10: Universal set (distinguish correct from hack)
+CORRECT (unchanged):
+OLD: all_dates = dj.U('session_date') & Session
+NEW: all_dates = dj.U('session_date') & Session  # Unchanged, correct
+
+HACK (always replace):
+OLD: result = dj.U('new_pk') * Session  # Hack to change primary key
+NEW: result = Session  # Simply use table directly
+
+REPORT:
+
+- Files modified: [list]
+- fetch() → to_arrays/to_dicts: [count]
+- fetch(..., format="frame") → to_pandas(): [count]
+- fetch1('KEY') → keys(): [count]
+- _update() → update1(): [count]
+- @ → * (natural join): [count]
+- .join(x, left=True) → .extend(x): [count]
+- dj.U() * table → table: [count]
+- dj.U() & table patterns (unchanged): [count]
+- dj.ERD() → dj.Diagram(): [count]
+- Semantic check failures: [count and resolution]
+- Tests passed: [yes/no]
+
+COMMIT MESSAGE FORMAT:
+"feat(phase-i): convert query and insert code to 2.0 API
+
+- Replace fetch() with to_arrays()/to_dicts()/to_pandas()
+- Replace fetch1('KEY') with keys()
+- Replace _update() with update1()
+- Replace @ operator with * (enables semantic checks)
+- Replace .join(x, left=True) with .extend(x)
+- Replace dj.ERD() with dj.Diagram()
+- Replace dj.U() * table with just table (was hack)
+- Keep dj.U() & table patterns unchanged (correct)
+- Investigate and resolve semantic check failures
+
+API conversions: X fetch, Y update, Z join"
+```
+
+---
+
+### Step 8: Update Populate Methods
+
+`make()` methods in Computed and Imported tables use the same API patterns covered in Steps 6-7.
+
+**Apply the following conversions to all `make()` methods:**
+
+1. **Fetch API conversions** (from Step 7)
+
+   - `fetch()` → `to_arrays()` or `to_dicts()`
+   - `fetch(..., format="frame")` → `to_pandas()`
+   - `fetch1('KEY')` → `keys()`
+   - All other fetch patterns
+
+2. **Join conversions** (from Step 7)
+
+   - `@` → `*` (enables semantic checks)
+   - `a.join(b, left=True)` → `a.extend(b)`
+   - `dj.U() * table` → `table` (was a hack)
+
+3. **Insert conversions** (NEW REQUIREMENT)
+
+   - Positional tuples NO LONGER SUPPORTED
+   - Must use named key-value mappings:
+     ```python
+     # OLD (no longer works)
+     self.insert1((key['id'], computed_value, timestamp))
+
+     # NEW (required)
+     self.insert1({
+         **key,
+         'computed_value': computed_value,
+         'timestamp': timestamp
+     })
+     ```
+
+**Note:** Since these are the same conversions from Step 7, you can apply them in a single pass. The only additional consideration is ensuring insert statements use dicts.
+
+---
+
+### Step 9: Verify Phase I Complete
+
+#### Checklist
+
+- [ ] `pre/v2.0` branch created
+- [ ] DataJoint 2.0 installed (`pip list | grep datajoint`)
+- [ ] Configuration files created (`.secrets/`, `datajoint.json`)
+- [ ] Test stores configured (if using in-store codecs)
+- [ ] In-store codecs tested (`<blob@>`, `<attach@>`, `<filepath@>`)
+- [ ] Hash-addressed file organization verified and understood
+- [ ] All schema declarations use `_v2` suffix
+- [ ] All table definitions use 2.0 type syntax
+- [ ] All in-table codecs converted (`<blob>`, `<attach>`)
+- [ ] All in-store codecs converted (`<blob@>`, `<attach@>`, `<filepath@>`)
+- [ ] All `fetch()` calls converted (except `fetch1()`)
+- [ ] All `fetch(..., format="frame")` converted to `to_pandas()`
+- [ ] All `fetch1('KEY')` converted to `keys()`
+- [ ] All `._update()` calls converted
+- [ ] All `@` operators converted to `*`
+- [ ] All `dj.U() * table` patterns replaced with just `table` (was a hack)
+- [ ] All `dj.U() & table` patterns verified as unchanged (correct)
+- [ ] All `dj.ERD()` calls converted to `dj.Diagram()`
+- [ ] All populate methods updated
+- [ ] No syntax errors
+- [ ] All `_v2` schemas created (empty)
+
+#### Test Schema Creation
+
+```python
+# Run your main module to create all tables
+import your_pipeline_v2
+
+# Verify schemas exist
+import datajoint as dj
+conn = dj.conn()
+
+schemas = conn.query("SHOW DATABASES LIKE '%_v2'").fetchall()
+print(f"Created {len(schemas)} _v2 schemas:")
+for schema in schemas:
+    print(f"  - {schema[0]}")
+
+# Verify tables created
+for schema_name in [s[0] for s in schemas]:
+    tables = conn.query(
+        f"SELECT COUNT(*) FROM information_schema.TABLES "
+        f"WHERE TABLE_SCHEMA='{schema_name}'"
+    ).fetchone()[0]
+    print(f"{schema_name}: {tables} tables")
+```
+
+#### Commit Phase I
+
+```bash
+# Review all changes
+git status
+git diff
+
+# Commit
+git add .
+git commit -m "feat: complete Phase I migration to DataJoint 2.0
+
+Summary:
+- Created _v2 schemas (empty)
+- Converted all table definitions to 2.0 syntax
+- Converted all query/insert code to 2.0 API
+- Converted all populate methods
+- Configured test stores for in-store codecs
+- Production data migration deferred to Phase III
+
+Schemas: X
+Tables: Y
+Code files: Z"
+
+git push origin pre/v2.0
+```
+
+✅ **Phase I Complete!**
+
+**You now have:**
+
+- 2.0-compatible code on `pre/v2.0` branch
+- Empty `_v2` schemas ready for testing
+- Production still running on `main` branch with pre-2.0
+
+**Next:** Phase II - Test with sample data
+
+---
+
+## Phase II: Test Compatibility and Equivalence
+
+**Goal:** Validate that the 2.0 pipeline produces equivalent results to the legacy pipeline.
+
+**End state:**
+
+- 2.0 pipeline runs correctly with sample data in `_v2` schemas and test stores
+- Results are equivalent to running legacy pipeline on same data
+- Confidence that migration is correct before touching production
+- Production still untouched
+
+**Key principle:** Test with identical data in both legacy and v2 schemas to verify equivalence.
+
+### Step 1: Run Your Regular Workflow
+
+Use your existing data entry and populate processes on the `_v2` schemas:
+
+```python
+# Import your v2 pipeline
+from your_pipeline_v2 import schema  # Points to my_pipeline_v2
+
+# Follow your normal workflow:
+# 1. Insert test data into manual tables (same process as usual)
+# 2. Run populate on computed/imported tables (same process as usual)
+# 3. Run any queries or analysis scripts (using 2.0 API)
+
+# Example (adapt to your pipeline):
+# YourManualTable.insert([...])  # Your usual insert process
+# YourComputedTable.populate(display_progress=True)  # Your usual populate
+```
+
+**Key points:**
+
+- Use a **representative subset** of data (not full production dataset)
+- Follow your **existing workflow** - don't create artificial examples
+- Populate computed tables using your **normal populate process**
+- Run any **existing analysis or query scripts** you have
+- Test that everything works with the 2.0 API
+
+### Step 2: Compare with Legacy Schema (Equivalence Testing)
+
+**Critical:** Run identical data through both legacy and v2 pipelines to verify equivalence.
+
+#### Option A: Side-by-Side Comparison
+
+```python
+# compare_legacy_v2.py
+import datajoint as dj
+import numpy as np
+
+# Import both legacy and v2 modules
+import your_pipeline as legacy  # pre-2.0 on main branch (checkout to test)
+import your_pipeline_v2 as v2  # 2.0 on pre/v2.0 branch
+
+def compare_results():
+    """Compare query results between legacy and v2."""
+
+    # Insert same data into both schemas
+    test_data = [
+        {'mouse_id': 0, 'dob': '2024-01-01', 'sex': 'M'},
+        {'mouse_id': 1, 'dob': '2024-01-15', 'sex': 'F'},
+    ]
+
+    legacy.Mouse.insert(test_data, skip_duplicates=True)
+    v2.Mouse.insert(test_data, skip_duplicates=True)
+
+    # Compare query results
+    legacy_mice = legacy.Mouse.fetch(as_dict=True)  # pre-2.0 syntax
+    v2_mice = v2.Mouse.to_dicts()  # 2.0 syntax
+
+    assert len(legacy_mice) == len(v2_mice), "Row count mismatch!"
+
+    # Compare values (excluding fetch-specific artifacts)
+    for leg, v2_row in zip(legacy_mice, v2_mice):
+        for key in leg.keys():
+            if leg[key] != v2_row[key]:
+                print(f"MISMATCH: {key}: {leg[key]} != {v2_row[key]}")
+                return False
+
+    print("✓ Query results are equivalent!")
+    return True
+
+def compare_populate():
+    """Compare populate results."""
+
+    # Populate both
+    legacy.Neuron.populate(display_progress=True)
+    v2.Neuron.populate(display_progress=True)
+
+    # Compare counts
+    legacy_count = len(legacy.Neuron())
+    v2_count = len(v2.Neuron())
+
+    assert legacy_count == v2_count, f"Count mismatch: {legacy_count} != {v2_count}"
+
+    print(f"✓ Populate generated same number of rows: {v2_count}")
+
+    # Compare computed values (if numeric)
+    for key in (legacy.Neuron & 'neuron_id=0').keys():
+        leg_val = (legacy.Neuron & key).fetch1('activity')
+        v2_val = (v2.Neuron & key).fetch1('activity')
+
+        if isinstance(leg_val, np.ndarray):
+            assert np.allclose(leg_val, v2_val, rtol=1e-9), "Array values differ!"
+        else:
+            assert leg_val == v2_val, f"Value mismatch: {leg_val} != {v2_val}"
+
+    print("✓ Populate results are equivalent!")
+    return True
+
+if __name__ == '__main__':
+    print("Comparing legacy and v2 pipelines...")
+    compare_results()
+    compare_populate()
+    print("\n✓ All equivalence tests passed!")
+```
+
+Run comparison:
+
+```bash
+python compare_legacy_v2.py
+```
+
+#### Option B: Data Copy and Validation
+
+If you can't easily import both modules:
+
+1. Copy sample data from production to both legacy test schema and `_v2` schema
+2. Run populate on both
+3. Use helper to compare:
+
+```python
+from datajoint.migrate import compare_query_results
+
+# Compare table contents
+result = compare_query_results(
+    prod_schema='my_pipeline',
+    test_schema='my_pipeline_v2',
+    table='neuron',
+    tolerance=1e-6,
+)
+
+if result['match']:
+    print(f"✓ {result['row_count']} rows match")
+else:
+    print(f"✗ Discrepancies found:")
+    for disc in result['discrepancies']:
+        print(f"  {disc}")
+```
+
+### Step 3: Run Existing Tests
+
+If you have a test suite:
+
+```bash
+# Run tests against _v2 schemas
+pytest tests/ -v
+
+# Or specific test modules
+pytest tests/test_queries.py -v
+pytest tests/test_populate.py -v
+```
+
+### Step 4: Document Test Results
+
+Document your testing process and results:
+
+**What to document:**
+
+- Date of testing
+- Test data used (subset, size, representative samples)
+- Tables tested and row counts
+- Populate results (did computed tables generate expected rows?)
+- Equivalence test results (if comparing with legacy)
+- Any issues found and how they were resolved
+- Test suite results (if you have automated tests)
+
+**Purpose:** Creates a record of validation for your team and future reference.
+Useful when planning production migration in Phase III.
+
+✅ **Phase II Complete!**
+
+**You now have:**
+
+- Validated 2.0 pipeline with sample data
+- Confidence in code migration
+- Test report documenting success
+- Ready to migrate production data
+
+**Next:** Phase III - Migrate production data
+
+---
+
+## Phase III: Migrate Production Data
+
+**Goal:** Migrate production data and configure production stores. Code is complete from Phase I.
+
+**End state:**
+
+- Production data migrated to `_v2` schemas
+- Production stores configured (replacing test stores)
+- In-store metadata updated (UUID → JSON)
+- Ready to switch production to 2.0
+
+**Key principle:** All code changes were completed in Phase I. This phase is DATA migration only.
+
+**Prerequisites:**
+
+- Phase I complete (all code migrated)
+- Phase II complete (equivalence validated)
+- Production backup created
+- Production workloads quiesced
+
+**Options:**
+
+- **Option A:** Copy data, rename schemas (recommended - safest)
+- **Option B:** In-place migration (for very large databases)
+- **Option C:** Gradual migration with legacy compatibility
+
+Choose the option that best fits your needs.
+
+### Option A: Copy Data and Rename Schemas (Recommended)
+
+**Best for:** Most pipelines, especially < 1 TB
+
+**Advantages:**
+
+- Safe - production unchanged until final step
+- Easy rollback
+- Can practice multiple times
+
+**Process:**
+
+#### 0. Configure Production Stores
+
+Update `datajoint.json` to point to production stores (not test stores):
+
+```json
+{
+  "stores": {
+    "default": "main",
+    "main": {
+      "protocol": "file",
+      "location": "/data/production_stores/main"  # Production location
+    }
+  }
+}
+```
+
+**For in-store data migration:** You can either:
+
+- **Keep files in place** (recommended): Point to existing pre-2.0 store locations
+- **Copy to new location**: Configure new production stores and copy files
+
+**Commit this change:**
+```bash
+git add datajoint.json
+git commit -m "config: update stores to production locations"
+```
+
+#### 1. Backup Production
+
+```bash
+# Full backup
+mysqldump --all-databases > backup_$(date +%Y%m%d).sql
+
+# Or schema-specific
+mysqldump my_pipeline > my_pipeline_backup_$(date +%Y%m%d).sql
+```
+
+#### 2. Copy Manual Table Data
+
+```python
+from datajoint.migrate import copy_table_data
+
+# Copy each manual table
+tables = ['mouse', 'session', 'experimenter']  # Your manual tables
+
+for table in tables:
+    result = copy_table_data(
+        source_schema='my_pipeline',
+        dest_schema='my_pipeline_v2',
+        table=table,
+    )
+    print(f"{table}: copied {result['rows_copied']} rows")
+```
+
+#### 3. Populate Computed Tables
+
+```python
+from your_pipeline_v2 import Neuron, Analysis
+
+# Populate using 2.0 code
+Neuron.populate(display_progress=True)
+Analysis.populate(display_progress=True)
+```
+
+#### 4. Migrate In-Store Metadata
+
+**Important:** Your code already handles in-store codecs (converted in Phase I). This step just updates metadata format.
+
+If you have tables using `<blob@>`, `<attach@>`, or `<filepath@>` codecs, migrate the storage metadata from legacy BINARY(16) UUID format to 2.0 JSON format:
+
+```python
+from datajoint.migrate import migrate_external_pointers_v2
+
+# Update metadata format (UUID → JSON)
+# This does NOT move files—just updates database pointers
+result = migrate_external_pointers_v2(
+    schema='my_pipeline_v2',
+    table='recording',
+    attribute='signal',
+    source_store='raw',  # Legacy pre-2.0 store name
+    dest_store='raw',  # 2.0 store name (from datajoint.json)
+    copy_files=False,  # Keep files in place (recommended)
+)
+
+print(f"Migrated {result['rows_migrated']} pointers")
+```
+
+**What this does:**
+
+- Reads legacy BINARY(16) UUID pointers from `~external_*` hidden tables
+- Creates new JSON metadata with file path, store name, hash
+- Writes JSON to the `<blob@store>` column (code written in Phase I)
+- Does NOT copy files (unless `copy_files=True`)
+
+**Result:** Files stay in place, but 2.0 code can now access them via the new codec system.
+
+#### 5. Validate Data Integrity
+
+```python
+from datajoint.migrate import compare_query_results
+
+# Compare production vs _v2
+tables_to_check = ['mouse', 'session', 'neuron', 'analysis']
+
+all_match = True
+for table in tables_to_check:
+    result = compare_query_results(
+        prod_schema='my_pipeline',
+        test_schema='my_pipeline_v2',
+        table=table,
+        tolerance=1e-6,
+    )
+
+    if result['match']:
+        print(f"✓ {table}: {result['row_count']} rows match")
+    else:
+        print(f"✗ {table}: discrepancies found")
+        for disc in result['discrepancies'][:5]:
+            print(f"    {disc}")
+        all_match = False
+
+if all_match:
+    print("\n✓ All tables validated! Ready for cutover.")
+else:
+    print("\n✗ Fix discrepancies before proceeding.")
+```
+
+#### 6. Schedule Cutover
+
+**Pre-cutover checklist:**
+
+- [ ] Full backup verified
+- [ ] All data copied
+- [ ] All computed tables populated
+- [ ] Validation passed
+- [ ] Team notified
+- [ ] Maintenance window scheduled
+- [ ] All pre-2.0 clients stopped
+
+**Execute cutover:**
+
+```sql
+-- Rename production → old
+RENAME TABLE `my_pipeline` TO `my_pipeline_old`;
+
+-- Rename _v2 → production
+RENAME TABLE `my_pipeline_v2` TO `my_pipeline`;
+```
+
+**Update code:**
+
+```bash
+# On pre/v2.0 branch, update schema names back
+sed -i '' 's/_v2//g' your_pipeline/*.py
+
+git add .
+git commit -m "chore: remove _v2 suffix for production"
+
+# Merge to main
+git checkout main
+git merge pre/v2.0
+git push origin main
+
+# Deploy updated code
+```
+
+#### 7. Verify Production
+
+```python
+# Test production after cutover
+from your_pipeline import schema, Mouse, Neuron
+
+print(f"Mice: {len(Mouse())}")
+print(f"Neurons: {len(Neuron())}")
+
+# Run a populate
+Neuron.populate(limit=5, display_progress=True)
+```
+
+#### 8. Cleanup (After 1-2 Weeks)
+
+```sql
+-- After confirming production stable
+DROP DATABASE `my_pipeline_old`;
+```
+
+### Option B: In-Place Migration
+
+**Best for:** Very large databases (> 1 TB) where copying is impractical
+
+**Warning:** Modifies production schema directly. Test thoroughly first!
+
+```python
+from datajoint.migrate import migrate_schema_in_place
+
+# Backup first
+backup_schema('my_pipeline', 'my_pipeline_backup_20260114')
+
+# Migrate in place
+result = migrate_schema_in_place(
+    schema='my_pipeline',
+    backup=True,
+    steps=[
+        'update_blob_comments',  # Add :<blob>: markers
+        'add_lineage_table',  # Create ~lineage
+        'migrate_external_storage',  # BINARY(16) → JSON
+    ]
+)
+
+print(f"Migrated {result['steps_completed']} steps")
+```
+
+### Option C: Gradual Migration with Legacy Compatibility
+
+**Best for:** Pipelines that must support both pre-2.0 and 2.0 clients simultaneously
+
+**Strategy:** Create dual columns for in-store codecs
+
+#### 1. Add `_v2` Columns
+
+For each in-store attribute, add a corresponding `_v2` column:
+
+```sql
+-- Add _v2 column for in-store codec
+ALTER TABLE `my_pipeline`.`recording`
+  ADD COLUMN `signal_v2` JSON COMMENT ':<blob@raw>:signal data';
+```
+
+#### 2. Populate `_v2` Columns
+
+```python
+from datajoint.migrate import populate_v2_columns
+
+result = populate_v2_columns(
+    schema='my_pipeline',
+    table='recording',
+    attribute='signal',
+    v2_attribute='signal_v2',
+    source_store='raw',
+    dest_store='raw',
+)
+
+print(f"Populated {result['rows']} _v2 columns")
+```
+
+#### 3. Update Code to Use `_v2` Columns
+
+```python
+# Update table definition
+@schema
+class Recording(dj.Manual):
+    definition = """
+    recording_id : uint32
+    ---
+    signal : blob@raw  # Legacy (pre-2.0 clients)
+    signal_v2 : <blob@raw>  # 2.0 clients
+    """
+```
+
+**Both APIs work:**
+
+- pre-2.0 clients use `signal`
+- 2.0 clients use `signal_v2`
+
+#### 4. Final Cutover
+
+Once all clients upgraded to 2.0:
+
+```sql
+-- Drop legacy column
+ALTER TABLE `my_pipeline`.`recording`
+  DROP COLUMN `signal`;
+
+-- Rename _v2 to original name
+ALTER TABLE `my_pipeline`.`recording`
+  CHANGE COLUMN `signal_v2` `signal` JSON;
+```
+
+---
+
+## Phase IV: Adopt New Features
+
+After successful migration, adopt DataJoint 2.0 features incrementally based
+on your needs. Migration is complete - these are optional enhancements.
+
+### New Features Overview
+
+**Schema-addressed storage** (`<npy@>`, `<object@>`)
+- Lazy-loading arrays with fsspec integration
+- Hierarchical organization by primary key
+- Mutable objects with streaming access
+- See: [Object Storage Tutorial](../tutorials/basics/06-object-storage.ipynb)
+
+**Semantic matching**
+- Lineage-based join validation (enabled by default with `*` operator)
+- Catches errors from incompatible data combinations
+- See: [Semantic Matching Spec](../reference/specs/semantic-matching.md)
+
+**Jobs 2.0**
+- Per-table job tracking (`~~table_name`)
+- Priority-based populate (with `reserve_jobs=True`)
+- Improved distributed computing coordination
+- See: [Distributed Computing Tutorial](../tutorials/advanced/distributed.ipynb)
+
+**Custom codecs**
+- Domain-specific data types
+- Extensible type system
+- See: [Custom Codecs Tutorial](../tutorials/advanced/custom-codecs.ipynb)
+
+### Learning Path
+
+**Start here:**
+
+1. [Object Storage Tutorial](../tutorials/basics/06-object-storage.ipynb) -
+   Learn `<npy@>` and `<object@>` for large arrays
+2. [Distributed Computing Tutorial](../tutorials/advanced/distributed.ipynb) -
+   Jobs 2.0 with priority-based populate
+3. [Custom Codecs Tutorial](../tutorials/advanced/custom-codecs.ipynb) -
+   Create domain-specific types
+
+**Reference documentation:**
+
+- [Object Store Configuration](../reference/specs/object-store-configuration.md)
+- [NPY Codec Spec](../reference/specs/npy-codec.md)
+- [Codec API](../reference/specs/codec-api.md)
+- [Semantic Matching Spec](../reference/specs/semantic-matching.md)
+- [AutoPopulate Spec](../reference/specs/autopopulate.md)
+
+**Adopt features incrementally:**
+
+- Start with one table using `<npy@>` for large arrays
+- Test performance and workflow improvements
+- Expand to other tables as needed
+- No need to adopt all features at once
+
+---
+
+## Troubleshooting
+
+### Import Errors
+
+**Issue:** Module not found after migration
+
+**Solution:**
+```python
+# Ensure all imports use datajoint namespace
+import datajoint as dj
+from datajoint import schema, Manual, Computed
+```
+
+### Schema Not Found
+
+**Issue:** `Database 'schema_v2' doesn't exist`
+
+**Solution:**
+```python
+# Ensure schema declared and created
+schema = dj.schema('schema_v2')
+schema.spawn_missing_classes()
+```
+
+### Type Syntax Errors
+
+**Issue:** `Invalid type: 'int unsigned'`
+
+**Solution:** Update to core types
+```python
+# Wrong
+definition = """
+id : int unsigned
+"""
+
+# Correct
+definition = """
+id : uint32
+"""
+```
+
+### External Storage Not Found
+
+**Issue:** Can't access external data after migration
+
+**Solution:**
+```python
+# Ensure stores configured
+dj.config['stores.default'] = 'main'
+dj.config['stores.main.location'] = '/data/stores'
+
+# Verify
+from datajoint.settings import get_store_spec
+print(get_store_spec('main'))
+```
+
+---
+
+## Summary
+
+**Phase I:** Branch and code migration (~1-4 hours with AI)
+- Create `pre/v2.0` branch
+- Update all code to 2.0 API
+- Create empty `_v2` schemas
+
+**Phase II:** Test with sample data (~1-2 days)
+- Insert test data
+- Validate functionality
+- Test new features
+
+**Phase III:** Migrate production data (~1-7 days)
+- Choose migration option
+- Copy or migrate data
+- Validate integrity
+- Execute cutover
+
+**Phase IV:** Adopt new features (ongoing)
+- Object storage
+- Semantic matching
+- Custom codecs
+- Jobs 2.0
+
+**Total timeline:** ~1-2 weeks for most pipelines
+
+---
 
 ## See Also
 
-- [Configure Object Storage](configure-storage.md) — New storage configuration
-- [Distributed Computing](distributed-computing.md) — Jobs 2.0 system
+**Core Documentation:**
+
+- [Type System Concept](../explanation/type-system.md)
+- [Configuration Reference](../reference/configuration.md)
+- [Definition Syntax](../reference/definition-syntax.md)
+- [Fetch API Reference](../reference/specs/fetch-api.md)
+
+**Tutorials:**
+
+- [Object Storage](../tutorials/basics/06-object-storage.ipynb)
+- [Custom Codecs](../tutorials/advanced/custom-codecs.ipynb)
+- [Distributed Computing](../tutorials/advanced/distributed.ipynb)
+
+**Specifications:**
+
+- [Type System Spec](../reference/specs/type-system.md)
+- [Codec API Spec](../reference/specs/codec-api.md)
+- [Object Store Configuration](../reference/specs/object-store-configuration.md)
+- [Semantic Matching](../reference/specs/semantic-matching.md)
 
 
 ---
-## File: how-to/model-relationships.md
+## File: how-to/model-relationships.ipynb
 
 # Model Relationships
 
-Define foreign key relationships between tables.
+Define foreign key relationships between tables. This guide shows how different foreign key placements create different relationship types, with actual schema diagrams.
+
+
+```python
+import datajoint as dj
+
+schema = dj.Schema('howto_relationships')
+schema.drop(prompt=False)
+schema = dj.Schema('howto_relationships')
+```
+
 
 ## Basic Foreign Key
 
 Reference another table with `->`:
+
 
 ```python
 @schema
@@ -10196,7 +17234,10 @@ class Session(dj.Manual):
     ---
     session_date : date
     """
+
+dj.Diagram(Subject) + dj.Diagram(Session)
 ```
+
 
 The `->` syntax:
 
@@ -10210,48 +17251,73 @@ The `->` syntax:
 Where you place a foreign key determines the relationship type:
 
 | Placement | Relationship | Diagram Line |
-|-----------|--------------|--------------|
+|-----------|--------------|-------------|
 | Entire primary key | One-to-one extension | Thick solid |
 | Part of primary key | One-to-many containment | Thin solid |
 | Secondary attribute | One-to-many reference | Dashed |
 
 ## One-to-Many: Containment
 
-Foreign key as part of the primary key (above `---`):
+Foreign key as **part of** the primary key (above `---`):
+
 
 ```python
 @schema
-class Session(dj.Manual):
+class Trial(dj.Manual):
     definition = """
-    -> Subject              # Part of primary key
-    session_idx : uint16    # Additional PK attribute
+    -> Session              # Part of primary key
+    trial_idx : uint16      # Additional PK attribute
     ---
-    session_date : date
+    outcome : varchar(20)
     """
+
+dj.Diagram(Session) + dj.Diagram(Trial)
 ```
 
-Sessions are identified **within** their subject. Session #1 for Subject A is different from Session #1 for Subject B.
+
+**Thin solid line** = containment. Trials are identified **within** their session. Trial #1 for Session A is different from Trial #1 for Session B.
+
+Notice `Trial` is **underlined** — it introduces a new [dimension](../explanation/entity-integrity.md#schema-dimensions) (`trial_idx`). A dimension is an independent axis of variation in your data, introduced by a table that defines new primary key attributes.
 
 ## One-to-Many: Reference
 
-Foreign key as secondary attribute (below `---`):
+Foreign key as **secondary attribute** (below `---`):
+
 
 ```python
 @schema
+class Equipment(dj.Lookup):
+    definition = """
+    equipment_id : varchar(16)
+    ---
+    equipment_name : varchar(60)
+    """
+    contents = [
+        {'equipment_id': 'rig1', 'equipment_name': 'Main Recording Rig'},
+        {'equipment_id': 'rig2', 'equipment_name': 'Backup Rig'},
+    ]
+
+@schema
 class Recording(dj.Manual):
     definition = """
-    recording_id : uuid     # Independent identity
+    recording_id : uuid         # Independent identity
     ---
-    -> Equipment            # Reference, not part of identity
+    -> Equipment                # Reference, not part of identity
     duration : float32
     """
+
+dj.Diagram(Equipment) + dj.Diagram(Recording)
 ```
 
-Recordings have their own global identity independent of equipment.
+
+**Dashed line** = reference. Recordings have their own global identity independent of equipment.
+
+Both tables are **underlined** — each introduces its own dimension.
 
 ## One-to-One: Extension
 
-Foreign key is the entire primary key:
+Foreign key **is** the entire primary key:
+
 
 ```python
 @schema
@@ -10262,33 +17328,58 @@ class SubjectDetails(dj.Manual):
     weight : float32
     notes : varchar(1000)
     """
+
+dj.Diagram(Subject) + dj.Diagram(SubjectDetails)
 ```
 
-Each subject has at most one details record. The tables share identity.
+
+**Thick solid line** = extension. Each subject has at most one details record. The tables share identity.
+
+Notice `SubjectDetails` is **not underlined** — it doesn't introduce a new dimension.
 
 ## Optional (Nullable) Foreign Keys
 
 Make a reference optional with `[nullable]`:
 
+
 ```python
 @schema
-class Trial(dj.Manual):
+class Stimulus(dj.Lookup):
     definition = """
-    -> Session
-    trial_idx : uint16
+    stimulus_type : varchar(32)
+    """
+    contents = [{'stimulus_type': 'visual'}, {'stimulus_type': 'auditory'}]
+
+@schema
+class TrialStimulus(dj.Manual):
+    definition = """
+    -> Trial
     ---
     -> [nullable] Stimulus   # Some trials have no stimulus
-    outcome : enum('hit', 'miss')
     """
+
+dj.Diagram(Trial) + dj.Diagram(Stimulus) + dj.Diagram(TrialStimulus)
 ```
+
 
 Only secondary foreign keys (below `---`) can be nullable.
 
+**Note:** The `[nullable]` modifier is NOT visible in diagrams — check the table definition.
+
 ## Unique Foreign Keys
 
-Enforce one-to-one with `[unique]`:
+Enforce one-to-one on a secondary FK with `[unique]`:
+
 
 ```python
+@schema
+class Employee(dj.Manual):
+    definition = """
+    employee_id : uint32
+    ---
+    name : varchar(60)
+    """
+
 @schema
 class ParkingSpot(dj.Manual):
     definition = """
@@ -10297,13 +17388,31 @@ class ParkingSpot(dj.Manual):
     -> [unique] Employee     # Each employee has at most one spot
     location : varchar(30)
     """
+
+dj.Diagram(Employee) + dj.Diagram(ParkingSpot)
 ```
+
+
+**Note:** The `[unique]` modifier is NOT visible in diagrams — the line is still dashed. Check the table definition to see the constraint.
 
 ## Many-to-Many
 
 Use an association table with composite primary key:
 
+
 ```python
+@schema
+class Protocol(dj.Lookup):
+    definition = """
+    protocol_id : varchar(16)
+    ---
+    protocol_name : varchar(100)
+    """
+    contents = [
+        {'protocol_id': 'iacuc_01', 'protocol_name': 'Mouse Protocol'},
+        {'protocol_id': 'iacuc_02', 'protocol_name': 'Rat Protocol'},
+    ]
+
 @schema
 class Assignment(dj.Manual):
     definition = """
@@ -10312,72 +17421,69 @@ class Assignment(dj.Manual):
     ---
     assigned_date : date
     """
+
+dj.Diagram(Subject) + dj.Diagram(Protocol) + dj.Diagram(Assignment)
 ```
 
-Each subject-protocol combination appears at most once.
+
+Two **thin solid lines** converge into `Assignment`. Each subject-protocol combination appears at most once.
+
+Notice `Assignment` is **not underlined** — it doesn't introduce a new dimension, just combines existing ones.
 
 ## Hierarchies
 
 Cascading one-to-many relationships create tree structures:
 
+
 ```python
-@schema
-class Study(dj.Manual):
-    definition = """
-    study : varchar(8)
-    ---
-    investigator : varchar(60)
-    """
-
-@schema
-class Subject(dj.Manual):
-    definition = """
-    -> Study
-    subject_id : varchar(12)
-    ---
-    species : varchar(32)
-    """
-
-@schema
-class Session(dj.Manual):
-    definition = """
-    -> Subject
-    session_idx : uint16
-    ---
-    session_date : date
-    """
+# Already defined: Subject -> Session -> Trial
+# Show the full hierarchy
+dj.Diagram(Subject) + dj.Diagram(Session) + dj.Diagram(Trial)
 ```
 
-Primary keys cascade: Session's key is `(study, subject_id, session_idx)`.
+
+Primary keys cascade: Trial's key is `(subject_id, session_idx, trial_idx)`.
+
+All three tables are **underlined** — each introduces a dimension.
 
 ## Part Tables
 
-Part tables have an implicit foreign key to their master:
+Part tables use the `-> master` alias to reference their enclosing table:
+
 
 ```python
 @schema
-class Session(dj.Manual):
+class Scan(dj.Manual):
     definition = """
-    -> Subject
-    session_idx : uint16
+    -> Session
+    scan_idx : uint16
     ---
-    session_date : date
+    depth : float32
     """
 
-    class Trial(dj.Part):
+    class ROI(dj.Part):
         definition = """
-        -> master
-        trial_idx : uint16
+        -> master               # References Scan's primary key
+        roi_idx : uint16        # Additional dimension
         ---
-        outcome : enum('hit', 'miss')
+        x : float32
+        y : float32
         """
+
+dj.Diagram(Session) + dj.Diagram(Scan) + dj.Diagram(Scan.ROI)
 ```
 
-`-> master` references the enclosing table's primary key.
+
+`-> master` is the standard way to declare the foreign key to the enclosing table. It references the master's primary key.
+
+Notice:
+- `Scan` is **underlined** (introduces `scan_idx`)
+- `Scan.ROI` is **underlined** (introduces `roi_idx`) — Part tables CAN introduce dimensions
 
 ## Renamed Foreign Keys
 
-Reference the same table multiple times with renamed attributes:
+Reference the same table multiple times with `.proj()` to rename attributes:
+
 
 ```python
 @schema
@@ -10388,25 +17494,47 @@ class Comparison(dj.Manual):
     ---
     similarity : float32
     """
+
+dj.Diagram(Session) + dj.Diagram(Comparison)
 ```
+
+
+**Orange dots** indicate renamed foreign keys. Hover over them to see the projection expression.
+
+This creates attributes `session_a` and `session_b`, both referencing `Session.session_idx`.
 
 ## Computed Dependencies
 
 Computed tables inherit keys from their dependencies:
 
+
 ```python
 @schema
-class ProcessedData(dj.Computed):
+class TrialAnalysis(dj.Computed):
     definition = """
-    -> RawData
+    -> Trial
     ---
-    result : float64
+    score : float64
     """
-
+    
     def make(self, key):
-        data = (RawData & key).fetch1('data')
-        self.insert1({**key, 'result': process(data)})
+        self.insert1({**key, 'score': 0.95})
+
+dj.Diagram(Trial) + dj.Diagram(TrialAnalysis)
 ```
+
+
+**Thick solid line** to a **red (Computed) table** that is **not underlined**.
+
+Computed tables never introduce dimensions — their primary key is entirely inherited from dependencies.
+
+## Full Schema View
+
+
+```python
+dj.Diagram(schema)
+```
+
 
 ## Schema as DAG
 
@@ -10418,11 +17546,27 @@ DataJoint schemas form a directed acyclic graph (DAG). Foreign keys:
 
 There are no cyclic dependencies—parent tables must always be populated before their children.
 
+## Summary
+
+| Pattern | Declaration | Line Style | Dimensions |
+|---------|-------------|------------|------------|
+| One-to-one | FK is entire PK | Thick solid | No new dimension |
+| One-to-many (contain) | FK + other attrs in PK | Thin solid | Usually new dimension |
+| One-to-many (ref) | FK in secondary | Dashed | Independent dimensions |
+| Many-to-many | Two FKs in PK | Two thin solid | No new dimension |
+| Part table | `-> master` | Thin solid | May introduce dimension |
+
 ## See Also
 
 - [Define Tables](define-tables.md) — Table definition syntax
 - [Design Primary Keys](design-primary-keys.md) — Key selection strategies
+- [Read Diagrams](read-diagrams.ipynb) — Diagram notation reference
 - [Delete Data](delete-data.md) — Cascade behavior
+
+
+```python
+schema.drop(prompt=False)
+```
 
 
 ---
@@ -10545,15 +17689,32 @@ import time
 from my_pipeline import ProcessedData
 
 while True:
-    remaining = len(ProcessedData.key_source - ProcessedData)
-    progress = ProcessedData.jobs.progress()
+    remaining, total = ProcessedData.progress()
 
-    print(f"\rRemaining: {remaining} | "
-          f"Pending: {progress.get('pending', 0)} | "
-          f"Running: {progress.get('reserved', 0)} | "
-          f"Errors: {progress.get('error', 0)}", end='')
+    print(f"\rProgress: {total - remaining}/{total} ({(total - remaining) / total:.0%})", end='')
 
     if remaining == 0:
+        print("\nDone!")
+        break
+
+    time.sleep(10)
+```
+
+For distributed mode with job tracking:
+
+```python
+import time
+from my_pipeline import ProcessedData
+
+while True:
+    status = ProcessedData.jobs.progress()
+
+    print(f"\rPending: {status.get('pending', 0)} | "
+          f"Running: {status.get('reserved', 0)} | "
+          f"Done: {status.get('success', 0)} | "
+          f"Errors: {status.get('error', 0)}", end='')
+
+    if status.get('pending', 0) == 0 and status.get('reserved', 0) == 0:
         print("\nDone!")
         break
 
@@ -10761,6 +17922,360 @@ len(Subject & condition)
 
 - [Operators Reference](../reference/operators.md) — Complete operator documentation
 - [Fetch Results](fetch-results.md) — Retrieving query results
+
+
+---
+## File: how-to/read-diagrams.ipynb
+
+# Read Schema Diagrams
+
+DataJoint diagrams visualize schema structure as directed acyclic graphs (DAGs). This guide teaches you to:
+
+- Interpret line styles and their semantic meaning
+- Recognize dimensions (underlined vs non-underlined tables)
+- Use diagram operations to explore large schemas
+- Compare DataJoint notation to traditional ER diagrams
+
+
+```python
+import datajoint as dj
+
+schema = dj.Schema('howto_diagrams')
+schema.drop(prompt=False)
+schema = dj.Schema('howto_diagrams')
+```
+
+
+## Quick Reference
+
+| Line Style | Relationship | Child's Primary Key |
+|------------|--------------|---------------------|
+| **Thick Solid** ━━━ | Extension | Parent PK only (one-to-one) |
+| **Thin Solid** ─── | Containment | Parent PK + own fields (one-to-many) |
+| **Dashed** ┄┄┄ | Reference | Own independent PK (one-to-many) |
+
+**Key principle:** Solid lines mean the parent's identity becomes part of the child's identity. Dashed lines mean the child maintains independent identity.
+
+## Thick Solid Line: Extension (One-to-One)
+
+The foreign key **is** the entire primary key. The child extends the parent.
+
+
+```python
+@schema
+class Customer(dj.Manual):
+    definition = """
+    customer_id : uint32
+    ---
+    name : varchar(60)
+    """
+
+@schema
+class CustomerPreferences(dj.Manual):
+    definition = """
+    -> Customer               # FK is entire PK
+    ---
+    theme : varchar(20)
+    notifications : bool
+    """
+
+dj.Diagram(Customer) + dj.Diagram(CustomerPreferences)
+```
+
+
+**Equivalent ER Diagram:**
+
+<img src="/images/er-one-to-one.svg" alt="ER One-to-One" width="280">
+
+**DataJoint vs ER:** The thick solid line immediately shows this is one-to-one. In ER notation, you must read the crow's foot symbols (`||--o|`).
+
+**Note:** `CustomerPreferences` is **not underlined** — it exists in the Customer dimension space.
+
+## Thin Solid Line: Containment (One-to-Many)
+
+The foreign key is **part of** the primary key, with additional fields.
+
+
+```python
+@schema
+class Account(dj.Manual):
+    definition = """
+    -> Customer               # Part of PK
+    account_num : uint16      # Additional PK field
+    ---
+    balance : decimal(10,2)
+    """
+
+dj.Diagram(Customer) + dj.Diagram(Account)
+```
+
+
+**Equivalent ER Diagram:**
+
+<img src="/images/er-one-to-many.svg" alt="ER One-to-Many" width="280">
+
+**DataJoint vs ER:** The thin solid line shows containment — accounts belong to customers. In ER, you see `||--o{` (one-to-many).
+
+**Note:** `Account` is **underlined** — it introduces the Account dimension.
+
+## Dashed Line: Reference (One-to-Many)
+
+The foreign key is a **secondary attribute** (below the `---` line).
+
+
+```python
+@schema
+class Department(dj.Manual):
+    definition = """
+    dept_id : uint16
+    ---
+    dept_name : varchar(60)
+    """
+
+@schema
+class Employee(dj.Manual):
+    definition = """
+    employee_id : uint32      # Own independent PK
+    ---
+    -> Department             # Secondary attribute
+    employee_name : varchar(60)
+    """
+
+dj.Diagram(Department) + dj.Diagram(Employee)
+```
+
+
+**Equivalent ER Diagram:**
+
+<img src="/images/er-reference.svg" alt="ER Reference" width="280">
+
+**DataJoint vs ER:** Both show one-to-many, but DataJoint's dashed line tells you immediately that Employee has independent identity. In ER, you must examine whether the FK is part of the PK.
+
+**Note:** Both tables are **underlined** — each introduces its own dimension.
+
+## Dimensions and Underlined Names
+
+A **dimension** is a new entity type introduced by a table that defines new primary key attributes. Each underlined table introduces exactly **one** dimension—even if it has multiple new PK attributes, together they identify one new entity type.
+
+| Visual | Meaning |
+|--------|--------|
+| **Underlined** | Introduces a new dimension (new entity type) |
+| Not underlined | Exists in the space defined by dimensions from referenced tables |
+
+**Key rules:**
+- Computed tables **never** introduce dimensions (always non-underlined)
+- Part tables **can** introduce dimensions (may be underlined)
+
+
+```python
+@schema
+class Subject(dj.Manual):
+    definition = """
+    subject_id : varchar(16)  # NEW dimension
+    ---
+    species : varchar(50)
+    """
+
+@schema
+class Session(dj.Manual):
+    definition = """
+    -> Subject                # Inherits subject_id
+    session_idx : uint16      # NEW dimension
+    ---
+    session_date : date
+    """
+
+@schema 
+class SessionQC(dj.Computed):
+    definition = """
+    -> Session                # Inherits both, adds nothing
+    ---
+    passed : bool
+    """
+    def make(self, key):
+        self.insert1({**key, 'passed': True})
+
+dj.Diagram(schema)
+```
+
+
+In this diagram:
+- `Subject` is **underlined** — introduces the Subject dimension
+- `Session` is **underlined** — introduces the Session dimension (within each Subject)
+- `SessionQC` is **not underlined** — exists in the Session dimension space, adds no new dimension
+
+**Why this matters:** Dimensions determine [attribute lineage](../explanation/entity-integrity.md#dimensions-and-attribute-lineage). Primary key attributes trace back to the dimension where they originated, enabling [semantic matching](../reference/specs/semantic-matching.md) for safe joins.
+
+## Many-to-Many: Converging Lines
+
+Many-to-many relationships appear as tables with multiple solid lines converging.
+
+
+```python
+@schema
+class Student(dj.Manual):
+    definition = """
+    student_id : uint32
+    ---
+    name : varchar(60)
+    """
+
+@schema
+class Course(dj.Manual):
+    definition = """
+    course_code : char(8)
+    ---
+    title : varchar(100)
+    """
+
+@schema
+class Enrollment(dj.Manual):
+    definition = """
+    -> Student
+    -> Course
+    ---
+    grade : enum('A','B','C','D','F')
+    """
+
+dj.Diagram(Student) + dj.Diagram(Course) + dj.Diagram(Enrollment)
+```
+
+
+**Equivalent ER Diagram:**
+
+<img src="/images/er-many-to-many.svg" alt="ER Many-to-Many" width="400">
+
+**DataJoint vs ER:** Both show the association table pattern. DataJoint's converging solid lines immediately indicate the composite primary key.
+
+**Note:** `Enrollment` is **not underlined** — it exists in the space defined by Student × Course dimensions.
+
+## Orange Dots: Renamed Foreign Keys
+
+When referencing the same table multiple times, use `.proj()` to rename. **Orange dots** indicate renamed FKs.
+
+
+```python
+@schema
+class Person(dj.Manual):
+    definition = """
+    person_id : uint32
+    ---
+    name : varchar(60)
+    """
+
+@schema
+class Marriage(dj.Manual):
+    definition = """
+    marriage_id : uint32
+    ---
+    -> Person.proj(spouse1='person_id')
+    -> Person.proj(spouse2='person_id')
+    marriage_date : date
+    """
+
+dj.Diagram(Person) + dj.Diagram(Marriage)
+```
+
+
+The orange dots between `Person` and `Marriage` indicate that projections renamed the foreign key attributes (`spouse1` and `spouse2` both reference `person_id`).
+
+**Tip:** In Jupyter, hover over orange dots to see the projection expression.
+
+## Diagram Operations
+
+Filter and combine diagrams to explore large schemas:
+
+
+```python
+# Entire schema
+dj.Diagram(schema)
+```
+
+
+
+```python
+# Session and 1 level upstream (dependencies)
+dj.Diagram(Session) - 1
+```
+
+
+
+```python
+# Subject and 2 levels downstream (dependents)
+dj.Diagram(Subject) + 2
+```
+
+
+**Operation Reference:**
+
+| Operation | Meaning |
+|-----------|--------|
+| `dj.Diagram(schema)` | Entire schema |
+| `dj.Diagram(Table) - N` | Table + N levels upstream |
+| `dj.Diagram(Table) + N` | Table + N levels downstream |
+| `D1 + D2` | Union of two diagrams |
+| `D1 * D2` | Intersection (common nodes) |
+
+**Finding paths:** Use intersection to find connection paths:
+```python
+(dj.Diagram(upstream) + 100) * (dj.Diagram(downstream) - 100)
+```
+
+## What Diagrams Don't Show
+
+Diagrams do **NOT** show these FK modifiers:
+
+| Modifier | Effect | Must Check Definition |
+|----------|--------|----------------------|
+| `[nullable]` | Optional reference | `-> [nullable] Parent` |
+| `[unique]` | One-to-one on secondary FK | `-> [unique] Parent` |
+
+A dashed line could be any of:
+- Required one-to-many (default)
+- Optional one-to-many (`[nullable]`)
+- Required one-to-one (`[unique]`)
+- Optional one-to-one (`[nullable, unique]`)
+
+**Always check the table definition** to see modifiers.
+
+## DataJoint vs Traditional ER Notation
+
+| Feature | Chen's ER | Crow's Foot | DataJoint |
+|---------|-----------|-------------|----------|
+| Cardinality | Numbers | Line symbols | **Line style** |
+| Direction | None | None | **Top-to-bottom** |
+| Cycles | Allowed | Allowed | **Not allowed** |
+| PK cascade | Not shown | Not shown | **Solid lines** |
+| Identity sharing | Not indicated | Not indicated | **Thick solid** |
+| New dimensions | Not indicated | Not indicated | **Underlined** |
+
+**Why DataJoint differs:**
+
+1. **DAG structure** — No cycles means schemas read as workflows (top-to-bottom)
+2. **Line semantics** — Immediately reveals relationship type
+3. **Executable** — Diagram is generated from schema, cannot drift out of sync
+
+## Summary
+
+| Visual | Meaning |
+|--------|--------|
+| **Thick solid** | One-to-one extension |
+| **Thin solid** | One-to-many containment |
+| **Dashed** | Reference (independent identity) |
+| **Underlined** | Introduces new dimension |
+| **Orange dots** | Renamed FK via `.proj()` |
+| **Colors** | Green=Manual, Gray=Lookup, Red=Computed, Blue=Imported |
+
+## Related
+
+- [Entity Integrity: Dimensions](../explanation/entity-integrity.md#schema-dimensions)
+- [Semantic Matching](../reference/specs/semantic-matching.md)
+- [Schema Design Tutorial](../tutorials/basics/02-schema-design.ipynb)
+
+
+```python
+schema.drop(prompt=False)
+```
 
 
 ---
@@ -11066,6 +18581,295 @@ cli(["-s", "my_lab:lab"])
 
 
 ---
+## File: how-to/use-npy-codec.md
+
+# Use the `<npy>` Codec
+
+Store NumPy arrays with lazy loading and metadata access.
+
+## Overview
+
+The `<npy@>` codec stores NumPy arrays as portable `.npy` files in object storage. On fetch, you get an `NpyRef` that provides metadata without downloading.
+
+**Key benefits:**
+- Access shape, dtype, size without I/O
+- Lazy loading - download only when needed
+- Memory mapping - random access to large arrays
+- Safe bulk fetch - inspect before downloading
+- Portable `.npy` format
+
+## Quick Start
+
+### 1. Configure a Store
+
+```python
+import datajoint as dj
+
+# Add store configuration
+dj.config.object_storage.stores['mystore'] = {
+    'protocol': 's3',
+    'endpoint': 'localhost:9000',
+    'bucket': 'my-bucket',
+    'access_key': 'access_key',
+    'secret_key': 'secret_key',
+    'location': 'data',
+}
+```
+
+Or in `datajoint.json`:
+```json
+{
+  "object_storage": {
+    "stores": {
+      "mystore": {
+        "protocol": "s3",
+        "endpoint": "s3.amazonaws.com",
+        "bucket": "my-bucket",
+        "location": "data"
+      }
+    }
+  }
+}
+```
+
+### 2. Define Table with `<npy@>`
+
+```python
+@schema
+class Recording(dj.Manual):
+    definition = """
+    recording_id : int32
+    ---
+    waveform : <npy@mystore>
+    """
+```
+
+### 3. Insert Arrays
+
+```python
+import numpy as np
+
+Recording.insert1({
+    'recording_id': 1,
+    'waveform': np.random.randn(1000, 32),
+})
+```
+
+### 4. Fetch with Lazy Loading
+
+```python
+# Returns NpyRef, not array
+ref = (Recording & 'recording_id=1').fetch1('waveform')
+
+# Metadata without download
+print(ref.shape)   # (1000, 32)
+print(ref.dtype)   # float64
+
+# Load when ready
+arr = ref.load()
+```
+
+## NpyRef Reference
+
+### Metadata Properties (No I/O)
+
+```python
+ref.shape      # Tuple of dimensions
+ref.dtype      # NumPy dtype
+ref.ndim       # Number of dimensions
+ref.size       # Total elements
+ref.nbytes     # Total bytes
+ref.path       # Storage path
+ref.store      # Store name
+ref.is_loaded  # Whether data is cached
+```
+
+### Loading Methods
+
+```python
+# Explicit load (recommended)
+arr = ref.load()
+
+# Via NumPy functions (auto-loads)
+mean = np.mean(ref)
+std = np.std(ref, axis=0)
+
+# Via conversion (auto-loads)
+arr = np.asarray(ref)
+
+# Indexing (loads then indexes)
+first_row = ref[0]
+snippet = ref[100:200, :]
+```
+
+### Memory Mapping
+
+For large arrays, use `mmap_mode` to access data without loading it all into memory:
+
+```python
+# Memory-mapped loading (random access)
+arr = ref.load(mmap_mode='r')
+
+# Only reads the portion you access
+slice = arr[1000:2000, :]  # Efficient for large arrays
+```
+
+**Modes:**
+- `'r'` - Read-only (recommended)
+- `'r+'` - Read-write
+- `'c'` - Copy-on-write (changes not saved)
+
+**Performance:**
+- Local filesystem stores: mmaps directly (no copy)
+- Remote stores (S3): downloads to cache first, then mmaps
+
+## Common Patterns
+
+### Bulk Fetch with Filtering
+
+```python
+# Fetch all - returns NpyRefs, not arrays
+results = MyTable.to_dicts()
+
+# Filter by metadata (no downloads)
+large = [r for r in results if r['data'].shape[0] > 1000]
+
+# Load only what you need
+for rec in large:
+    arr = rec['data'].load()
+    process(arr)
+```
+
+### Computed Tables
+
+```python
+@schema
+class ProcessedData(dj.Computed):
+    definition = """
+    -> RawData
+    ---
+    result : <npy@mystore>
+    """
+
+    def make(self, key):
+        # Fetch lazy reference
+        ref = (RawData & key).fetch1('raw')
+
+        # NumPy functions auto-load
+        result = np.fft.fft(ref, axis=1)
+
+        self.insert1({**key, 'result': result})
+```
+
+### Memory-Efficient Processing
+
+```python
+# Process recordings one at a time
+for key in Recording.keys():
+    ref = (Recording & key).fetch1('data')
+
+    # Check size before loading
+    if ref.nbytes > 1e9:  # > 1 GB
+        print(f"Skipping large recording: {ref.nbytes/1e9:.1f} GB")
+        continue
+
+    process(ref.load())
+```
+
+## Comparison with `<blob@>`
+
+| Aspect | `<npy@>` | `<blob@>` |
+|--------|----------|----------|
+| **On fetch** | NpyRef (lazy) | Array (eager) |
+| **Metadata access** | Without download | Must download |
+| **Memory mapping** | Yes, via `mmap_mode` | No |
+| **Addressing** | Schema-addressed | Hash-addressed |
+| **Deduplication** | No | Yes |
+| **Format** | `.npy` (portable) | DJ blob (Python) |
+| **Best for** | Large arrays, lazy loading | Small arrays, dedup |
+
+### When to Use Each
+
+**Use `<npy@>` when:**
+- Arrays are large (> 10 MB)
+- You need to inspect shape/dtype before loading
+- Fetching many rows but processing few
+- Random access to slices of very large arrays (memory mapping)
+- Interoperability matters (non-Python tools)
+
+**Use `<blob@>` when:**
+- Arrays are small (< 10 MB)
+- Same arrays appear in multiple rows (deduplication)
+- Storing non-array Python objects (dicts, lists)
+
+## Supported Array Types
+
+The `<npy>` codec supports any NumPy array except object dtype:
+
+```python
+# Supported
+np.array([1, 2, 3], dtype=np.int32)          # Integer
+np.array([1.0, 2.0], dtype=np.float64)       # Float
+np.array([True, False], dtype=np.bool_)      # Boolean
+np.array([1+2j, 3+4j], dtype=np.complex128)  # Complex
+np.zeros((10, 10, 10))                       # N-dimensional
+np.array(42)                                 # 0-dimensional scalar
+
+# Structured arrays
+dt = np.dtype([('x', np.float64), ('y', np.float64)])
+np.array([(1.0, 2.0), (3.0, 4.0)], dtype=dt)
+
+# NOT supported
+np.array([{}, []], dtype=object)  # Object dtype
+```
+
+## Troubleshooting
+
+### "Store not configured"
+
+Ensure your store is configured before using `<npy@store>`:
+
+```python
+dj.config.object_storage.stores['store'] = {...}
+```
+
+### "requires @ (store only)"
+
+The `<npy>` codec requires the `@` modifier:
+
+```python
+# Wrong
+data : <npy>
+
+# Correct
+data : <npy@>
+data : <npy@mystore>
+```
+
+### Memory issues with large arrays
+
+Use lazy loading or memory mapping to control memory:
+
+```python
+# Check size before loading
+if ref.nbytes > available_memory:
+    # Use memory mapping for random access
+    arr = ref.load(mmap_mode='r')
+    # Process in chunks
+    for i in range(0, len(arr), chunk_size):
+        process(arr[i:i+chunk_size])
+else:
+    arr = ref.load()
+```
+
+## See Also
+
+- [Use Object Storage](use-object-storage.md) - Complete storage guide
+- [Configure Object Storage](configure-storage.md) - Store setup
+- [`<npy>` Codec Specification](../reference/specs/npy-codec.md) - Full spec
+
+
+---
 ## File: how-to/use-object-storage.md
 
 # Use Object Storage
@@ -11076,13 +18880,14 @@ Store large data objects as part of your Object-Augmented Schema.
 
 An **Object-Augmented Schema** extends relational tables with object storage as a unified system. The relational database stores metadata, references, and small values while large objects (arrays, files, datasets) are stored in object storage. DataJoint maintains referential integrity across both storage layers—when you delete a row, its associated objects are cleaned up automatically.
 
-OAS supports three storage sections:
+OAS supports two addressing schemes:
 
-| Section | Location | Addressing | Use Case |
-|---------|----------|------------|----------|
-| **Internal** | Database | Row-based | Small objects (< 1 MB) |
-| **Hash-addressed** | Object store | Content hash | Arrays, files (deduplication) |
-| **Path-addressed** | Object store | Primary key path | Zarr, HDF5, streaming access |
+| Addressing | Location | Path Derived From | Use Case |
+|------------|----------|-------------------|----------|
+| **Hash-addressed** | Object store | Content hash (MD5) | Blobs, attachments (with deduplication) |
+| **Schema-addressed** | Object store | Schema structure | NumPy arrays, Zarr, HDF5 (browsable paths) |
+
+Data can also be stored **inline** directly in the database column (no `@` modifier).
 
 For complete details, see the [Type System specification](../reference/specs/type-system.md).
 
@@ -11095,7 +18900,7 @@ Use the `@` modifier for:
 - Zarr arrays and HDF5 files
 - Any data too large for efficient database storage
 
-## Internal vs Object Storage
+## Inline vs Object Store
 
 ```python
 @schema
@@ -11103,15 +18908,17 @@ class Recording(dj.Manual):
     definition = """
     recording_id : uuid
     ---
-    metadata : <blob>           # Internal: stored in database
-    raw_data : <blob@>          # Object storage: stored externally
+    metadata : <blob>           # Inline: stored in database column
+    raw_data : <blob@>          # Object store: hash-addressed
+    waveforms : <npy@>          # Object store: schema-addressed (lazy)
     """
 ```
 
 | Syntax | Storage | Best For |
 |--------|---------|----------|
 | `<blob>` | Database | Small objects (< 1 MB) |
-| `<blob@>` | Default store | Large objects |
+| `<blob@>` | Default store | Large objects (hash-addressed) |
+| `<npy@>` | Default store | NumPy arrays (schema-addressed, lazy) |
 | `<blob@store>` | Named store | Specific storage tier |
 
 ## Store Data
@@ -11158,10 +18965,17 @@ Configure stores in `datajoint.json`:
 
 ```json
 {
-  "object_storage": {
-    "stores": {
-      "raw": {"protocol": "file", "location": "/fast/storage"},
-      "archive": {"protocol": "s3", "bucket": "archive", ...}
+  "stores": {
+    "default": "raw",
+    "raw": {
+      "protocol": "file",
+      "location": "/fast/storage"
+    },
+    "archive": {
+      "protocol": "s3",
+      "endpoint": "s3.amazonaws.com",
+      "bucket": "archive",
+      "location": "project-data"
     }
   }
 }
@@ -11171,7 +18985,7 @@ Configure stores in `datajoint.json`:
 
 `<blob@>` and `<attach@>` use **hash-addressed** storage:
 
-- Objects are stored by their content hash (SHA-256)
+- Objects are stored by their content hash (MD5)
 - Identical data is stored once (automatic deduplication)
 - Multiple rows can reference the same object
 - Immutable—changing data creates a new object
@@ -11183,14 +18997,14 @@ Table.insert1({'id': 1, 'array': data})
 Table.insert1({'id': 2, 'array': data})  # References same object
 ```
 
-## Path-Addressed Storage
+## Schema-Addressed Storage
 
-`<object@>` uses **path-addressed** storage for file-like objects:
+`<npy@>` and `<object@>` use **schema-addressed** storage:
 
-- Objects stored at predictable paths based on primary key
-- Path format: `{schema}/{table}/{pk_hash}/{attribute}/`
-- Supports streaming access and partial reads
-- Mutable—can update in place (e.g., append to Zarr)
+- Objects stored at paths that mirror database schema: `{schema}/{table}/{pk}/{attribute}.npy`
+- Browsable organization in object storage
+- One object per entity (no deduplication)
+- Supports lazy loading with metadata access
 
 ```python
 @schema
@@ -11278,6 +19092,66 @@ Document.insert1({
 })
 ```
 
+## NumPy Arrays with `<npy@>`
+
+The `<npy@>` codec stores NumPy arrays as portable `.npy` files with lazy loading:
+
+```python
+@schema
+class Recording(dj.Manual):
+    definition = """
+    recording_id : int32
+    ---
+    waveform : <npy@mystore>    # NumPy array, schema-addressed
+    """
+
+# Insert - just pass the array
+Recording.insert1({
+    'recording_id': 1,
+    'waveform': np.random.randn(1000, 32),
+})
+
+# Fetch returns NpyRef (lazy)
+ref = (Recording & 'recording_id=1').fetch1('waveform')
+```
+
+### NpyRef: Lazy Array Reference
+
+`NpyRef` provides metadata without downloading:
+
+```python
+ref = (Recording & key).fetch1('waveform')
+
+# Metadata access - NO download
+ref.shape    # (1000, 32)
+ref.dtype    # float64
+ref.nbytes   # 256000
+ref.is_loaded  # False
+
+# Explicit loading
+arr = ref.load()    # Downloads and caches
+ref.is_loaded       # True
+
+# Numpy integration (triggers download)
+result = np.mean(ref)           # Uses __array__ protocol
+result = np.asarray(ref) + 1    # Convert then operate
+```
+
+### Bulk Fetch Safety
+
+Fetching many rows doesn't download until you access each array:
+
+```python
+# Fetch 1000 recordings - NO downloads yet
+results = Recording.to_dicts()
+
+# Inspect metadata without downloading
+for rec in results:
+    ref = rec['waveform']
+    if ref.shape[0] > 500:     # Check without download
+        process(ref.load())     # Download only what you need
+```
+
 ## Lazy Loading with ObjectRef
 
 `<object@>` and `<filepath@>` return lazy references:
@@ -11297,18 +19171,19 @@ local_path = ref.download('/tmp/data')
 
 ### Choose the Right Codec
 
-| Data Type | Codec | Storage |
-|-----------|-------|---------|
-| NumPy arrays | `<blob@>` | Hash-addressed |
-| File attachments | `<attach@>` | Hash-addressed |
-| Zarr/HDF5 | `<object@>` | Path-addressed |
-| File references | `<filepath@>` | Path-addressed |
+| Data Type | Codec | Addressing | Lazy | Best For |
+|-----------|-------|------------|------|----------|
+| NumPy arrays | `<npy@>` | Schema | Yes | Arrays needing lazy load, metadata inspection |
+| Python objects | `<blob@>` | Hash | No | Dicts, lists, small arrays (with dedup) |
+| File attachments | `<attach@>` | Hash | No | Files with original filename preserved |
+| Zarr/HDF5 | `<object@>` | Schema | Yes | Chunked arrays, streaming access |
+| File references | `<filepath@>` | External | Yes | References to external files |
 
 ### Size Guidelines
 
-- **< 1 MB**: Internal storage (`<blob>`) is fine
-- **1 MB - 1 GB**: Object storage (`<blob@>`)
-- **> 1 GB**: Path-addressed (`<object@>`) for streaming
+- **< 1 MB**: Inline storage (`<blob>`) is fine
+- **1 MB - 1 GB**: Object store (`<npy@>` or `<blob@>`)
+- **> 1 GB**: Schema-addressed (`<npy@>`, `<object@>`) for lazy loading
 
 ### Store Tiers
 
@@ -11316,11 +19191,23 @@ Configure stores for different access patterns:
 
 ```json
 {
-  "object_storage": {
-    "stores": {
-      "hot": {"protocol": "file", "location": "/ssd/data"},
-      "warm": {"protocol": "s3", "bucket": "project-data"},
-      "cold": {"protocol": "s3", "bucket": "archive", ...}
+  "stores": {
+    "default": "hot",
+    "hot": {
+      "protocol": "file",
+      "location": "/ssd/data"
+    },
+    "warm": {
+      "protocol": "s3",
+      "endpoint": "s3.amazonaws.com",
+      "bucket": "project-data",
+      "location": "active"
+    },
+    "cold": {
+      "protocol": "s3",
+      "endpoint": "s3.amazonaws.com",
+      "bucket": "archive",
+      "location": "long-term"
     }
   }
 }
@@ -11362,24 +19249,139 @@ Configuration is loaded in priority order:
 | `database.port` | `DJ_PORT` | `3306` | MySQL server port |
 | `database.user` | `DJ_USER` | — | Database username |
 | `database.password` | `DJ_PASS` | — | Database password |
+| `database.reconnect` | — | `True` | Auto-reconnect on connection loss |
+| `database.use_tls` | — | `None` | Enable TLS encryption |
 
-## Object Storage Settings
+## Connection Settings
 
-| Setting | Environment | Default | Description |
-|---------|-------------|---------|-------------|
-| `stores.default` | — | — | Default store name |
-| `stores.<name>.protocol` | — | `file` | Storage protocol (file, s3, gs) |
-| `stores.<name>.endpoint` | — | — | S3-compatible endpoint URL |
-| `stores.<name>.bucket` | — | — | Bucket or root path |
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `connection.init_function` | `None` | SQL function to run on connect |
+| `connection.charset` | `""` | Character set (pymysql default) |
+
+## Stores Configuration
+
+Unified storage configuration for all external storage types (`<blob@>`, `<attach@>`, `<filepath@>`, `<object@>`, `<npy@>`).
+
+**Default stores:**
+
+DataJoint uses two default settings to reflect the architectural distinction between integrated and reference storage:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `stores.default` | — | Default store for integrated storage (`<blob@>`, `<attach@>`, `<object@>`, `<npy@>`) |
+| `stores.filepath_default` | — | Default store for filepath references (`<filepath@>`) — often different from `stores.default` |
+
+**Why separate defaults?** Hash and schema-addressed storage are integrated into the Object-Augmented Schema (OAS)—DataJoint manages paths, lifecycle, and integrity. Filepath storage is user-managed references to existing files—DataJoint only stores the path. These are architecturally distinct and often use different storage locations.
+
+**Common settings (all protocols):**
+
+| Setting | Required | Description |
+|---------|----------|-------------|
+| `stores.<name>.protocol` | Yes | Storage protocol: `file`, `s3`, `gcs`, `azure` |
+| `stores.<name>.location` | Yes | Base path or prefix (includes project context) |
+| `stores.<name>.hash_prefix` | No | Path prefix for hash-addressed section (default: `"_hash"`) |
+| `stores.<name>.schema_prefix` | No | Path prefix for schema-addressed section (default: `"_schema"`) |
+| `stores.<name>.filepath_prefix` | No | Required path prefix for filepath section, or `null` for unrestricted (default: `null`) |
+| `stores.<name>.subfolding` | No | Directory nesting for hash-addressed storage, e.g., `[2, 2]` (default: no subfolding) |
+| `stores.<name>.partition_pattern` | No | Path partitioning for schema-addressed storage, e.g., `"subject_id/session_date"` (default: no partitioning) |
+| `stores.<name>.token_length` | No | Random token length for schema-addressed filenames (default: `8`) |
+
+**Storage sections:**
+
+Each store is divided into sections defined by prefix configuration. The `*_prefix` parameters set the path prefix for each storage section:
+
+- **`hash_prefix`**: Defines the hash-addressed section for `<blob@>` and `<attach@>` (default: `"_hash"`)
+- **`schema_prefix`**: Defines the schema-addressed section for `<object@>` and `<npy@>` (default: `"_schema"`)
+- **`filepath_prefix`**: Optionally restricts the filepath section for `<filepath@>` (default: `null` = unrestricted)
+
+Prefixes must be mutually exclusive (no prefix can be a parent/child of another). This allows mapping DataJoint to existing storage layouts:
+
+```json
+{
+  "stores": {
+    "legacy": {
+      "protocol": "file",
+      "location": "/data/existing_storage",
+      "hash_prefix": "content_addressed",      // Path prefix for hash section
+      "schema_prefix": "structured_data",       // Path prefix for schema section
+      "filepath_prefix": "raw_files"            // Path prefix for filepath section
+    }
+  }
+}
+```
+
+**S3-specific settings:**
+
+| Setting | Required | Description |
+|---------|----------|-------------|
+| `stores.<name>.endpoint` | Yes | S3 endpoint URL (e.g., `s3.amazonaws.com`) |
+| `stores.<name>.bucket` | Yes | Bucket name |
+| `stores.<name>.access_key` | Yes | S3 access key ID |
+| `stores.<name>.secret_key` | Yes | S3 secret access key |
+| `stores.<name>.secure` | No | Use HTTPS (default: `True`) |
+
+**GCS-specific settings:**
+
+| Setting | Required | Description |
+|---------|----------|-------------|
+| `stores.<name>.bucket` | Yes | GCS bucket name |
+| `stores.<name>.token` | Yes | Authentication token path |
+| `stores.<name>.project` | No | GCS project ID |
+
+**Azure-specific settings:**
+
+| Setting | Required | Description |
+|---------|----------|-------------|
+| `stores.<name>.container` | Yes | Azure container name |
+| `stores.<name>.account_name` | Yes | Storage account name |
+| `stores.<name>.account_key` | Yes | Storage account key |
+| `stores.<name>.connection_string` | No | Alternative to account_name + account_key |
+
+**How storage methods use stores:**
+
+- **Hash-addressed** (`<blob@>`, `<attach@>`): `{location}/{hash_prefix}/{schema}/{hash}` with optional subfolding
+- **Schema-addressed** (`<object@>`, `<npy@>`): `{location}/{schema_prefix}/{partition}/{schema}/{table}/{key}/{field}.{token}.{ext}` with optional partitioning
+- **Filepath** (`<filepath@>`): `{location}/{filepath_prefix}/{user_path}` (user-managed, cannot use hash or schema prefixes)
+
+All storage methods share the same stores and default store. DataJoint reserves the configured `hash_prefix` and `schema_prefix` sections for managed storage; `<filepath@>` references can use any other paths (unless `filepath_prefix` is configured to restrict them).
+
+**Path structure examples:**
+
+Without partitioning:
+```
+{location}/_hash/{schema}/ab/cd/abcd1234...                    # hash-addressed with subfolding
+{location}/_schema/{schema}/{table}/{key}/data.x8f2a9b1.zarr   # schema-addressed, no partitioning
+```
+
+With `partition_pattern: "subject_id/session_date"`:
+```
+{location}/_schema/subject_id=042/session_date=2024-01-15/{schema}/{table}/{remaining_key}/data.x8f2a9b1.zarr
+```
+
+If table lacks partition attributes, it follows normal path structure.
+
+**Credentials should be stored in secrets:**
+
+```
+.secrets/
+├── stores.main.access_key
+├── stores.main.secret_key
+├── stores.archive.access_key
+└── stores.archive.secret_key
+```
 
 ## Jobs Settings
 
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `jobs.auto_refresh` | `True` | Auto-refresh job queue on populate |
-| `jobs.keep_completed` | `False` | Retain success records |
+| `jobs.keep_completed` | `False` | Retain success records in jobs table |
 | `jobs.stale_timeout` | `3600` | Seconds before stale job cleanup |
+| `jobs.default_priority` | `5` | Default priority (0-255, lower = more urgent) |
+| `jobs.version_method` | `None` | Version tracking: `git`, `none`, or `None` (disabled) |
 | `jobs.add_job_metadata` | `False` | Add hidden metadata to computed tables |
+| `jobs.allow_new_pk_fields_in_computed_tables` | `False` | Allow non-FK primary key fields |
 
 ## Display Settings
 
@@ -11387,20 +19389,49 @@ Configuration is loaded in priority order:
 |---------|---------|-------------|
 | `display.limit` | `12` | Max rows to display |
 | `display.width` | `14` | Column width |
+| `display.show_tuple_count` | `True` | Show row count in output |
+
+## Top-Level Settings
+
+| Setting | Environment | Default | Description |
+|---------|-------------|---------|-------------|
+| `loglevel` | `DJ_LOG_LEVEL` | `INFO` | Log level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |
+| `safemode` | — | `True` | Require confirmation for destructive operations |
+| `enable_python_native_blobs` | — | `True` | Allow Python-native blob serialization |
+| `cache` | — | `None` | Path for query result cache |
+| `query_cache` | — | `None` | Path for compiled query cache |
+| `download_path` | — | `.` | Download location for attachments/filepaths |
 
 ## Example Configuration
 
-### datajoint.json
+### datajoint.json (Non-sensitive settings)
 
 ```json
 {
     "database.host": "mysql.example.com",
     "database.port": 3306,
     "stores": {
+        "default": "main",
+        "filepath_default": "raw_data",
         "main": {
             "protocol": "s3",
             "endpoint": "s3.amazonaws.com",
-            "bucket": "my-data-bucket"
+            "bucket": "datajoint-bucket",
+            "location": "neuroscience-lab/production",
+            "partition_pattern": "subject_id/session_date",
+            "token_length": 8
+        },
+        "archive": {
+            "protocol": "s3",
+            "endpoint": "s3.amazonaws.com",
+            "bucket": "archive-bucket",
+            "location": "neuroscience-lab/long-term",
+            "subfolding": [2, 2]
+        },
+        "raw_data": {
+            "protocol": "file",
+            "location": "/mnt/acquisition",
+            "filepath_prefix": "recordings"
         }
     },
     "jobs": {
@@ -11409,22 +19440,34 @@ Configuration is loaded in priority order:
 }
 ```
 
-### Environment Variables
+### .secrets/ (Credentials - never commit!)
+
+```
+.secrets/
+├── database.user                      # analyst
+├── database.password                  # dbpass123
+├── stores.main.access_key             # AKIAIOSFODNN7EXAMPLE
+├── stores.main.secret_key             # wJalrXUtnFEMI/K7MDENG...
+├── stores.archive.access_key          # AKIAIOSFODNN8EXAMPLE
+└── stores.archive.secret_key          # xKbmsYVuoGFNJ/L8NEOH...
+```
+
+Add `.secrets/` to `.gitignore`:
 
 ```bash
+echo ".secrets/" >> .gitignore
+```
+
+### Environment Variables (Alternative to .secrets/)
+
+```bash
+# Database
 export DJ_HOST=mysql.example.com
 export DJ_USER=analyst
 export DJ_PASS=secret
 ```
 
-### Secrets Directory
-
-```
-.secrets/
-├── database.user      # Contains: analyst
-├── database.password  # Contains: secret
-└── aws.access_key_id  # Contains: AKIA...
-```
+**Note:** Per-store credentials must be configured in `datajoint.json` or `.secrets/` — environment variable overrides are not supported for nested store configurations.
 
 ## API Reference
 
@@ -11796,6 +19839,7 @@ Detailed specifications of DataJoint's behavior and semantics.
 - [Semantic Matching](specs/semantic-matching.md) — Attribute lineage and homologous matching
 - [Type System](specs/type-system.md) — Core types, codecs, and storage modes
 - [Codec API](specs/codec-api.md) — Creating custom attribute types
+- [Object Store Configuration](specs/object-store-configuration.md) — Store configuration, path generation, and integrated storage models
 - [AutoPopulate](specs/autopopulate.md) — Jobs 2.0 specification
 - [Fetch API](specs/fetch-api.md) — Data retrieval methods
 - [Job Metadata](specs/job-metadata.md) — Hidden job tracking columns
@@ -11806,6 +19850,12 @@ Detailed specifications of DataJoint's behavior and semantics.
 - [Definition Syntax](definition-syntax.md) — Table definition grammar
 - [Operators](operators.md) — Query operator summary
 - [Errors](errors.md) — Exception types and meanings
+
+## Elements
+
+Curated pipeline modules for neurophysiology experiments.
+
+- [DataJoint Elements](../elements/index.md) — Pre-built pipelines for calcium imaging, electrophysiology, behavior tracking, and more
 
 ## API Documentation
 
@@ -12138,17 +20188,13 @@ Student * Course.proj(..., course_name='name')
 
 - [Query Algebra Specification](specs/query-algebra.md) — Complete formal specification
 - [Fetch API](specs/fetch-api.md) — Retrieving query results
-- [Queries Tutorial](../tutorials/04-queries.ipynb) — Hands-on examples
+- [Queries Tutorial](../tutorials/basics/04-queries.ipynb) — Hands-on examples
 
 
 ---
 ## File: reference/specs/autopopulate.md
 
 # AutoPopulate Specification
-
-Version: 2.0
-Status: Draft
-Last Updated: 2026-01-07
 
 ## Overview
 
@@ -12465,6 +20511,10 @@ def make(self, key):
     combined = (TableA * TableB & key).to_dicts()
 ```
 
+**Upstream-only convention:** Inside `make()`, fetch only from tables that are strictly upstream in the pipeline—tables referenced by foreign keys in the definition, their ancestors, and their part tables. This ensures reproducibility: computed results depend only on their declared dependencies.
+
+This convention is not currently enforced programmatically but is critical for pipeline integrity. Some pipelines violate this rule for operational reasons, which makes them non-reproducible. A future release may programmatically enforce upstream-only fetches inside `make()`.
+
 ### 4.4 Tripartite Make Pattern
 
 For long-running computations, use the tripartite pattern to separate fetch, compute, and insert phases. This enables better transaction management for jobs that take minutes or hours.
@@ -12539,6 +20589,13 @@ class ConfigurableAnalysis(dj.Computed):
 ConfigurableAnalysis.populate(make_kwargs={'threshold': 0.8})
 ```
 
+**Anti-pattern warning:** Passing arguments that affect the computed result breaks reproducibility—all inputs should come from `fetch` calls inside `make()`. If a parameter affects results, it should be stored in a lookup table and referenced via foreign key.
+
+**Acceptable use:** Directives that don't affect results, such as:
+- `verbose=True` for logging
+- `gpu_id=0` for device selection
+- `n_workers=4` for parallelization
+
 ---
 
 ## 5. Transaction Management
@@ -12588,18 +20645,19 @@ BEGIN TRANSACTION
 COMMIT
 ```
 
-**Tripartite make (two transactions):**
+**Tripartite make (single transaction):**
 ```
-BEGIN TRANSACTION 1
-  └── make_fetch(key) or yield point 1
-COMMIT
+[No transaction]
+  ├── make_fetch(key)           # Fetch source data
+  └── make_compute(key, data)   # Long-running computation
 
-[No transaction - computation runs here]
-
-BEGIN TRANSACTION 2
-  └── make_insert(key, result) or yield point 2
+BEGIN TRANSACTION
+  ├── make_fetch(key)           # Repeat fetch, verify unchanged
+  └── make_insert(key, result)  # Insert computed result
 COMMIT
 ```
+
+This pattern allows long computations without holding database locks, while ensuring data consistency by verifying the source data hasn't changed before inserting.
 
 ### 5.4 Nested Operations
 
@@ -12830,9 +20888,41 @@ version : varchar(255)              # Code version
 |--------|-------------|
 | `pending` | Queued and ready to process |
 | `reserved` | Currently being processed by a worker |
-| `success` | Completed successfully (optional retention) |
+| `success` | Completed successfully (when `jobs.keep_completed=True`) |
 | `error` | Failed with error details |
 | `ignore` | Manually marked to skip |
+
+```mermaid
+stateDiagram-v2
+    state "(none)" as none1
+    state "(none)" as none2
+    none1 --> pending : refresh()
+    none1 --> ignore : ignore()
+    pending --> reserved : reserve()
+    reserved --> none2 : complete()
+    reserved --> success : complete()*
+    reserved --> error : error()
+    success --> pending : refresh()*
+    error --> none2 : delete()
+    success --> none2 : delete()
+    ignore --> none2 : delete()
+```
+
+**Transitions:**
+
+| Method | Description |
+|--------|-------------|
+| `refresh()` | Adds new jobs as `pending`; re-pends `success` jobs if key is in `key_source` but not in target |
+| `ignore()` | Marks a key as `ignore` (can be called on keys not yet in jobs table) |
+| `reserve()` | Marks a `pending` job as `reserved` before calling `make()` |
+| `complete()` | Deletes job (default) or marks as `success` (when `jobs.keep_completed=True`) |
+| `error()` | Marks `reserved` job as `error` with message and stack trace |
+| `delete()` | Removes job entry; use `(jobs & condition).delete()` pattern |
+
+**Notes:**
+
+- `ignore` is set manually via `jobs.ignore(key)` and skipped by `populate()` and `refresh()`
+- To reset an ignored job: `jobs.ignored.delete(); jobs.refresh()`
 
 ### 9.4 Jobs API
 
@@ -13025,28 +21115,9 @@ slow = Analysis & '_job_duration > 3600'
 
 ---
 
-## 15. Migration from Earlier Versions
+## 15. Migration from Legacy DataJoint
 
-### 15.1 Changes from DataJoint 1.x
-
-DataJoint 2.0 replaces the schema-level `~jobs` table with per-table jobs:
-
-| Feature | 1.x | 2.0 |
-|---------|-----|-----|
-| Jobs table | Schema-level `~jobs` | Per-table `~~table_name` |
-| Key storage | Hashed | Native (readable) |
-| Statuses | `reserved`, `error`, `ignore` | + `pending`, `success` |
-
-### 15.2 Migration Steps
-
-1. Complete or clear pending work in the old system
-2. Export error records if needed for reference
-3. Use new system: `populate(reserve_jobs=True)` creates new jobs tables
-
-```python
-# New system auto-creates jobs tables
-Analysis.populate(reserve_jobs=True)
-```
+DataJoint 2.0 replaces the schema-level `~jobs` table with per-table `~~table_name` jobs tables. See the [Migration Guide](../../how-to/migrate-to-v20.md) for details.
 
 ---
 
@@ -13108,10 +21179,11 @@ def make_insert(self, key, result): self.insert1(...)
 ---
 ## File: reference/specs/codec-api.md
 
-# Codec Specification
+# Codec API Specification
 
-This document specifies the DataJoint Codec API for creating custom attribute types
-that extend DataJoint's native type system.
+This document specifies the DataJoint Codec API for creating custom attribute types.
+For the complete type system architecture (core types, built-in codecs, storage modes),
+see the [Type System Specification](type-system.md).
 
 ## Overview
 
@@ -13119,15 +21191,24 @@ Codecs define bidirectional conversion between Python objects and database stora
 They enable storing complex data types (graphs, models, custom formats) while
 maintaining DataJoint's query capabilities.
 
-```
-┌─────────────────┐                    ┌─────────────────┐
-│  Python Object  │  ──── encode ────► │  Storage Type   │
-│   (e.g. Graph)  │                    │  (e.g. bytes)   │
-│                 │  ◄─── decode ────  │                 │
-└─────────────────┘                    └─────────────────┘
+```mermaid
+flowchart LR
+    A["Python Object<br/>(e.g. Graph)"] -- encode --> B["Storage Type<br/>(e.g. bytes)"]
+    B -- decode --> A
 ```
 
-## Quick Start
+## Two Patterns for Custom Codecs
+
+There are two approaches for creating custom codecs:
+
+| Pattern | When to Use | Base Class |
+|---------|-------------|------------|
+| **Type Chaining** | Transform Python objects, use existing storage | `dj.Codec` |
+| **SchemaCodec Subclassing** | Custom file formats with schema-addressed paths | `dj.SchemaCodec` |
+
+### Pattern 1: Type Chaining (Most Common)
+
+Chain to an existing codec for storage. Your codec transforms objects; the chained codec handles storage.
 
 ```python
 import datajoint as dj
@@ -13138,7 +21219,7 @@ class GraphCodec(dj.Codec):
 
     name = "graph"  # Use as <graph> in definitions
 
-    def get_dtype(self, is_external: bool) -> str:
+    def get_dtype(self, is_store: bool) -> str:
         return "<blob>"  # Delegate to blob for serialization
 
     def encode(self, graph, *, key=None, store_name=None):
@@ -13159,7 +21240,47 @@ class Connectivity(dj.Manual):
     definition = '''
     conn_id : int
     ---
-    network : <graph>
+    network : <graph>      # inline storage
+    network_ext : <graph@>  # object store
+    '''
+```
+
+### Pattern 2: SchemaCodec Subclassing (File Formats)
+
+For custom file formats that need schema-addressed storage paths.
+
+```python
+import datajoint as dj
+
+class ParquetCodec(dj.SchemaCodec):
+    """Store DataFrames as Parquet files."""
+
+    name = "parquet"
+
+    # get_dtype inherited: returns "json", requires @
+
+    def encode(self, df, *, key=None, store_name=None):
+        import io
+        schema, table, field, pk = self._extract_context(key)
+        path, _ = self._build_path(schema, table, field, pk, ext=".parquet")
+        backend = self._get_backend(store_name)
+
+        buffer = io.BytesIO()
+        df.to_parquet(buffer)
+        backend.put_buffer(buffer.getvalue(), path)
+
+        return {"path": path, "store": store_name, "shape": list(df.shape)}
+
+    def decode(self, stored, *, key=None):
+        return ParquetRef(stored, self._get_backend(stored.get("store")))
+
+# Use in table definition (store only)
+@schema
+class Results(dj.Manual):
+    definition = '''
+    result_id : int
+    ---
+    data : <parquet@>
     '''
 ```
 
@@ -13173,7 +21294,7 @@ class Codec(ABC):
 
     name: str | None = None  # Required: unique identifier
 
-    def get_dtype(self, is_external: bool) -> str:
+    def get_dtype(self, is_store: bool) -> str:
         """Return the storage dtype."""
         raise NotImplementedError
 
@@ -13190,6 +21311,33 @@ class Codec(ABC):
     def validate(self, value) -> None:
         """Optional: validate value before encoding."""
         pass
+```
+
+## The SchemaCodec Base Class
+
+For schema-addressed storage (file formats), inherit from `dj.SchemaCodec`:
+
+```python
+class SchemaCodec(Codec, register=False):
+    """Base class for schema-addressed codecs."""
+
+    def get_dtype(self, is_store: bool) -> str:
+        """Store only, returns 'json'."""
+        if not is_store:
+            raise DataJointError(f"<{self.name}> requires @ (store only)")
+        return "json"
+
+    def _extract_context(self, key: dict) -> tuple[str, str, str, dict]:
+        """Parse key into (schema, table, field, primary_key)."""
+        ...
+
+    def _build_path(self, schema, table, field, pk, ext=None) -> tuple[str, str]:
+        """Build schema-addressed path: {schema}/{table}/{pk}/{field}{ext}"""
+        ...
+
+    def _get_backend(self, store_name: str = None):
+        """Get storage backend by name."""
+        ...
 ```
 
 ## Required Components
@@ -13211,21 +21359,21 @@ Naming conventions:
 
 ### 2. The `get_dtype()` Method
 
-Returns the underlying storage type. The `is_external` parameter indicates whether
+Returns the underlying storage type. The `is_store` parameter indicates whether
 the `@` modifier is present in the table definition:
 
 ```python
-def get_dtype(self, is_external: bool) -> str:
+def get_dtype(self, is_store: bool) -> str:
     """
     Args:
-        is_external: True if @ modifier present (e.g., <mycodec@store>)
+        is_store: True if @ modifier present (e.g., <mycodec@store>)
 
     Returns:
         - A core type: "bytes", "json", "varchar(N)", "int32", etc.
         - Another codec: "<blob>", "<hash>", etc.
 
     Raises:
-        DataJointError: If external storage not supported but @ is present
+        DataJointError: If store not supported but @ is present
     """
 ```
 
@@ -13233,17 +21381,17 @@ Examples:
 
 ```python
 # Simple: always store as bytes
-def get_dtype(self, is_external: bool) -> str:
+def get_dtype(self, is_store: bool) -> str:
     return "bytes"
 
-# Different behavior for internal/external
-def get_dtype(self, is_external: bool) -> str:
-    return "<hash>" if is_external else "bytes"
+# Different behavior for inline/store
+def get_dtype(self, is_store: bool) -> str:
+    return "<hash>" if is_store else "bytes"
 
-# External-only codec
-def get_dtype(self, is_external: bool) -> str:
-    if not is_external:
-        raise DataJointError("<object> requires @ (external storage only)")
+# Store-only codec
+def get_dtype(self, is_store: bool) -> str:
+    if not is_store:
+        raise DataJointError("<object> requires @ (store only)")
     return "json"
 ```
 
@@ -13357,7 +21505,7 @@ class CompressedJsonCodec(dj.Codec):
 
     name = "zjson"
 
-    def get_dtype(self, is_external: bool) -> str:
+    def get_dtype(self, is_store: bool) -> str:
         return "<blob>"  # Delegate serialization to blob codec
 
     def encode(self, value, *, key=None, store_name=None):
@@ -13375,8 +21523,8 @@ class CompressedJsonCodec(dj.Codec):
 
 When DataJoint encounters `<zjson>`:
 
-1. Calls `ZjsonCodec.get_dtype(is_external=False)` → returns `"<blob>"`
-2. Calls `BlobCodec.get_dtype(is_external=False)` → returns `"bytes"`
+1. Calls `ZjsonCodec.get_dtype(is_store=False)` → returns `"<blob>"`
+2. Calls `BlobCodec.get_dtype(is_store=False)` → returns `"bytes"`
 3. Final storage type is `bytes` (LONGBLOB in MySQL)
 
 During INSERT:
@@ -13393,30 +21541,29 @@ During FETCH:
 
 DataJoint's built-in codecs form these chains:
 
-```
-<blob>     → bytes (internal)
-<blob@>    → <hash@> → json (external)
-
-<attach>   → bytes (internal)
-<attach@>  → <hash@> → json (external)
-
-<hash@>    → json (external only)
-<object@>  → json (external only)
-<filepath@> → json (external only)
-```
+| Codec | Chain | Final Storage |
+|-------|-------|---------------|
+| `<blob>` | `<blob>` → `bytes` | Inline |
+| `<blob@>` | `<blob>` → `<hash>` → `json` | Store (hash-addressed) |
+| `<attach>` | `<attach>` → `bytes` | Inline |
+| `<attach@>` | `<attach>` → `<hash>` → `json` | Store (hash-addressed) |
+| `<hash@>` | `<hash>` → `json` | Store only (hash-addressed) |
+| `<object@>` | `<object>` → `json` | Store only (schema-addressed) |
+| `<npy@>` | `<npy>` → `json` | Store only (schema-addressed) |
+| `<filepath@>` | `<filepath>` → `json` | Store only (external ref) |
 
 ### Store Name Propagation
 
-When using external storage (`@`), the store name propagates through the chain:
+When using object storage (`@`), the store name propagates through the chain:
 
 ```python
 # Table definition
 data : <mycodec@coldstore>
 
 # Resolution:
-# 1. MyCodec.get_dtype(is_external=True) → "<blob>"
-# 2. BlobCodec.get_dtype(is_external=True) → "<hash>"
-# 3. HashCodec.get_dtype(is_external=True) → "json"
+# 1. MyCodec.get_dtype(is_store=True) → "<blob>"
+# 2. BlobCodec.get_dtype(is_store=True) → "<hash>"
+# 3. HashCodec.get_dtype(is_store=True) → "json"
 # 4. store_name="coldstore" passed to HashCodec.encode()
 ```
 
@@ -13458,7 +21605,7 @@ import networkx as nx
 class GraphCodec(dj.Codec):
     name = "graph"
 
-    def get_dtype(self, is_external: bool) -> str:
+    def get_dtype(self, is_store: bool) -> str:
         return "<blob>"
 
     def encode(self, graph, *, key=None, store_name=None):
@@ -13476,7 +21623,7 @@ class GraphCodec(dj.Codec):
 class WeightedGraphCodec(dj.Codec):
     name = "weighted_graph"
 
-    def get_dtype(self, is_external: bool) -> str:
+    def get_dtype(self, is_store: bool) -> str:
         return "<blob>"
 
     def encode(self, graph, *, key=None, store_name=None):
@@ -13548,15 +21695,20 @@ from datajoint.codecs import (
 
 ## Built-in Codecs
 
-DataJoint provides these built-in codecs:
+DataJoint provides these built-in codecs. See the [Type System Specification](type-system.md) for detailed behavior and implementation.
 
-| Codec | Internal | External | Description |
-|-------|----------|----------|-------------|
-| `<blob>` | `bytes` | `<hash@>` | DataJoint serialization for Python objects |
-| `<hash@>` | N/A | `json` | Content-addressed storage with MD5 deduplication |
-| `<object@>` | N/A | `json` | Path-addressed storage for files/folders |
-| `<attach>` | `bytes` | `<hash@>` | File attachments with filename preserved |
-| `<filepath@>` | N/A | `json` | Reference to existing files in store |
+| Codec | Inline | Store | Addressing | Description |
+|-------|--------|-------|------------|-------------|
+| `<blob>` | `bytes` | `<hash@>` | Hash | DataJoint serialization for Python objects |
+| `<attach>` | `bytes` | `<hash@>` | Hash | File attachments with filename preserved |
+| `<hash@>` | N/A | `json` | Hash | Hash-addressed storage with MD5 deduplication |
+| `<object@>` | N/A | `json` | Schema | Schema-addressed storage for files/folders |
+| `<npy@>` | N/A | `json` | Schema | Schema-addressed storage for numpy arrays |
+| `<filepath@>` | N/A | `json` | External | Reference to existing files in store |
+
+**Addressing schemes:**
+- **Hash-addressed**: Path from content hash. Automatic deduplication.
+- **Schema-addressed**: Path mirrors database structure. One location per entity.
 
 ## Complete Examples
 
@@ -13571,7 +21723,7 @@ class SpikeTrainCodec(dj.Codec):
 
     name = "spike_train"
 
-    def get_dtype(self, is_external: bool) -> str:
+    def get_dtype(self, is_store: bool) -> str:
         return "<blob>"
 
     def validate(self, value):
@@ -13602,9 +21754,9 @@ class ModelCodec(dj.Codec):
 
     name = "model"
 
-    def get_dtype(self, is_external: bool) -> str:
+    def get_dtype(self, is_store: bool) -> str:
         # Use hash-addressed storage for large models
-        return "<hash>" if is_external else "<blob>"
+        return "<hash>" if is_store else "<blob>"
 
     def encode(self, model, *, key=None, store_name=None):
         return pickle.dumps(model, protocol=pickle.HIGHEST_PROTOCOL)
@@ -13651,7 +21803,7 @@ class ConfigCodec(dj.Codec):
         "required": ["version", "settings"],
     }
 
-    def get_dtype(self, is_external: bool) -> str:
+    def get_dtype(self, is_store: bool) -> str:
         return "json"
 
     def validate(self, value):
@@ -13674,7 +21826,7 @@ class VersionedDataCodec(dj.Codec):
 
     name = "versioned"
 
-    def get_dtype(self, is_external: bool) -> str:
+    def get_dtype(self, is_store: bool) -> str:
         return "<blob>"
 
     def encode(self, value, *, key=None, store_name=None):
@@ -13714,8 +21866,8 @@ class ZarrCodec(dj.Codec):
 
     name = "zarr"
 
-    def get_dtype(self, is_external: bool) -> str:
-        if not is_external:
+    def get_dtype(self, is_store: bool) -> str:
+        if not is_store:
             raise dj.DataJointError("<zarr> requires @ (external storage only)")
         return "<object>"  # Delegate to object storage
 
@@ -13864,8 +22016,8 @@ print(dj.list_codecs())
 # Inspect a codec
 codec = dj.get_codec("mycodec")
 print(f"Name: {codec.name}")
-print(f"Internal dtype: {codec.get_dtype(is_external=False)}")
-print(f"External dtype: {codec.get_dtype(is_external=True)}")
+print(f"Internal dtype: {codec.get_dtype(is_store=False)}")
+print(f"External dtype: {codec.get_dtype(is_store=True)}")
 
 # Resolve full chain
 from datajoint.codecs import resolve_dtype
@@ -13880,10 +22032,6 @@ print(f"Store: {store}")
 ## File: reference/specs/data-manipulation.md
 
 # DataJoint Data Manipulation Specification
-
-Version: 1.0
-Status: Draft
-Last Updated: 2026-01-07
 
 ## Overview
 
@@ -14582,6 +22730,9 @@ DataJoint 2.0 replaces the complex `fetch()` method with a set of explicit, comp
 | `keys()` | `list[dict]` | Primary key values only |
 | `fetch1()` | `dict` | Single row as dict (raises if not exactly 1) |
 | `fetch1('a', 'b')` | `tuple` | Single row attribute values |
+| `head(limit=25)` | `list[dict]` | Preview first N entries |
+| `tail(limit=25)` | `list[dict]` | Preview last N entries |
+| `cursor(as_dict=False)` | `cursor` | Raw database cursor for manual iteration |
 
 ### Common Parameters
 
@@ -14898,14 +23049,14 @@ Each specification follows a consistent structure:
 | [Master-Part Relationships](master-part.md) | Compositional data modeling, integrity, and cascading operations |
 | [Virtual Schemas](virtual-schemas.md) | Accessing schemas without Python source, introspection API |
 
-### Query Operations
+### Query Algebra
 
 | Specification | Description |
 |---------------|-------------|
-| [Query Algebra](query-algebra.md) | Operators: restrict, proj, join, aggr, extend, union, U() |
-| [Data Manipulation](data-manipulation.md) | Insert, update1, delete operations and workflow normalization |
-| [Primary Keys](primary-keys.md) | How primary keys propagate through query operators |
+| [Query Operators](query-algebra.md) | Operators: restrict, proj, join, aggr, extend, union, U() |
 | [Semantic Matching](semantic-matching.md) | Attribute lineage and join compatibility |
+| [Primary Keys](primary-keys.md) | How primary keys propagate through query operators |
+| [Fetch API](fetch-api.md) | Data retrieval methods and formats |
 
 ### Type System
 
@@ -14913,19 +23064,22 @@ Each specification follows a consistent structure:
 |---------------|-------------|
 | [Type System](type-system.md) | Three-layer type architecture: native, core, and codec types |
 | [Codec API](codec-api.md) | Custom type implementation with encode/decode semantics |
+| [`<npy>` Codec](npy-codec.md) | Store numpy arrays as portable `.npy` files |
 
-### Queries
-
-| Specification | Description |
-|---------------|-------------|
-| [Fetch API](fetch-api.md) | Data retrieval methods and formats |
-
-### Computation
+### Object Store Configuration
 
 | Specification | Description |
 |---------------|-------------|
+| [Object Store Configuration](object-store-configuration.md) | Store configuration, path generation, and storage models: hash-addressed (integrated), schema-addressed (integrated), and filepath (reference) |
+
+### Data Operations
+
+| Specification | Description |
+|---------------|-------------|
+| [Data Manipulation](data-manipulation.md) | Insert, update1, delete operations and workflow normalization |
 | [AutoPopulate](autopopulate.md) | Jobs 2.0 system for automated computation |
 | [Job Metadata](job-metadata.md) | Hidden columns for job tracking |
+
 
 
 ---
@@ -15292,10 +23446,6 @@ ProcessedData().to_arrays('_job_start_time', '_job_duration', '_job_version')
 ## File: reference/specs/master-part.md
 
 # Master-Part Relationships Specification
-
-Version: 1.0
-Status: Draft
-Last Updated: 2026-01-08
 
 ## Overview
 
@@ -15692,369 +23842,1088 @@ class TrialEvent(dj.Manual):  # Not a Part, but references Trial
 
 
 ---
-## File: reference/specs/migration-2.0.md
+## File: reference/specs/npy-codec.md
 
-# DataJoint 2.0 Migration Specification
+# `<npy>` Codec Specification
 
-This specification defines the migration process from DataJoint 0.x to DataJoint 2.0. The migration preserves all existing data while updating metadata to leverage 2.0's enhanced type system.
-
-> **Warning: Read and understand this entire specification before migrating.**
->
-> Migration involves irreversible changes to external storage metadata. We strongly recommend using an advanced AI coding assistant (e.g., Claude Code, Cursor, GitHub Copilot) to:
->
-> 1. **Analyze your schema** — Identify all tables, data types, and external storage usage
-> 2. **Generate a migration plan** — Create a step-by-step plan specific to your pipeline
-> 3. **Execute with oversight** — Run migration steps with human review at each stage
->
-> The migration process is designed and tested for agentic execution, allowing AI assistants to safely perform the migration while keeping you informed of each change.
+Schema-addressed storage for numpy arrays as portable `.npy` files.
 
 ## Overview
 
-DataJoint 2.0 introduces a unified type system with explicit codecs for object storage. **Migration is required** to use 2.0's full feature set. The migration updates table metadata (column comments) to include type labels that 2.0 uses to interpret data correctly.
+The `<npy@>` codec stores numpy arrays as standard `.npy` files using
+schema-addressed paths that mirror the database structure. On fetch, it returns
+`NpyRef`—a lazy reference that provides metadata access without downloading,
+and transparent numpy integration via the `__array__` protocol.
 
-**Key points:**
-- DataJoint 2.0 can read 0.x schemas **before migration** (including external storage)
-- Migration updates metadata only; underlying data remains unchanged
-- **External storage migration is one-way** — once migrated, 0.14 loses access to external data
+**Key characteristics:**
 
-### Migration Components
+- **Store only**: Requires `@` modifier (`<npy@>` or `<npy@store>`)
+- **Schema-addressed**: Paths mirror database structure (`{schema}/{table}/{pk}/{attr}.npy`)
+- **Lazy loading**: Shape/dtype available without download
+- **Transparent**: Use directly in numpy operations
+- **Portable**: Standard `.npy` format readable by numpy, MATLAB, etc.
 
-| Step | Component | Description |
-|------|-----------|-------------|
-| 0 | Settings | Update configuration to `datajoint.json` format |
-| 1 | Core Types | Add type labels to column comments for numeric/string types |
-| 2 | Internal Blobs | Convert `LONGBLOB` columns to `<blob>` codec |
-| 3 | Internal Attachments | Convert attachment columns to `<attach>` codec |
-| 4 | External Objects | Convert external blobs/attachments to `<blob@>` / `<attach@>` codecs |
-| 5 | Filepaths | Convert filepath columns to `<filepath@>` codec |
-
----
-
-## Step 0: Settings File Migration
-
-### Current (0.x)
-```python
-dj.config['database.host'] = 'localhost'
-dj.config['database.user'] = 'root'
-dj.config['database.password'] = 'secret'
-dj.config['stores'] = {
-    'external': {
-        'protocol': 'file',
-        'location': '/data/external'
-    }
-}
-```
-
-### Target (2.0)
-```
-project/
-├── datajoint.json
-└── .secrets/
-    ├── database.password
-    └── database.user
-```
-
-**datajoint.json:**
-```json
-{
-  "database.host": "localhost",
-  "stores": {
-    "external": {
-      "protocol": "file",
-      "location": "/data/external"
-    }
-  }
-}
-```
-
-### Migration Actions
-1. Create `datajoint.json` from existing `dj_local_conf.json` or `dj.config` settings
-2. Move credentials to `.secrets/` directory
-3. Add `.secrets/` to `.gitignore`
-4. Update environment variables if used (`DJ_*` prefix)
-
----
-
-## Step 1: Core Type Labels
-
-DataJoint 2.0 uses explicit type aliases (`int32`, `float64`, etc.) stored in column comments.
-
-### Type Mapping
-
-| MySQL Native | DataJoint 2.0 | Comment Label |
-|--------------|---------------|---------------|
-| `TINYINT` | `int8` | `:int8:` |
-| `TINYINT UNSIGNED` | `uint8` | `:uint8:` |
-| `SMALLINT` | `int16` | `:int16:` |
-| `SMALLINT UNSIGNED` | `uint16` | `:uint16:` |
-| `INT` | `int32` | `:int32:` |
-| `INT UNSIGNED` | `uint32` | `:uint32:` |
-| `BIGINT` | `int64` | `:int64:` |
-| `BIGINT UNSIGNED` | `uint64` | `:uint64:` |
-| `FLOAT` | `float32` | `:float32:` |
-| `DOUBLE` | `float64` | `:float64:` |
-| `TINYINT(1)` | `bool` | `:bool:` |
-
-### Migration Actions
-1. Query `INFORMATION_SCHEMA.COLUMNS` for all tables in schema
-2. For each numeric column, determine the appropriate 2.0 type
-3. Update column comment to include type label prefix
-
-### Example SQL
-```sql
-ALTER TABLE `schema`.`table_name`
-MODIFY COLUMN `column_name` INT NOT NULL COMMENT ':int32: original comment';
-```
-
----
-
-## Step 2: Internal Blobs (`<blob>`)
-
-Internal blobs are stored directly in the database as `LONGBLOB` columns.
-
-### Identification
-- Column type: `LONGBLOB`
-- No external store reference in comment
-- Used for numpy arrays, pickled objects
-
-### Current Storage
-```sql
-column_name LONGBLOB COMMENT 'some description'
-```
-
-### Target Format
-```sql
-column_name LONGBLOB COMMENT ':blob: some description'
-```
-
-### Migration Actions
-1. Identify all `LONGBLOB` columns without external store markers
-2. Add `:blob:` prefix to column comment
-3. No data modification required (format unchanged)
-
----
-
-## Step 3: Internal Attachments (`<attach>`)
-
-Internal attachments store files directly in the database with filename metadata.
-
-### Identification
-- Column type: `LONGBLOB`
-- Comment contains `:attach:` or attachment indicator
-- Stores serialized (filename, content) tuples
-
-### Current Storage
-```sql
-attachment LONGBLOB COMMENT ':attach: uploaded file'
-```
-
-### Target Format
-```sql
-attachment LONGBLOB COMMENT ':attach: uploaded file'
-```
-
-### Migration Actions
-1. Identify attachment columns (existing `:attach:` marker or known attachment pattern)
-2. Verify comment format matches 2.0 specification
-3. No data modification required
-
----
-
-## Step 4: External Objects (`<blob@>`, `<attach@>`)
-
-External objects store data in configured storage backends (S3, filesystem) with metadata in the database.
-
-### Identification
-- Column type: `VARCHAR(255)` or similar (stores hash/path)
-- Comment contains store reference (e.g., `:external:`)
-- Corresponding entry in external storage
-
-### Current Storage
-```sql
-external_data VARCHAR(255) COMMENT ':external: large array'
-```
-
-### Target Format
-```sql
-external_data JSON COMMENT ':blob@external: large array'
-```
-
-### Migration Actions
-1. Identify external blob/attachment columns
-2. Verify store configuration exists in `datajoint.json`
-3. Update column comment to use `<blob@store>` or `<attach@store>` format
-4. Migrate column type from `VARCHAR` to `JSON` if needed
-5. Update path format to URL representation (`file://`, `s3://`)
-
-### Store Configuration
-Ensure stores are defined in `datajoint.json`:
-```json
-{
-  "stores": {
-    "external": {
-      "protocol": "file",
-      "location": "/data/external"
-    },
-    "s3store": {
-      "protocol": "s3",
-      "endpoint": "s3.amazonaws.com",
-      "bucket": "my-bucket"
-    }
-  }
-}
-```
-
----
-
-## Step 5: Filepath Codec (`<filepath@>`)
-
-Filepath columns store references to managed files in external storage.
-
-### Identification
-- Column type: `VARCHAR(255)` or similar
-- Comment contains `:filepath:` or filepath indicator
-- References files in managed storage location
-
-### Current Storage
-```sql
-file_path VARCHAR(255) COMMENT ':filepath@store: data file'
-```
-
-### Target Format
-```sql
-file_path JSON COMMENT ':filepath@store: data file'
-```
-
-### Migration Actions
-1. Identify filepath columns
-2. Verify store configuration
-3. Update column type to `JSON` if needed
-4. Convert stored paths to URL format
-5. Update comment to 2.0 format
-
----
-
-## AI-Assisted Migration
-
-The migration process is optimized for execution by AI coding assistants. Before running the migration tool, use your AI assistant to:
-
-### 1. Schema Analysis
-```
-Analyze my DataJoint schema at [database_host]:
-- List all schemas and tables
-- Identify column types requiring migration
-- Flag external storage usage and store configurations
-- Report any potential compatibility issues
-```
-
-### 2. Migration Plan Generation
-```
-Create a migration plan for schema [schema_name]:
-- Step-by-step actions with SQL statements
-- Backup checkpoints before irreversible changes
-- Validation queries after each step
-- Estimated impact (rows affected, storage changes)
-```
-
-### 3. Supervised Execution
-```
-Execute the migration plan for [schema_name]:
-- Run each step and report results
-- Pause for confirmation before external storage migration
-- Verify data integrity after completion
-```
-
-The AI assistant will use this specification and the migration tool to execute the plan safely.
-
----
-
-## Migration Tool
-
-DataJoint 2.0 provides a migration utility:
+## Quick Start
 
 ```python
-from datajoint.migrate import migrate_schema
+import datajoint as dj
+import numpy as np
 
-# Analyze schema without making changes
-report = migrate_schema('my_schema', dry_run=True)
-print(report)
+@schema
+class Recording(dj.Manual):
+    definition = """
+    recording_id : int
+    ---
+    waveform : <npy@>
+    """
 
-# Perform migration
-migrate_schema('my_schema', dry_run=False)
+# Insert - just pass the array
+Recording.insert1({
+    'recording_id': 1,
+    'waveform': np.random.randn(1000, 32),
+})
+
+# Fetch - returns NpyRef (lazy)
+ref = (Recording & 'recording_id=1').fetch1('waveform')
+
+# Metadata without download
+ref.shape   # (1000, 32)
+ref.dtype   # float64
+
+# Use in numpy ops - downloads automatically
+mean = np.mean(ref, axis=0)
+
+# Or load explicitly
+arr = ref.load()
 ```
 
-### Options
-- `dry_run`: Analyze without modifying (default: True)
-- `backup`: Create backup before migration (default: True)
-- `stores`: Store configuration dict (uses config if not provided)
+## NpyRef: Lazy Array Reference
 
----
+When you fetch an `<npy@>` attribute, you get an `NpyRef` object:
 
-## Rollback
+```python
+ref = (Recording & key).fetch1('waveform')
+type(ref)  # <class 'datajoint.builtin_codecs.NpyRef'>
+```
 
-If migration issues occur:
+### Metadata Access (No I/O)
 
-1. **Settings**: Restore original `dj_local_conf.json`
-2. **Column comments**: Revert comment changes via SQL
-3. **Core types and internal blobs**: Fully reversible
+```python
+ref.shape    # tuple: (1000, 32)
+ref.dtype    # numpy.dtype: float64
+ref.ndim     # int: 2
+ref.size     # int: 32000
+ref.nbytes   # int: 256000 (estimated)
+ref.path     # str: "my_schema/recording/recording_id=1/waveform.npy"
+ref.store    # str or None: store name
+ref.is_loaded  # bool: False (until loaded)
+```
 
-**External storage cannot be rolled back.** Once external object references are migrated from hidden tables to JSON fields:
-- The hidden `~external_*` tables are no longer updated
-- DataJoint 0.14 cannot read the JSON field format
-- Reverting requires restoring from backup
+### Loading Data
 
-**Recommendation:** Create a full database backup before migrating schemas with external storage.
+**Explicit loading:**
+```python
+arr = ref.load()  # Downloads, caches, returns np.ndarray
+arr = ref.load()  # Returns cached copy (no re-download)
+```
 
----
+**Implicit loading via `__array__`:**
+```python
+# These all trigger automatic download
+result = ref + 1
+result = np.mean(ref)
+result = np.dot(ref, weights)
+arr = np.asarray(ref)
+```
+
+**Indexing/slicing:**
+```python
+first_row = ref[0]      # Loads then indexes
+subset = ref[100:200]   # Loads then slices
+```
+
+### Memory Mapping
+
+For very large arrays, use `mmap_mode` to access data without loading it all:
+
+```python
+# Memory-mapped loading (random access)
+arr = ref.load(mmap_mode='r')
+
+# Efficient random access - only reads needed portions
+slice = arr[1000:2000, :]
+chunk = arr[::100]
+```
+
+**Modes:**
+- `'r'` - Read-only (recommended)
+- `'r+'` - Read-write (modifications persist)
+- `'c'` - Copy-on-write (changes not saved)
+
+**Performance characteristics:**
+- Local filesystem stores: memory-maps the file directly (zero-copy)
+- Remote stores (S3, GCS): downloads to local cache first, then memory-maps
+
+**When to use:**
+- Arrays too large to fit in memory
+- Only need random access to portions of the array
+- Processing data in chunks
+
+### Safe Bulk Fetch
+
+The lazy design protects against accidental mass downloads:
+
+```python
+# Fetch 10,000 recordings - NO downloads happen yet
+recs = Recording.fetch()
+
+# Inspect without downloading
+for rec in recs:
+    ref = rec['waveform']
+    print(f"Shape: {ref.shape}, dtype: {ref.dtype}")  # No I/O
+
+# Download only what you need
+large_arrays = [rec['waveform'] for rec in recs if rec['waveform'].shape[0] > 1000]
+for ref in large_arrays:
+    process(ref.load())  # Downloads here
+```
+
+### Repr for Debugging
+
+```python
+>>> ref
+NpyRef(shape=(1000, 32), dtype=float64, not loaded)
+
+>>> ref.load()
+>>> ref
+NpyRef(shape=(1000, 32), dtype=float64, loaded)
+```
+
+## Table Definition
+
+```python
+@schema
+class Recording(dj.Manual):
+    definition = """
+    recording_id : int
+    ---
+    waveform : <npy@>           # default store
+    spectrogram : <npy@archive>  # specific store
+    """
+```
+
+## Storage Details
+
+### Addressing Scheme
+
+The `<npy@>` codec uses **schema-addressed** storage, where paths mirror the
+database schema structure. This creates a browsable organization in object
+storage that reflects your data model.
+
+### Type Chain
+
+```
+<npy@> → "json" (metadata stored in JSON column)
+```
+
+### File Format
+
+- Format: NumPy `.npy` (version 1.0 or 2.0 depending on array size)
+- Encoding: `numpy.save()` with `allow_pickle=False`
+- Extension: `.npy`
+
+### Schema-Addressed Path Construction
+
+```
+{schema}/{table}/{primary_key_values}/{attribute}.npy
+```
+
+Example: `lab_ephys/recording/recording_id=1/waveform.npy`
+
+This schema-addressed layout means you can browse the object store and understand
+the organization because it mirrors your database schema.
+
+### JSON Metadata
+
+The database column stores:
+
+```json
+{
+  "path": "lab_ephys/recording/recording_id=1/waveform.npy",
+  "store": "main",
+  "dtype": "float64",
+  "shape": [1000, 32]
+}
+```
 
 ## Validation
 
-After migration, verify:
+The codec validates on insert:
+
+- Value must be `numpy.ndarray`
+- Array must not have `object` dtype
+
+```python
+# Valid
+Recording.insert1({'recording_id': 1, 'waveform': np.array([1, 2, 3])})
+
+# Invalid - not an array
+Recording.insert1({'recording_id': 1, 'waveform': [1, 2, 3]})
+# DataJointError: <npy> requires numpy.ndarray, got list
+
+# Invalid - object dtype
+Recording.insert1({'recording_id': 1, 'waveform': np.array([{}, []])})
+# DataJointError: <npy> does not support object dtype arrays
+```
+
+## Direct File Access
+
+Files are stored at predictable paths and can be accessed directly:
+
+```python
+# Get the storage path
+ref = (Recording & 'recording_id=1').fetch1('waveform')
+print(ref.path)  # "my_schema/recording/recording_id=1/waveform.npy"
+
+# Load directly with numpy (if you have store access)
+arr = np.load('/path/to/store/my_schema/recording/recording_id=1/waveform.npy')
+```
+
+## Comparison with Other Codecs
+
+| Codec | Format | Addressing | Lazy | Memory Map | Portability |
+|-------|--------|------------|------|------------|-------------|
+| `<npy@>` | `.npy` | Schema | Yes (NpyRef) | Yes | High (numpy, MATLAB) |
+| `<object@>` | varies | Schema | Yes (ObjectRef) | No | Depends on content |
+| `<blob@>` | pickle | Hash | No | No | Python only |
+| `<hash@>` | raw bytes | Hash | No | No | N/A |
+
+**Addressing schemes:**
+- **Schema-addressed**: Path mirrors database structure. Browsable, one location per entity.
+- **Hash-addressed**: Path from content hash. Automatic deduplication.
+
+## When to Use `<npy@>`
+
+**Use `<npy@>` when:**
+- Storing single numpy arrays
+- Interoperability matters (non-Python tools)
+- You want lazy loading with metadata inspection
+- Fetching many rows where not all arrays are needed
+- Random access to large arrays via memory mapping
+- Browsable object store organization is valuable
+
+**Use `<blob@>` when:**
+- Storing arbitrary Python objects (dicts, lists, mixed types)
+- Arrays are small and eager loading is fine
+- MATLAB compatibility with DataJoint's mYm format is needed
+- Deduplication is beneficial (hash-addressed)
+
+**Use `<object@>` when:**
+- Storing files/folders (Zarr, HDF5, multi-file outputs)
+- Content is not a single numpy array
+
+## Limitations
+
+1. **Single array only**: For multiple arrays, use separate attributes or `<object@>` with `.npz`
+2. **No compression**: For compressed storage, use a custom codec with `numpy.savez_compressed`
+3. **No object dtype**: Arrays containing arbitrary Python objects are not supported
+4. **Store only**: Cannot store inline in the database column
+
+## See Also
+
+- [Type System Specification](type-system.md) - Complete type system overview
+- [Codec API](codec-api.md) - Creating custom codecs
+- [Object Storage](type-system.md#object--path-addressed-storage) - Path-addressed storage details
+
+
+---
+## File: reference/specs/object-store-configuration.md
+
+# Object Store Configuration Specification
+
+This specification defines DataJoint's unified object store system, including store configuration, path generation algorithms, and storage models.
+
+## Overview
+
+DataJoint's Object-Augmented Schema (OAS) integrates relational tables with object storage as a single coherent system. Large data objects are stored in file systems or cloud storage while maintaining full referential integrity with the relational database.
+
+### Storage Models
+
+DataJoint 2.0 supports three storage models, all sharing the same store configuration:
+
+| Model | Data Types | Path Structure | Integration | Use Case |
+|-------|------------|----------------|-------------|----------|
+| **Hash-addressed** | `<blob@store>`, `<attach@store>` | Content-addressed by hash | **Integrated** (OAS) | Immutable data, automatic deduplication |
+| **Schema-addressed** | `<object@store>`, `<npy@store>` | Key-based hierarchical paths | **Integrated** (OAS) | Mutable data, streaming access, arrays |
+| **Filepath** | `<filepath@store>` | User-managed paths | **Reference** | User-managed files (no lifecycle management) |
+
+**Key distinction:**
+- **Hash-addressed** and **schema-addressed** storage are **integrated** into the Object-Augmented Schema. DataJoint manages their lifecycle, paths, integrity, garbage collection, transaction safety, and deduplication.
+- **Filepath** storage stores only the path string. DataJoint provides no lifecycle management, garbage collection, transaction safety, or deduplication. Users control file creation, organization, and lifecycle.
+
+**Legacy note:** DataJoint 0.14.x only supported hash-addressed (called "external") and filepath storage. Schema-addressed storage is new in 2.0.
+
+## Store Configuration
+
+### Minimal Configuration
+
+Every store requires two fields:
+
+```json
+{
+  "stores": {
+    "default": "main",
+    "main": {
+      "protocol": "file",
+      "location": "/data/my-project"
+    }
+  }
+}
+```
+
+This creates a store named `main` and designates it as the default.
+
+### Default Store
+
+DataJoint uses two default settings to reflect the architectural distinction between integrated and reference storage:
+
+#### stores.default — Integrated Storage (OAS)
+
+The `stores.default` setting determines which store is used for **integrated storage** (hash-addressed and schema-addressed) when no store is specified:
+
+```python
+# These are equivalent when stores.default = "main"
+signal : <blob>           # Uses stores.default
+signal : <blob@main>      # Explicitly names store
+
+arrays : <object>         # Uses stores.default
+arrays : <object@main>    # Explicitly names store
+```
+
+**Rules:**
+- `stores.default` must be a string naming a configured store
+- Required for `<blob>`, `<attach>`, `<object>`, `<npy>` without explicit `@store`
+- Each project typically uses one primary store for integrated data
+
+#### stores.filepath_default — Filepath References
+
+The `stores.filepath_default` setting determines which store is used for **filepath references** when no store is specified:
+
+```python
+# These are equivalent when stores.filepath_default = "raw_data"
+recording : <filepath@>          # Uses stores.filepath_default
+recording : <filepath@raw_data>  # Explicitly names store
+```
+
+**Rules:**
+- `stores.filepath_default` must be a string naming a configured store
+- Required for `<filepath@>` without explicit store name
+- Often configured differently from `stores.default` because filepath references are not part of OAS
+- Users manage file lifecycle and organization
+
+**Why separate defaults?**
+
+Integrated storage (hash, schema) is managed by DataJoint as part of the Object-Augmented Schema—DataJoint controls paths, lifecycle, integrity, garbage collection, transaction safety, and deduplication. Filepath storage is user-managed—DataJoint only stores the path string and provides no lifecycle management, garbage collection, transaction safety, or deduplication. These are architecturally distinct, so they often use different storage locations and require separate defaults.
+
+### Complete Store Configuration
+
+A fully configured store specifying all sections:
+
+```json
+{
+  "stores": {
+    "default": "main",
+    "main": {
+      "protocol": "s3",
+      "endpoint": "s3.amazonaws.com",
+      "bucket": "neuroscience-data",
+      "location": "lab-project-2024",
+
+      "hash_prefix": "blobs",
+      "schema_prefix": "arrays",
+      "filepath_prefix": "imported",
+
+      "subfolding": [2, 2],
+      "partition_pattern": "subject_id/session_date",
+      "token_length": 8
+    }
+  }
+}
+```
+
+### Section Prefixes
+
+Each store is divided into sections controlled by prefix configuration. The `*_prefix` parameters define the path prefix for each storage section:
+
+| Configuration Parameter | Default | Storage Section | Used By |
+|------------------------|---------|-----------------|---------|
+| `hash_prefix` | `"_hash"` | Hash-addressed section | `<blob@>`, `<attach@>` |
+| `schema_prefix` | `"_schema"` | Schema-addressed section | `<object@>`, `<npy@>` |
+| `filepath_prefix` | `null` | Filepath section (optional) | `<filepath@>` |
+
+**Validation rules:**
+1. All prefixes must be mutually exclusive (no nesting)
+2. `hash_prefix` and `schema_prefix` are reserved for DataJoint
+3. `filepath_prefix` is optional:
+   - `null` (default): filepaths can use any path except reserved sections
+   - `"some/prefix"`: all filepaths must start with this prefix
+
+**Example with custom prefixes:**
+
+```json
+{
+  "hash_prefix": "content_addressed",
+  "schema_prefix": "structured_data",
+  "filepath_prefix": "user_files"
+}
+```
+
+Results in these sections:
+- `{location}/content_addressed/{schema}/{hash}` — hash-addressed
+- `{location}/structured_data/{schema}/{table}/{key}/` — schema-addressed
+- `{location}/user_files/{user_path}` — filepath (required prefix)
+
+### Multiple Stores
+
+Configure multiple stores for different data types or storage tiers:
+
+```json
+{
+  "stores": {
+    "default": "main",
+    "filepath_default": "raw_data",
+    "main": {
+      "protocol": "file",
+      "location": "/data/fast-storage",
+      "hash_prefix": "blobs",
+      "schema_prefix": "arrays"
+    },
+    "archive": {
+      "protocol": "s3",
+      "endpoint": "s3.amazonaws.com",
+      "bucket": "archive-bucket",
+      "location": "long-term-storage",
+      "hash_prefix": "archived_blobs",
+      "schema_prefix": "archived_arrays",
+      "subfolding": [2, 2]
+    },
+    "raw_data": {
+      "protocol": "file",
+      "location": "/data/acquisition",
+      "filepath_prefix": "recordings"
+    }
+  }
+}
+```
+
+Use named stores in table definitions:
+
+```python
+@schema
+class Recording(dj.Manual):
+    definition = """
+    recording_id : uuid
+    ---
+    metadata     : <blob@main>          # Fast storage, hash-addressed
+    raw_file     : <filepath@raw_data>  # Reference existing acquisition file
+    processed    : <object@main>        # Fast storage, schema-addressed
+    backup       : <blob@archive>       # Long-term storage
+    """
+```
+
+## Secret Management
+
+Store credentials separately from configuration files using the `.secrets/` directory.
+
+### Secrets Directory Structure
+
+```
+project/
+├── datajoint.json              # Non-sensitive configuration
+└── .secrets/                   # Credentials (gitignored)
+    ├── .gitignore              # Ensures secrets aren't committed
+    ├── database.user
+    ├── database.password
+    ├── stores.main.access_key
+    ├── stores.main.secret_key
+    ├── stores.archive.access_key
+    └── stores.archive.secret_key
+```
+
+### Configuration Priority
+
+DataJoint loads configuration in this order (highest priority first):
+
+1. **Environment variables**: `DJ_HOST`, `DJ_USER`, `DJ_PASS`
+2. **Secrets directory**: `.secrets/database.user`, `.secrets/stores.main.access_key`
+3. **Config file**: `datajoint.json`
+4. **Defaults**: Built-in defaults
+
+### Secrets File Format
+
+Each secret file contains a single value (no quotes, no JSON):
+
+```bash
+# .secrets/database.password
+my_secure_password
+```
+
+```bash
+# .secrets/stores.main.access_key
+AKIAIOSFODNN7EXAMPLE
+```
+
+### Per-Store Credentials
+
+Store credentials use the naming pattern: `stores.<name>.<attribute>`
+
+**S3 stores:**
+```
+.secrets/stores.main.access_key
+.secrets/stores.main.secret_key
+```
+
+**GCS stores:**
+```
+.secrets/stores.gcs_store.token
+```
+
+**Azure stores:**
+```
+.secrets/stores.azure_store.account_key
+```
+
+### Setting Up Secrets
+
+```bash
+# Create secrets directory
+mkdir .secrets
+echo "*" > .secrets/.gitignore
+
+# Add credentials (no quotes)
+echo "analyst" > .secrets/database.user
+echo "dbpass123" > .secrets/database.password
+echo "AKIAIOSFODNN7EXAMPLE" > .secrets/stores.main.access_key
+echo "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" > .secrets/stores.main.secret_key
+
+# Verify .secrets/ is gitignored
+git check-ignore .secrets/database.password  # Should output the path
+```
+
+### Template Generation
+
+Generate configuration templates:
 
 ```python
 import datajoint as dj
 
-schema = dj.Schema('my_schema')
+# Create config file
+dj.config.save_template('datajoint.json')
 
-# Check all tables load correctly
-for table in schema.list_tables():
-    tbl = schema(table)
-    print(f"{table}: {len(tbl)} rows")
-    # Fetch sample to verify data access
-    if len(tbl) > 0:
-        tbl.fetch(limit=1)
+# Create config + secrets directory with placeholders
+dj.config.save_template('datajoint.json', create_secrets_dir=True)
 ```
 
----
+## Path Generation
 
-## Version Compatibility
+### Hash-Addressed Storage
 
-| DataJoint Version | Can Read 0.x Data | Can Read 2.0 Data |
-|-------------------|-------------------|-------------------|
-| 0.14.x | Yes | No (loses external data access) |
-| 2.0.x | Yes (including external) | Yes |
+**Data types:** `<blob@store>`, `<attach@store>`
 
-### External Storage Breaking Change
+**Path structure:**
+```
+{location}/{hash_prefix}/{schema_name}/{hash}[.ext]
+```
 
-**This is a one-way migration for external storage.**
+**With subfolding `[2, 2]`:**
+```
+{location}/{hash_prefix}/{schema_name}/{h1}{h2}/{h3}{h4}/{hash}[.ext]
+```
 
-- **0.14.x** stores external object references in hidden tables (`~external_*`)
-- **2.0** stores external object references as JSON fields directly in the table
+**Algorithm:**
 
-| Scenario | Result |
-|----------|--------|
-| Before migration, 2.0 reads 0.x schema | Works - 2.0 can read hidden table format |
-| After migration, 2.0 reads schema | Works - uses JSON field format |
-| After migration, 0.14 reads schema | **Breaks** - 0.14 cannot read JSON format, loses access to external data |
+1. Serialize value using codec-specific format
+2. Compute Blake2b hash of serialized data
+3. Encode hash as base32 (lowercase, no padding)
+4. Apply subfolding if configured
+5. Construct path: `{hash_prefix}/{schema}/{subfolded_hash}`
+6. Store metadata in relational database as JSON
 
-**Warning:** Once external storage is migrated to 2.0 format, reverting to DataJoint 0.14 will result in loss of access to externally stored data. Ensure all users/pipelines are ready for 2.0 before migrating schemas with external storage.
+**Properties:**
+- **Immutable**: Content defines path, cannot be changed
+- **Deduplicated**: Identical content stored once
+- **Integrity**: Hash validates content on retrieval
 
-### Recommended Migration Order
+**Example:**
 
-1. Update all code to DataJoint 2.0
-2. Test with existing schemas (2.0 can read 0.x format)
-3. Migrate schemas once all systems are on 2.0
-4. Verify data access after migration
+```python
+# Table definition
+@schema
+class Experiment(dj.Manual):
+    definition = """
+    experiment_id : int
+    ---
+    data : <blob@main>
+    """
+
+# With config:
+# hash_prefix = "blobs"
+# location = "/data/store"
+# subfolding = [2, 2]
+
+# Insert
+Experiment.insert1({'experiment_id': 1, 'data': my_data})
+
+# Resulting path:
+# /data/store/blobs/my_schema/ab/cd/abcdef123456...
+```
+
+### Schema-Addressed Storage
+
+**Data types:** `<object@store>`, `<npy@store>`
+
+**Path structure (no partitioning):**
+```
+{location}/{schema_prefix}/{schema_name}/{table_name}/{key_string}/{field_name}.{token}.{ext}
+```
+
+**With partitioning:**
+```
+{location}/{schema_prefix}/{partition_path}/{schema_name}/{table_name}/{remaining_key}/{field_name}.{token}.{ext}
+```
+
+**Algorithm:**
+
+1. Extract primary key values from the row
+2. If partition pattern configured, extract partition attributes
+3. Build partition path from partition attributes (if any)
+4. Build remaining key string from non-partition primary key attributes
+5. Generate random token (default 8 characters)
+6. Construct full path
+7. Store path metadata in relational database as JSON
+
+**Partition pattern format:**
+
+```json
+{
+  "partition_pattern": "subject_id/session_date"
+}
+```
+
+This creates paths like:
+```
+{schema_prefix}/subject_id=042/session_date=2024-01-15/{schema}/{table}/{remaining_key}/
+```
+
+**Key string encoding:**
+
+Primary key values are encoded as: `{attr}={value}`
+
+- Multiple attributes joined with `/`
+- Values URL-encoded if necessary
+- Order matches table definition
+
+**Properties:**
+- **Mutable**: Can overwrite by writing to same path
+- **Streaming**: fsspec integration for lazy loading
+- **Organized**: Hierarchical structure mirrors data relationships
+
+**Example without partitioning:**
+
+```python
+@schema
+class Recording(dj.Manual):
+    definition = """
+    subject_id : int
+    session_id : int
+    ---
+    neural_data : <object@main>
+    """
+
+# With config:
+# schema_prefix = "arrays"
+# location = "/data/store"
+# token_length = 8
+
+Recording.insert1({
+    'subject_id': 42,
+    'session_id': 100,
+    'neural_data': zarr_array
+})
+
+# Resulting path:
+# /data/store/arrays/neuroscience/Recording/subject_id=42/session_id=100/neural_data.x8a7b2c4.zarr
+```
+
+**Example with partitioning:**
+
+```python
+# Same table, but with partition configuration:
+# partition_pattern = "subject_id/session_date"
+
+@schema
+class Recording(dj.Manual):
+    definition = """
+    subject_id : int
+    session_date : date
+    session_id : int
+    ---
+    neural_data : <object@main>
+    """
+
+Recording.insert1({
+    'subject_id': 42,
+    'session_date': '2024-01-15',
+    'session_id': 100,
+    'neural_data': zarr_array
+})
+
+# Resulting path:
+# /data/store/arrays/subject_id=42/session_date=2024-01-15/neuroscience/Recording/session_id=100/neural_data.x8a7b2c4.zarr
+```
+
+**Partition extraction:**
+
+When a partition pattern is configured:
+
+1. Check if table has all partition attributes in primary key
+2. If yes: extract those attributes to partition path, remaining attributes to key path
+3. If no: use normal structure (no partitioning for this table)
+
+This allows a single `partition_pattern` to apply to multiple tables, with automatic fallback for tables lacking partition attributes.
+
+**Path collision prevention:**
+
+The random token ensures uniqueness:
+- 8 characters (default): 62^8 = ~218 trillion combinations
+- Collision probability negligible for typical table sizes
+- Token regenerated on each write
+
+### Filepath Storage
+
+**Data type:** `<filepath@store>`
+
+**Path structure:**
+```
+{location}/{filepath_prefix}/{user_path}
+```
+
+Or if `filepath_prefix = null`:
+```
+{location}/{user_path}
+```
+
+**Algorithm:**
+
+1. User provides relative path within store
+2. Validate path doesn't use reserved sections (`hash_prefix`, `schema_prefix`)
+3. If `filepath_prefix` configured, validate path starts with it
+4. Check file exists at `{location}/{user_path}`
+5. Record path, size, and timestamp in JSON metadata
+6. No file copying occurs
+
+**Properties:**
+- **Path-only storage**: DataJoint stores path string, no file management
+- **No lifecycle management**: No garbage collection, transaction safety, or deduplication
+- **User-managed**: User controls file creation, organization, and lifecycle
+- **Collision-prone**: **User responsible for avoiding name collisions**
+- **Flexible**: Can reference existing files or create new ones
+
+**Collision handling:**
+
+DataJoint does **not** prevent filename collisions for filepath storage. Users must ensure:
+
+1. Unique paths for each referenced file
+2. No overwrites of files still referenced by database
+3. Coordination if multiple processes write to same store
+
+**Strategies for avoiding collisions:**
+
+```python
+# Strategy 1: Include primary key in path
+recording_path = f"subject_{subject_id}/session_{session_id}/data.bin"
+
+# Strategy 2: Use UUIDs
+import uuid
+recording_path = f"recordings/{uuid.uuid4()}.nwb"
+
+# Strategy 3: Timestamps
+from datetime import datetime
+recording_path = f"data_{datetime.now().isoformat()}.dat"
+
+# Strategy 4: Enforce via filepath_prefix
+# Config: "filepath_prefix": "recordings"
+# All paths must start with recordings/, organize within that namespace
+```
+
+**Reserved sections:**
+
+Filepath storage cannot use paths starting with configured `hash_prefix` or `schema_prefix`:
+
+```python
+# Invalid (default prefixes)
+table.insert1({'id': 1, 'file': '_hash/data.bin'})       # ERROR
+table.insert1({'id': 2, 'file': '_schema/data.zarr'})    # ERROR
+
+# Invalid (custom prefixes: hash_prefix="blobs")
+table.insert1({'id': 3, 'file': 'blobs/data.bin'})       # ERROR
+
+# Valid
+table.insert1({'id': 4, 'file': 'raw/subject01/rec.bin'})  # OK
+```
+
+**Example:**
+
+```python
+@schema
+class RawRecording(dj.Manual):
+    definition = """
+    recording_id : uuid
+    ---
+    acquisition_file : <filepath@acquisition>
+    """
+
+# With config:
+# filepath_prefix = "imported"
+# location = "/data/acquisition"
+
+# File already exists at: /data/acquisition/imported/subject01/session001/data.nwb
+
+RawRecording.insert1({
+    'recording_id': my_uuid,
+    'acquisition_file': 'imported/subject01/session001/data.nwb'
+})
+
+# DataJoint validates file exists, stores reference
+# User responsible for ensuring path uniqueness across recordings
+```
+
+## Storage Type Comparison
+
+| Feature | Hash-addressed | Schema-addressed | Filepath |
+|---------|----------------|------------------|----------|
+| **Mutability** | Immutable | Mutable | User-managed |
+| **Deduplication** | Automatic | None | None |
+| **Streaming** | No (load full) | Yes (fsspec) | Yes (fsspec) |
+| **Organization** | Flat (by hash) | Hierarchical (by key) | User-defined |
+| **Collision handling** | Automatic (by content) | Automatic (token) | **User responsibility** |
+| **DataJoint manages lifecycle** | Yes | Yes | **No** |
+| **Suitable for** | Immutable blobs | Large mutable arrays | Existing files |
+
+## Protocol-Specific Configuration
+
+### File Protocol
+
+```json
+{
+  "protocol": "file",
+  "location": "/data/my-project",
+  "hash_prefix": "blobs",
+  "schema_prefix": "arrays",
+  "filepath_prefix": null
+}
+```
+
+**Required:** `protocol`, `location`
+
+### S3 Protocol
+
+```json
+{
+  "protocol": "s3",
+  "endpoint": "s3.amazonaws.com",
+  "bucket": "my-bucket",
+  "location": "my-project/production",
+  "secure": true,
+  "hash_prefix": "blobs",
+  "schema_prefix": "arrays"
+}
+```
+
+**Required:** `protocol`, `endpoint`, `bucket`, `location`, `access_key`, `secret_key`
+
+**Credentials:** Store in `.secrets/stores.<name>.access_key` and `.secrets/stores.<name>.secret_key`
+
+### GCS Protocol
+
+```json
+{
+  "protocol": "gcs",
+  "bucket": "my-gcs-bucket",
+  "location": "my-project",
+  "project": "my-gcp-project",
+  "hash_prefix": "blobs",
+  "schema_prefix": "arrays"
+}
+```
+
+**Required:** `protocol`, `bucket`, `location`, `token`
+
+**Credentials:** Store in `.secrets/stores.<name>.token` (path to service account JSON)
+
+### Azure Protocol
+
+```json
+{
+  "protocol": "azure",
+  "container": "my-container",
+  "location": "my-project",
+  "hash_prefix": "blobs",
+  "schema_prefix": "arrays"
+}
+```
+
+**Required:** `protocol`, `container`, `location`, `account_name`, `account_key`
+
+**Credentials:** Store in `.secrets/stores.<name>.account_key`
+
+## Migration from Legacy Storage
+
+DataJoint 0.14.x used separate configuration systems:
+
+### Legacy "External" Storage (Hash-addressed Integrated)
+
+```python
+# 0.14.x config
+dj.config['stores'] = {
+    'my_store': {
+        'protocol': 's3',
+        'endpoint': 's3.amazonaws.com',
+        'bucket': 'my-bucket',
+        'location': 'my-project',
+        'access_key': 'XXX',
+        'secret_key': 'YYY'
+    }
+}
+
+# 0.14.x usage
+data : external-my_store
+```
+
+### 2.0 Equivalent
+
+```json
+{
+  "stores": {
+    "default": "my_store",
+    "my_store": {
+      "protocol": "s3",
+      "endpoint": "s3.amazonaws.com",
+      "bucket": "my-bucket",
+      "location": "my-project",
+      "hash_prefix": "_hash"
+    }
+  }
+}
+```
+
+Credentials moved to `.secrets/`:
+```
+.secrets/stores.my_store.access_key
+.secrets/stores.my_store.secret_key
+```
+
+```python
+# 2.0 usage (equivalent)
+data : <blob@my_store>
+```
+
+### New in 2.0: Schema-addressed Storage
+
+Schema-addressed storage (`<object@>`, `<npy@>`) is entirely new in DataJoint 2.0. No migration needed as this feature didn't exist in 0.14.x.
+
+## Validation and Testing
+
+### Verify Store Configuration
+
+```python
+import datajoint as dj
+
+# Check default store
+spec = dj.config.get_store_spec()
+print(f"Default store: {dj.config['stores']['default']}")
+print(f"Protocol: {spec['protocol']}")
+print(f"Location: {spec['location']}")
+print(f"Hash prefix: {spec['hash_prefix']}")
+print(f"Schema prefix: {spec['schema_prefix']}")
+print(f"Filepath prefix: {spec['filepath_prefix']}")
+
+# Check named store
+spec = dj.config.get_store_spec('archive')
+print(f"Archive location: {spec['location']}")
+
+# List all stores
+print(f"Configured stores: {list(dj.config['stores'].keys())}")
+```
+
+### Test Storage Access
+
+```python
+from datajoint.hash_registry import get_store_backend
+
+# Test backend connectivity
+backend = get_store_backend('main')
+print(f"Backend type: {type(backend)}")
+
+# For file protocol, check paths exist
+if spec['protocol'] == 'file':
+    import os
+    assert os.path.exists(spec['location']), f"Location not found: {spec['location']}"
+```
+
+## Best Practices
+
+### Store Organization
+
+1. **Use one default store** for most data
+2. **Add specialized stores** for specific needs:
+   - `archive` — long-term cold storage
+   - `fast` — high-performance tier
+   - `shared` — cross-project data
+   - `raw` — acquisition files (filepath only)
+
+### Prefix Configuration
+
+1. **Use defaults** unless integrating with existing storage
+2. **Choose meaningful names** if customizing: `blobs`, `arrays`, `user_files`
+3. **Keep prefixes short** to minimize path length
+
+### Secret Management
+
+1. **Never commit credentials** to version control
+2. **Use `.secrets/` directory** for all credentials
+3. **Set restrictive permissions**: `chmod 700 .secrets`
+4. **Document required secrets** in project README
+
+### Partitioning Strategy
+
+1. **Choose partition attributes carefully:**
+   - High cardinality (many unique values)
+   - Natural data organization (subject, date)
+   - Query patterns (often filtered by these attributes)
+
+2. **Example patterns:**
+   - Neuroscience: `subject_id/session_date`
+   - Genomics: `sample_id/sequencing_run`
+   - Microscopy: `experiment_id/imaging_session`
+
+3. **Avoid over-partitioning:**
+   - Don't partition by high-cardinality unique IDs
+   - Limit to 2-3 partition levels
+
+### Filepath Usage
+
+1. **Design naming conventions** before inserting data
+2. **Include unique identifiers** in paths
+3. **Document collision prevention strategy** for the team
+4. **Consider using `filepath_prefix`** to enforce structure
+
+## See Also
+
+- [Configuration Reference](../configuration.md) — All configuration options
+- [Configure Object Stores](../../how-to/configure-storage.md) — Setup guide
+- [Type System Specification](type-system.md) — Data type definitions
+- [Codec API Specification](codec-api.md) — Codec implementation details
 
 
 ---
@@ -16384,10 +25253,6 @@ dj.U('a', 'b') * A  # DataJointError with migration guidance
 ## File: reference/specs/query-algebra.md
 
 # DataJoint Query Algebra Specification
-
-Version: 1.0
-Status: Draft
-Last Updated: 2026-01-07
 
 ## Overview
 
@@ -17226,7 +26091,104 @@ Session & dj.Top(None, "session_date DESC")
 
 ---
 
-## 13. Implementation Reference
+## 13. SQL Transpilation
+
+This section describes how DataJoint translates query expressions to SQL.
+
+### 13.1 MySQL Clause Evaluation Order
+
+MySQL differs from standard SQL in clause evaluation:
+
+```
+Standard SQL: FROM → WHERE → GROUP BY → HAVING → SELECT
+MySQL:        FROM → WHERE → SELECT → GROUP BY → HAVING
+```
+
+This allows `GROUP BY` and `HAVING` clauses to use alias column names created by `SELECT`. DataJoint targets MySQL's behavior where column aliases can be used in `HAVING`.
+
+### 13.2 QueryExpression Properties
+
+Each `QueryExpression` represents a `SELECT` statement with these properties:
+
+| Property | SQL Clause | Description |
+|----------|------------|-------------|
+| `heading` | `SELECT` | Attributes to retrieve |
+| `restriction` | `WHERE` | List of conditions (AND) |
+| `support` | `FROM` | Tables/subqueries to query |
+
+Operators create new expressions by combining these properties:
+- `proj` → creates new `heading`
+- `&` → appends to `restriction`
+- `*` → adds to `support`
+
+### 13.3 Subquery Generation Rules
+
+Operators merge properties when possible, avoiding subqueries. A subquery is generated when:
+
+| Situation | Reason |
+|-----------|--------|
+| Restriction uses alias attributes | Alias must exist in SELECT before WHERE can reference it |
+| Projection creates alias from alias | Must materialize first alias |
+| Join on alias attribute | Alias must exist before join condition |
+| Aggregation as operand | GROUP BY requires complete subquery |
+| Union operand | UNION requires complete subqueries |
+
+When a subquery is created, the input becomes a `FROM` clause element in a new `QueryExpression`.
+
+### 13.4 Join Mechanics
+
+Joins combine the properties of both inputs:
+
+```python
+result.support = A.support + B.support
+result.restriction = A.restriction + B.restriction
+result.heading = merge(A.heading, B.heading)
+```
+
+Restrictions from inputs propagate to the output. Inputs that don't become subqueries donate their supports, restrictions, and projections directly to the join.
+
+### 13.5 Aggregation SQL
+
+Aggregation translates to:
+
+```sql
+SELECT A.pk, A.secondary, agg_func(B.col) AS computed
+FROM A
+LEFT JOIN B USING (pk)
+WHERE <restrictions on A>
+GROUP BY A.pk
+HAVING <restrictions on B or computed>
+```
+
+Key behavior:
+- Restrictions on A → `WHERE` clause (before grouping)
+- Restrictions on B or computed attributes → `HAVING` clause (after grouping)
+- Aggregation never generates a subquery when restricted
+
+### 13.6 Union SQL
+
+Union performs an outer join:
+
+```sql
+(SELECT A.pk, A.secondary, NULL as B.secondary FROM A)
+UNION
+(SELECT B.pk, NULL as A.secondary, B.secondary FROM B
+ WHERE B.pk NOT IN (SELECT pk FROM A))
+```
+
+All union inputs become subqueries except unrestricted unions.
+
+### 13.7 Query Backprojection
+
+Before execution, `finalize()` recursively projects out unnecessary attributes from all inputs. This optimization:
+
+- Reduces data transfer (especially for blobs)
+- Compensates for MySQL's query optimizer limitations
+- Produces leaner queries for complex expressions
+
+---
+
+## 14. Implementation Reference
 
 | File | Purpose |
 |------|---------|
@@ -17238,7 +26200,7 @@ Session & dj.Top(None, "session_date DESC")
 
 ---
 
-## 14. Quick Reference
+## 15. Quick Reference
 
 | Operation | Syntax | Result PK |
 |-----------|--------|-----------|
@@ -17488,7 +26450,9 @@ dj.U('a', 'b') * A   # DataJointError: use & instead
 
 ### Attribute Lineage
 
-Lineage identifies the **origin** of an attribute - where it was first defined. It is represented as a string:
+Lineage identifies the **origin** of an attribute—the **dimension** where it was first defined. A dimension is an independent axis of variation introduced by a table that defines new primary key attributes. See [Schema Dimensions](../../explanation/entity-integrity.md#schema-dimensions) for details.
+
+Lineage is represented as a string:
 
 ```
 schema_name.table_name.attribute_name
@@ -17802,10 +26766,6 @@ class Marriage(dj.Manual):
 ## File: reference/specs/table-declaration.md
 
 # DataJoint Table Declaration Specification
-
-Version: 1.0
-Status: Draft
-Last Updated: 2026-01-07
 
 ## Overview
 
@@ -18402,45 +27362,25 @@ This document defines a three-layer type architecture:
 2. **Core DataJoint types** - Standardized across backends, scientist-friendly (`float32`, `uint8`, `bool`, `json`).
 3. **Codec Types** - Programmatic types with `encode()`/`decode()` semantics. Composable.
 
-```mermaid
-block-beta
-    columns 1
-    block:layer3:1
-        columns 1
-        L3["Codec Types (Layer 3)"]
-        B3a["Built-in: &lt;blob&gt; &lt;attach&gt; &lt;object@&gt; &lt;hash@&gt; &lt;filepath@&gt;"]
-        B3b["User-defined: &lt;graph&gt; &lt;image&gt; &lt;custom&gt; ..."]
-    end
-    block:layer2:1
-        columns 1
-        L2["Core DataJoint Types (Layer 2)"]
-        B2["float32 float64 int64 uint64 int32 uint32 int16 uint16\nint8 uint8 bool uuid json bytes date datetime\nchar(n) varchar(n) enum(...) decimal(n,f)"]
-    end
-    block:layer1:1
-        columns 1
-        L1["Native Database Types (Layer 1)"]
-        B1["MySQL: TINYINT SMALLINT INT BIGINT FLOAT DOUBLE TEXT ...\nPostgreSQL: SMALLINT INTEGER BIGINT REAL DOUBLE PRECISION TEXT\n(pass through with warning — discouraged)"]
-    end
-    layer3 --> layer2 --> layer1
-```
-
 | Layer | Description | Examples |
 |-------|-------------|----------|
-| **3. Codec Types** | Programmatic types with `encode()`/`decode()` semantics | `<blob>`, `<attach>`, `<object@>`, `<hash@>`, `<filepath@>` |
-| **2. Core DataJoint** | Standardized, scientist-friendly types (preferred) | `int32`, `float64`, `varchar(n)`, `bool`, `datetime` |
+| **3. Codec Types** | Programmatic types with `encode()`/`decode()` semantics | `<blob>`, `<attach>`, `<object@>`, `<hash@>`, `<filepath@>`, user-defined |
+| **2. Core DataJoint** | Standardized, scientist-friendly types (preferred) | `int32`, `float64`, `varchar(n)`, `bool`, `datetime`, `json`, `bytes` |
 | **1. Native Database** | Backend-specific types (discouraged) | `INT`, `FLOAT`, `TINYINT UNSIGNED`, `LONGBLOB` |
+
+Codec types resolve through core types to native types: `<blob>` → `bytes` → `LONGBLOB`.
 
 **Syntax distinction:**
 - Core types: `int32`, `float64`, `varchar(255)` - no brackets
 - Codec types: `<blob>`, `<object@store>`, `<filepath@main>` - angle brackets
-- The `@` character indicates external storage (object store vs database)
+- The `@` character indicates store (object storage vs inline in database)
 
-### OAS Storage Regions
+### OAS Addressing Schemes
 
-| Region | Path Pattern | Addressing | Use Case |
-|--------|--------------|------------|----------|
-| Object | `{schema}/{table}/{pk}/` | Primary key | Large objects, Zarr, HDF5 |
-| Hash | `_hash/{hash}` | MD5 hash | Deduplicated blobs/files |
+| Scheme | Path Pattern | Description | Use Case |
+|--------|--------------|-------------|----------|
+| **Schema-addressed** | `{schema}/{table}/{pk}/` | Path mirrors database structure | Large objects, Zarr, HDF5, numpy arrays |
+| **Hash-addressed** | `_hash/{hash}` | Path from content hash (MD5) | Deduplicated blobs/attachments |
 
 ### URL Representation
 
@@ -18458,7 +27398,7 @@ This unified approach treats all storage backends uniformly via fsspec, enabling
 - Transparent switching between storage backends
 - Streaming access to any storage type
 
-### External References
+### Store References
 
 `<filepath@store>` provides portable relative paths within configured stores with lazy ObjectRef access.
 For arbitrary URLs that don't need ObjectRef semantics, use `varchar` instead.
@@ -18629,103 +27569,25 @@ composable and can be built-in or user-defined.
 
 ### Storage Mode: `@` Convention
 
-The `@` character in codec syntax indicates **external storage** (object store):
+The `@` character in codec syntax indicates **object store** (vs inline in database):
 
-- **No `@`**: Internal storage (database) - e.g., `<blob>`, `<attach>`
-- **`@` present**: External storage (object store) - e.g., `<blob@>`, `<attach@store>`
+- **No `@`**: Inline storage (database column) - e.g., `<blob>`, `<attach>`
+- **`@` present**: Object store - e.g., `<blob@>`, `<attach@store>`
 - **`@` alone**: Use default store - e.g., `<blob@>`
 - **`@name`**: Use named store - e.g., `<blob@cold>`
 
-Some codecs support both modes (`<blob>`, `<attach>`), others are external-only (`<object@>`, `<hash@>`, `<filepath@>`).
+Some codecs support both modes (`<blob>`, `<attach>`), others are store-only (`<object@>`, `<npy@>`, `<hash@>`, `<filepath@>`).
 
 ### Codec Base Class
 
-Codecs auto-register when subclassed using Python's `__init_subclass__` mechanism.
-No decorator is needed.
-
-```python
-from abc import ABC, abstractmethod
-from typing import Any
-
-# Global codec registry
-_codec_registry: dict[str, "Codec"] = {}
-
-
-class Codec(ABC):
-    """
-    Base class for codec types. Subclasses auto-register by name.
-
-    Requires Python 3.10+.
-    """
-    name: str | None = None  # Must be set by concrete subclasses
-
-    def __init_subclass__(cls, *, register: bool = True, **kwargs):
-        """Auto-register concrete codecs when subclassed."""
-        super().__init_subclass__(**kwargs)
-
-        if not register:
-            return  # Skip registration for abstract bases
-
-        if cls.name is None:
-            return  # Skip registration if no name (abstract)
-
-        if cls.name in _codec_registry:
-            existing = _codec_registry[cls.name]
-            if type(existing) is not cls:
-                raise DataJointError(
-                    f"Codec <{cls.name}> already registered by {type(existing).__name__}"
-                )
-            return  # Same class, idempotent
-
-        _codec_registry[cls.name] = cls()
-
-    def get_dtype(self, is_external: bool) -> str:
-        """
-        Return the storage dtype for this codec.
-
-        Args:
-            is_external: True if @ modifier present (external storage)
-
-        Returns:
-            A core type (e.g., "bytes", "json") or another codec (e.g., "<hash>")
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def encode(self, value: Any, *, key: dict | None = None, store_name: str | None = None) -> Any:
-        """Encode Python value for storage."""
-        ...
-
-    @abstractmethod
-    def decode(self, stored: Any, *, key: dict | None = None) -> Any:
-        """Decode stored value back to Python."""
-        ...
-
-    def validate(self, value: Any) -> None:
-        """Optional validation before encoding. Override to add constraints."""
-        pass
-
-
-def list_codecs() -> list[str]:
-    """Return list of registered codec names."""
-    return sorted(_codec_registry.keys())
-
-
-def get_codec(name: str) -> Codec:
-    """Get codec by name. Raises DataJointError if not found."""
-    if name not in _codec_registry:
-        raise DataJointError(f"Unknown codec: <{name}>")
-    return _codec_registry[name]
-```
-
-**Usage - no decorator needed:**
+Codecs inherit from `dj.Codec` and auto-register when their class is defined. See the [Codec API Specification](codec-api.md) for complete details on creating custom codecs.
 
 ```python
 class GraphCodec(dj.Codec):
     """Auto-registered as <graph>."""
     name = "graph"
 
-    def get_dtype(self, is_external: bool) -> str:
+    def get_dtype(self, is_store: bool) -> str:
         return "<blob>"
 
     def encode(self, graph, *, key=None, store_name=None):
@@ -18739,47 +27601,32 @@ class GraphCodec(dj.Codec):
         return G
 ```
 
-**Skip registration for abstract bases:**
-
-```python
-class ExternalOnlyCodec(dj.Codec, register=False):
-    """Abstract base for external-only codecs. Not registered."""
-
-    def get_dtype(self, is_external: bool) -> str:
-        if not is_external:
-            raise DataJointError(f"<{self.name}> requires @ (external only)")
-        return "json"
-```
-
 ### Codec Resolution and Chaining
 
-Codecs resolve to core types through chaining. The `get_dtype(is_external)` method
+Codecs resolve to core types through chaining. The `get_dtype(is_store)` method
 returns the appropriate dtype based on storage mode:
 
-```
-Resolution at declaration time:
+| Codec | `is_store` | Resolution Chain | SQL Type |
+|-------|------------|------------------|----------|
+| `<blob>` | `False` | `"bytes"` | `LONGBLOB`/`BYTEA` |
+| `<blob@>` | `True` | `"<hash>"` → `"json"` | `JSON`/`JSONB` |
+| `<blob@cold>` | `True` | `"<hash>"` → `"json"` (store=cold) | `JSON`/`JSONB` |
+| `<attach>` | `False` | `"bytes"` | `LONGBLOB`/`BYTEA` |
+| `<attach@>` | `True` | `"<hash>"` → `"json"` | `JSON`/`JSONB` |
+| `<object@>` | `True` | `"json"` | `JSON`/`JSONB` |
+| `<npy@>` | `True` | `"json"` | `JSON`/`JSONB` |
+| `<object>` | `False` | ERROR (store only) | — |
+| `<npy>` | `False` | ERROR (store only) | — |
+| `<hash@>` | `True` | `"json"` | `JSON`/`JSONB` |
+| `<filepath@>` | `True` | `"json"` | `JSON`/`JSONB` |
 
-<blob>         → get_dtype(False) → "bytes"     → LONGBLOB/BYTEA
-<blob@>        → get_dtype(True)  → "<hash>" → json → JSON/JSONB
-<blob@cold>    → get_dtype(True)  → "<hash>" → json (store=cold)
+### `<object@>` / `<object@store>` - Schema-Addressed Storage
 
-<attach>       → get_dtype(False) → "bytes"     → LONGBLOB/BYTEA
-<attach@>      → get_dtype(True)  → "<hash>" → json → JSON/JSONB
+**Built-in codec. Store only.**
 
-<object@>      → get_dtype(True)  → "json"      → JSON/JSONB
-<object>       → get_dtype(False) → ERROR (external only)
+Schema-addressed OAS storage for files and folders:
 
-<hash@>     → get_dtype(True)  → "json"      → JSON/JSONB
-<filepath@s>   → get_dtype(True)  → "json"      → JSON/JSONB
-```
-
-### `<object@>` / `<object@store>` - Path-Addressed Storage
-
-**Built-in codec. External only.**
-
-OAS (Object-Augmented Schema) storage for files and folders:
-
-- Path derived from primary key: `{schema}/{table}/{pk}/{attribute}/`
+- **Schema-addressed**: Path mirrors database structure: `{schema}/{table}/{pk}/{attribute}/`
 - One-to-one relationship with table row
 - Deleted when row is deleted
 - Returns `ObjectRef` for lazy access
@@ -18799,46 +27646,45 @@ class Analysis(dj.Computed):
 #### Implementation
 
 ```python
-class ObjectCodec(dj.Codec):
-    """Path-addressed OAS storage. External only."""
+class ObjectCodec(SchemaCodec):
+    """Schema-addressed OAS storage. Store only."""
     name = "object"
 
-    def get_dtype(self, is_external: bool) -> str:
-        if not is_external:
-            raise DataJointError("<object> requires @ (external storage only)")
-        return "json"
+    # get_dtype inherited from SchemaCodec
 
     def encode(self, value, *, key=None, store_name=None) -> dict:
-        store = get_store(store_name or dj.config['stores']['default'])
-        path = self._compute_path(key)  # {schema}/{table}/{pk}/{attr}/
-        store.put(path, value)
+        schema, table, field, pk = self._extract_context(key)
+        path, _ = self._build_path(schema, table, field, pk)
+        backend = self._get_backend(store_name)
+        backend.put(path, value)
         return {"path": path, "store": store_name, ...}
 
     def decode(self, stored: dict, *, key=None) -> ObjectRef:
-        return ObjectRef(store=get_store(stored["store"]), path=stored["path"])
+        backend = self._get_backend(stored["store"])
+        return ObjectRef.from_json(stored, backend=backend)
 ```
 
 ### `<hash@>` / `<hash@store>` - Hash-Addressed Storage
 
-**Built-in codec. External only.**
+**Built-in codec. Store only.**
 
 Hash-addressed storage with deduplication:
 
+- **Hash-addressed**: Path derived from content hash: `_hash/{hash[:2]}/{hash[2:4]}/{hash}`
 - **Single blob only**: stores a single file or serialized object (not folders)
 - **Per-project scope**: content is shared across all schemas in a project (not per-schema)
-- Path derived from content hash: `_hash/{hash[:2]}/{hash[2:4]}/{hash}`
 - Many-to-one: multiple rows (even across schemas) can reference same content
 - Reference counted for garbage collection
 - Deduplication: identical content stored once across the entire project
-- For folders/complex objects, use `object` type instead
+- For folders/complex objects, use `<object@>` instead
 - **dtype**: `json` (stores hash, store name, size, metadata)
 
 ```
 store_root/
-├── {schema}/{table}/{pk}/     # object storage (path-addressed by PK)
+├── {schema}/{table}/{pk}/     # schema-addressed storage
 │   └── {attribute}/
 │
-└── _hash/                   # content storage (hash-addressed)
+└── _hash/                     # hash-addressed storage
     └── {hash[:2]}/{hash[2:4]}/{hash}
 ```
 
@@ -18846,12 +27692,12 @@ store_root/
 
 ```python
 class HashCodec(dj.Codec):
-    """Hash-addressed storage. External only."""
+    """Hash-addressed storage. Store only."""
     name = "hash"
 
-    def get_dtype(self, is_external: bool) -> str:
-        if not is_external:
-            raise DataJointError("<hash> requires @ (external storage only)")
+    def get_dtype(self, is_store: bool) -> str:
+        if not is_store:
+            raise DataJointError("<hash> requires @ (store only)")
         return "json"
 
     def encode(self, data: bytes, *, key=None, store_name=None) -> dict:
@@ -19085,48 +27931,13 @@ class Attachments(dj.Manual):
 
 ## User-Defined Codecs
 
-Users can define custom codecs for domain-specific data:
+Users can define custom codecs for domain-specific data. See the [Codec API Specification](codec-api.md) for complete examples including:
 
-```python
-class GraphCodec(dj.Codec):
-    """Store NetworkX graphs. Internal only (no external support)."""
-    name = "graph"
-
-    def get_dtype(self, is_external: bool) -> str:
-        if is_external:
-            raise DataJointError("<graph> does not support external storage")
-        return "<blob>"  # Chain to blob for serialization
-
-    def encode(self, graph, *, key=None, store_name=None):
-        return {'nodes': list(graph.nodes()), 'edges': list(graph.edges())}
-
-    def decode(self, stored, *, key=None):
-        import networkx as nx
-        G = nx.Graph()
-        G.add_nodes_from(stored['nodes'])
-        G.add_edges_from(stored['edges'])
-        return G
-```
-
-Custom codecs can support both modes by returning different dtypes:
-
-```python
-class ImageCodec(dj.Codec):
-    """Store images. Supports both internal and external."""
-    name = "image"
-
-    def get_dtype(self, is_external: bool) -> str:
-        return "<hash>" if is_external else "bytes"
-
-    def encode(self, image, *, key=None, store_name=None) -> bytes:
-        # Convert PIL Image to PNG bytes
-        buffer = io.BytesIO()
-        image.save(buffer, format='PNG')
-        return buffer.getvalue()
-
-    def decode(self, stored: bytes, *, key=None):
-        return PIL.Image.open(io.BytesIO(stored))
-```
+- Simple serialization codecs
+- External storage codecs
+- JSON with schema validation
+- Context-dependent encoding
+- External-only codecs (Zarr, HDF5)
 
 ## Storage Comparison
 
@@ -19241,8 +28052,7 @@ Content-addressed storage uses **MD5** (128-bit, 32-char hex) rather than SHA256
    The new system changes only the storage format (hex string in JSON vs binary UUID),
    not the underlying hash algorithm. This simplifies migration.
 
-5. **Consistency with existing codebase**: The `dj.hash` module already uses MD5 for
-   `key_hash()` (job reservation) and `uuid_from_buffer()` (query caching).
+5. **Consistency with existing codebase**: Internal functions use MD5 for query caching.
 
 **Why not SHA256?**
 
@@ -19324,10 +28134,6 @@ def migrate_external_store(schema, store_name):
 ## File: reference/specs/virtual-schemas.md
 
 # Virtual Schemas Specification
-
-Version: 1.0
-Status: Stable
-Last Updated: 2026-01-08
 
 ## Overview
 
@@ -19492,13 +28298,13 @@ lab.schema.list_tables()  # ['subject', 'session', ...]
 
 ## 4. Table Class Generation
 
-### 4.1 `spawn_missing_classes()`
+### 4.1 `make_classes()`
 
 Create Python classes for all tables in a schema:
 
 ```python
 schema = dj.Schema('existing_schema')
-schema.spawn_missing_classes(context=locals())
+schema.make_classes()
 
 # Now table classes are available in local namespace
 Subject.fetch()
@@ -19506,7 +28312,7 @@ Session & 'date > "2024-01-01"'
 ```
 
 **Parameters:**
-- `context` (dict): Namespace to populate. Defaults to caller's locals.
+- `into` (dict, optional): Namespace to populate. Defaults to caller's locals.
 
 ### 4.2 Generated Class Types
 
@@ -19573,21 +28379,22 @@ class Analysis(dj.Computed):
 old = dj.virtual_schema('old_schema')
 new = dj.Schema('new_schema')
 
-# Copy data
+# Copy data in topological order (iteration yields dependencies first)
 for table in old:
     new_table = new.get_table(table.table_name)
-    new_table.insert(table.fetch(as_dict=True))
+    # Server-side INSERT...SELECT (no client-side data transfer)
+    new_table.insert(table)
 ```
 
 ### 5.4 Garbage Collection
 
 ```python
-from datajoint.gc import scan_content_references
+from datajoint.gc import scan_hash_references
 
 schema = dj.Schema('my_schema')
 
-# Scan all tables for content references
-refs = scan_content_references(schema, verbose=True)
+# Scan all tables for hash references
+refs = scan_hash_references(schema, verbose=True)
 ```
 
 ---
@@ -19601,7 +28408,7 @@ refs = scan_content_references(schema, verbose=True)
 | `for t in schema` | Iterate all tables | `FreeTable` generator |
 | `'Name' in schema` | Check existence | `bool` |
 | `dj.virtual_schema(name)` | Module-like access | `VirtualModule` |
-| `spawn_missing_classes()` | Populate namespace | None (side effect) |
+| `make_classes()` | Populate namespace | None (side effect) |
 
 ---
 
@@ -19715,6 +28522,48 @@ Found a bug or have a feature request? Open an issue on GitHub:
 - [datajoint-python issues](https://github.com/datajoint/datajoint-python/issues)
 - [datajoint-docs issues](https://github.com/datajoint/datajoint-docs/issues)
 
+### Propose Enhancements (RFC Process)
+
+For significant changes to DataJoint—new features, API changes, or specification updates—we use an RFC (Request for Comments) process via GitHub Discussions.
+
+**When to use an RFC:**
+
+- API changes or new features in datajoint-python
+- Changes to the DataJoint specification
+- Breaking changes or deprecations
+- Major documentation restructuring
+
+**RFC Process:**
+
+1. **Propose** — Create a new Discussion using the RFC template in the appropriate repository:
+   - [datajoint-python Discussions](https://github.com/datajoint/datajoint-python/discussions/new?category=rfc)
+   - [datajoint-docs Discussions](https://github.com/datajoint/datajoint-docs/discussions/new?category=rfc)
+
+2. **Discuss** — Community and maintainers provide feedback (2-4 weeks). Use 👍/👎 reactions to signal support. Prototyping in parallel is encouraged.
+
+3. **Final Comment Period** — Once consensus emerges, maintainers announce a 1-2 week final comment period. No changes during this time.
+
+4. **Decision** — RFC is accepted, rejected, or postponed. Accepted RFCs become tracking issues for implementation.
+
+**RFC Labels:**
+
+| Label | Meaning |
+|-------|---------|
+| `rfc` | All enhancement proposals |
+| `status: proposed` | Initial submission |
+| `status: under-review` | Active discussion |
+| `status: final-comment` | Final comment period |
+| `status: accepted` | Approved for implementation |
+| `status: rejected` | Not accepted |
+| `status: postponed` | Deferred to future |
+
+**Tips for a good RFC:**
+
+- Search existing discussions first
+- Include concrete use cases and code examples
+- Consider backwards compatibility
+- Start with motivation before diving into design
+
 ### Improve Documentation
 
 Documentation improvements are valuable contributions:
@@ -19764,18 +28613,12 @@ mkdocs serve
 
 ## Testing
 
-```bash
-# Run unit tests
-pytest tests/unit
-
-# Run integration tests (requires Docker)
-DOCKER_HOST=unix:///path/to/docker.sock pytest tests/
-```
+See the [Developer Guide](https://github.com/datajoint/datajoint-python/blob/main/CONTRIBUTING.md)
+for current testing instructions using `pixi` and `testcontainers`.
 
 ## Questions?
 
 - Open a [GitHub Discussion](https://github.com/datajoint/datajoint-python/discussions)
-- Join the [DataJoint Slack](https://datajoint.slack.com)
 
 
 ---
@@ -19864,4 +28707,302 @@ DataJoint is developed openly on GitHub. Contributions are welcome.
 DataJoint is released under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 Copyright 2024 DataJoint Inc. and contributors.
+
+
+---
+## File: about/platform.md
+
+# DataJoint Platform
+
+The **DataJoint Platform** extends the open-source DataJoint library with managed infrastructure and tools for team-based data operations.
+
+## Architecture
+
+The platform builds on the open-source core—relational database, code repository, and object storage—with functional extensions organized into four categories:
+
+### Interactions
+
+Tools for different users and tasks:
+
+- **Pipeline Navigator** — Visual exploration of schema diagrams, table contents, and data dependencies
+- **Electronic Lab Notebook** — Integration with laboratory documentation for manual data entry and experimental notes
+- **Development Environment** — Support for Jupyter notebooks, VS Code, and other scientific programming tools
+- **Visualization Dashboard** — Interactive exploration of results and pipeline status
+
+### Infrastructure
+
+Managed computing resources:
+
+- **Security** — Access control integrated with institutional identity management
+- **Deployment** — Cloud platforms (AWS, GCP, Azure) and hybrid configurations
+- **Compute Resources** — Integration with HPC clusters, GPU resources, and cloud compute
+
+### Automation
+
+Intelligent workflow execution:
+
+- **Automated Population** — The `populate()` mechanism identifies and executes missing computations
+- **Job Orchestration** — Integration with workflow schedulers (Airflow, SLURM, Kubernetes)
+- **AI Pipeline Agent** — Emerging capabilities for AI-assisted pipeline development and operation
+
+### Orchestration
+
+Coordination across the data lifecycle:
+
+- **Data Ingest** — Tools for importing data from instruments and external systems
+- **Collaboration** — Shared database access with coordinated permissions
+- **Export & Integration** — Capabilities for delivering results to downstream systems
+
+## Open-Source vs Platform
+
+| Capability | Open-Source | Platform |
+|------------|-------------|----------|
+| Core library | ✅ | ✅ |
+| Schema definition | ✅ | ✅ |
+| Query algebra | ✅ | ✅ |
+| AutoPopulate | ✅ | ✅ |
+| Object storage | ✅ | ✅ Managed |
+| Database hosting | Self-managed | ✅ Managed |
+| User management | Self-managed | ✅ Managed |
+| Visual tools | — | ✅ |
+| Job orchestration | Self-managed | ✅ Managed |
+| Support | Community | ✅ Enterprise |
+
+## Learn More
+
+- [Request a Platform account](https://www.datajoint.com/sign-up)
+- [DataJoint website](https://www.datajoint.com)
+
+
+---
+## File: about/publications.md
+
+# Publications
+
+The following publications relied on DataJoint open-source software for data analysis.
+If your work uses DataJoint or DataJoint Elements, please cite the respective
+[manuscripts and RRIDs](./citation.md).
+
+## 2025
+
++ Bae, J. A., Baptiste, M., Bodor, A. L., Brittain, D., Buchanan, J., Bumbarger, D. J., Castro, M. A., Celii, B., Cobos, E., Collman, F., ... (2025). [Functional connectomics spanning multiple areas of mouse visual cortex](https://doi.org/10.1038/s41586-025-08790-w). *Nature*, 640(8058), 435-447.
+
++ Celii, B., Papadopoulos, S., Ding, Z., Fahey, P. G., Wang, E., Papadopoulos, C., ... & Reimer, J. (2025). [NEURD offers automated proofreading and feature extraction for connectomics](https://doi.org/10.1038/s41586-025-08660-5). *Nature*, 640(8058), 487-496.
+
++ Ding, Z., Fahey, P.G., Papadopoulos, S., Wang, E.Y., Celii, B., Papadopoulos, C., Chang, A., Kunin, A.B., Tran, D., Fu, J. ... & Tolias, A. S. (2025). [Functional connectomics reveals general wiring rule in mouse visual cortex](https://doi.org/10.1038/s41586-025-08840-3). *Nature*, 640(8058), 459-469.
+
++ Dyszkant, N., Oesterle, J., Qiu, Y., Harrer, M., Schubert, T., Gonschorek, D. & Euler, T. (2025). [Photoreceptor degeneration has heterogeneous effects on functional retinal ganglion cell types](https://doi.org/10.1113/JP287643). *The Journal of Physiology*, 603(21), 6599-6621.
+
++ Finkelstein, A., Daie, K., Rózsa, M., Darshan, R. & Svoboda, K. (2025). [Connectivity underlying motor cortex activity during goal-directed behaviour](https://doi.org/10.1038/s41586-025-09758-6). *Nature*.
+
++ Gillon, C.J., Baker, C., Ly, R., Balzani, E., Brunton, B.W., Schottdorf, M., Ghosh, S. and Dehghani, N.(2025). [Open data in neurophysiology: Advancements, solutions & challenges](https://doi.org/10.1523/ENEURO.0486-24.2025). *eNeuro*, 12(11).
+
++ Huang, J.Y., Hess, M., Bajpai, A., Li, X., Hobson, L.N., Xu, A.J., Barton, S.J. and Lu, H.C.(2025). [From initial formation to developmental refinement: GABAergic inputs shape neuronal subnetworks in the primary somatosensory cortex](https://doi.org/10.1016/j.isci.2025.112104). *iScience*, 28(3).
+
++ Lee, K. H., Denovellis, E. L., Ly, R., Magland, J., Soules, J., Comrie, A. E., Gramling, D. P., Guidera, J. A., Nevers, R., Adenekan, P., Brozdowski, C., Bray, S. R., Monroe, E., Bak, J. H., Coulter, M. E., Sun, X., Broyles, E., Shin, D., Chiang, S., Holobetz, C., ... Frank, L. M. (2025). [Spyglass: a data analysis framework for reproducible and shareable neuroscience research](https://elifesciences.org/reviewed-preprints/108089). *eLife*.
+
++ Lees, R.M., Bianco, I.H., Campbell, R.A.A., Orlova, N., Peterka, D.S., Pichler, B., Smith, S.L., Yatsenko, D., Yu, C.H. & Packer, A.M. (2025). [Standardized measurements for monitoring and comparing multiphoton microscope systems](https://doi.org/10.1038/s41596-024-01120-w). *Nature Protocols*, 20, 2171–2208.
+
++ Schmors, L., Kotkat, A.H., Bauer, Y., Huang, Z., Crombie, D., Meyerolbersleben, L.S., Sokoloski, S., Berens, P. & Busse, L. (2025). [Effects of corticothalamic feedback depend on visual responsiveness and stimulus type](https://doi.org/10.1016/j.isci.2025.112481). *iScience*, 28, 112481.
+
++ Sibener, L.J., Mosberger, A.C., Chen, T.X., Athalye, V.R., Murray, J.M. & Costa, R.M. (2025). [Dissociable roles of distinct thalamic circuits in learning reaches to spatial targets](https://doi.org/10.1038/s41467-025-58143-4). *Nature Communications*, 16, 2962.
+
+## 2024
+
++ Chen, S., Liu, Y., Wang, Z. A., Colonell, J., Liu, L. D., Hou, H., ... & Svoboda, K. (2024). [Brain-wide neural activity underlying memory-guided movement](https://www.cell.com/cell/pdf/S0092-8674(23)01445-9.pdf). *Cell*, 187(3), 676-691.
+
++ Gonzalo Cogno, S., Obenhaus, H. A., Lautrup, A., Jacobsen, R. I., Clopath, C., Andersson, S. O., ... & Moser, E. I. (2024). [Minute-scale oscillatory sequences in medial entorhinal cortex](https://www.nature.com/articles/s41586-023-06864-1). *Nature*, 625(7994), 338-344.
+
++ Korympidou, M.M., Strauss, S., Schubert, T., Franke, K., Berens, P., Euler, T. & Vlasits, A.L. (2024). [GABAergic amacrine cells balance biased chromatic information in the mouse retina](https://doi.org/10.1016/j.celrep.2024.114953). *Cell Reports*, 43(11), 114953.
+
++ Mosberger, A.C., Sibener, L.J., Chen, T.X., Rodrigues, H.F., Hormigo, R., Ingram, J.N., Athalye, V.R., Tabachnik, T., Wolpert, D.M., Murray, J.M. and Costa, R.M. (2024). [Exploration biases forelimb reaching strategies](https://www.cell.com/cell-reports/fulltext/S2211-1247(24)00286-9). *Cell Reports*, 43(4).
+
++ Reimer, M. L., Kauer, S. D., Benson, C. A., King, J. F., Patwa, S., Feng, S., Estacion, M. A., Bangalore, L., Waxman, S. G., & Tan, A. M. (2024). [A FAIR, open-source virtual reality platform for dendritic spine analysis](https://www.cell.com/patterns/pdf/S2666-3899(24)00183-1.pdf). *Patterns*, 5(9).
+
+## 2023
+
++ Willeke, K.F., Restivo, K., Franke, K., Nix, A.F., Cadena, S.A., Shinn, T., Nealley, C., Rodriguez, G., Patel, S., Ecker, A.S., Sinz, F.H. & Tolias, A.S. (2023). [Deep learning-driven characterization of single cell tuning in primate visual area V4 supports topological organization](https://doi.org/10.1101/2023.05.12.540591). *bioRxiv*.
+
++ Laboratory, I. B., Bonacchi, N., Chapuis, G. A., Churchland, A. K., DeWitt, E. E., Faulkner, M., ... & Wells, M. J. (2023). [A modular architecture for organizing, processing and sharing neurophysiology data](https://doi.org/10.1038/s41592-022-01742-6). *Nature Methods*. 1-5.
+
+## 2022
+
++ Franke, K., Willeke, K. F., Ponder, K., Galdamez, M., Zhou, N., Muhammad, T., ... & Tolias, A. S. (2022). [State-dependent pupil dilation rapidly shifts visual feature selectivity](https://www.nature.com/articles/s41586-022-05270-3). *Nature*, 610(7930), 128-134.
+
++ Wang, Y., Chiola, S., Yang, G., Russell, C., Armstrong, C.J., Wu, Y., ... & Shcheglovitov, A. (2022). [Modeling human telencephalic development and autism-associated SHANK3 deficiency using organoids generated from single neural rosettes](https://doi.org/10.1038/s41467-022-33364-z). *Nature Communications*, 13, 5688.
+
++ Goetz, J., Jessen, Z. F., Jacobi, A., Mani, A., Cooler, S., Greer, D., ... & Schwartz, G. W. (2022). [Unified classification of mouse retinal ganglion cells using function, morphology, and gene expression](https://doi.org/10.1016/j.celrep.2022.111040). *Cell Reports*, 40(2), 111040.
+
++ Obenhaus, H.A., Zong, W., Jacobsen, R.I., Rose, T., Donato, F., Chen, L., Cheng, H., Bonhoeffer, T., Moser, M.B. & Moser, E.I. (2022). [Functional network topography of the medial entorhinal cortex](https://doi.org/10.1073/pnas.2121655119). *Proceedings of the National Academy of Sciences*, 119(7).
+
++ Pettit, N. H., Yap, E., Greenberg, M. E., Harvey, C. D. (2022). [Fos ensembles encode and shape stable spatial maps in the hippocampus](https://www.nature.com/articles/s41586-022-05113-1). *Nature*.
+
++ Tseng, S. Y., Chettih, S. N., Arlt, C., Barroso-Luque, R., & Harvey, C. D. (2022). [Shared and specialized coding across posterior cortical areas for dynamic navigation decisions](https://doi.org/10.1016/j.neuron.2022.05.012). *Neuron*.
+
++ Turner, N. L., Macrina, T., Bae, J. A., Yang, R., Wilson, A. M., Schneider-Mizell, C., ... & Seung, H. S. (2022). [Reconstruction of neocortex: Organelles, compartments, cells, circuits, and activity](https://doi.org/10.1016/j.cell.2022.01.023). *Cell*, 185(6), 1082-1100.
+
++ Zong, W., Obenhaus, H.A., Skytoen, E.R., Eneqvist, H., de Jong, N.L., Vale, R., Jorge, M.R., Moser, M.B. and Moser, E.I. (2022). [Large-scale two-photon calcium imaging in freely moving mice](https://www.sciencedirect.com/science/article/pii/S0092867422001970). *Cell*, 185(7), 1240-1256.
+
+## 2021
+
++ Dennis, E.J., El Hady, A., Michaiel, A., Clemens, A., Tervo, D.R.G., Voigts, J. & Datta, S.R. (2021). [Systems Neuroscience of Natural Behaviors in Rodents](https://doi.org/10.1523/JNEUROSCI.1877-20.2020). *Journal of Neuroscience*, 41(5), 911-919.
+
++ Born, G., Schneider-Soupiadis, F. A., Erisken, S., Vaiceliunaite, A., Lao, C. L., Mobarhan, M. H., Spacek, M. A., Einevoll, G. T., & Busse, L. (2021). [Corticothalamic feedback sculpts visual spatial integration in mouse thalamus](https://doi.org/10.1038/s41593-021-00943-0). *Nature Neuroscience*, 24(12), 1711-1720.
+
++ Finkelstein, A., Fontolan, L., Economo, M. N., Li, N., Romani, S., & Svoboda, K. (2021). [Attractor dynamics gate cortical information flow during decision-making](https://doi.org/10.1038/s41593-021-00840-6). *Nature Neuroscience*, 24(6), 843-850.
+
++ Laboratory, T. I. B., Aguillon-Rodriguez, V., Angelaki, D., Bayer, H., Bonacchi, N., Carandini, M., Cazettes, F., Chapuis, G., Churchland, A. K., Dan, Y., ... (2021). [Standardized and reproducible measurement of decision-making in mice](https://doi.org/10.7554/eLife.63711). *eLife*, 10.
+
+## 2020
+
++ Angelaki, D. E., Ng, J., Abrego, A. M., Cham, H. X., Asprodini, E. K., Dickman, J. D., & Laurens, J. (2020). [A gravity-based three-dimensional compass in the mouse brain](https://doi.org/10.1038/s41467-020-15566-5). *Nature Communications*, 11(1), 1-13.
+
++ Heath, S. L., Christenson, M. P., Oriol, E., Saavedra-Weisenhaus, M., Kohn, J. R., & Behnia, R. (2020). [Circuit mechanisms underlying chromatic encoding in drosophila photoreceptors](https://doi.org/10.1016/j.cub.2019.11.075). *Current Biology*.
+
++ Yatsenko, D., Moreaux, L. C., Choi, J., Tolias, A., Shepard, K. L., & Roukes, M. L. (2020). [Signal separability in integrated neurophotonics](https://doi.org/10.1101/2020.09.27.315556). *bioRxiv*.
+
+## 2019
+
++ Chettih, S. N., & Harvey, C. D. (2019). [Single-neuron perturbations reveal feature-specific competition in V1](https://doi.org/10.1038/s41586-019-0997-6). *Nature*, 567(7748), 334-340.
+
++ Walker, E. Y., Sinz, F. H., Cobos, E., Muhammad, T., Froudarakis, E., Fahey, P. G., Ecker, A. S., Reimer, J., Pitkow, X., & Tolias, A. S. (2019). [Inception loops discover what excites neurons most using deep predictive models](https://doi.org/10.1038/s41593-019-0517-x). *Nature Neuroscience*, 22(12), 2060-2065.
+
+## 2018
+
++ Denfield, G. H., Ecker, A. S., Shinn, T. J., Bethge, M., & Tolias, A. S. (2018). [Attentional fluctuations induce shared variability in macaque primary visual cortex](https://doi.org/10.1038/s41467-018-05123-6). *Nature Communications*, 9(1), 2654.
+
+## 2017
+
++ Franke, K., Berens, P., Schubert, T., Bethge, M., Euler, T., & Baden, T. (2017). [Inhibition decorrelates visual feature representations in the inner retina](https://doi.org/10.1038/nature21394). *Nature*, 542(7642), 439.
+
+## 2016
+
++ Baden, T., Berens, P., Franke, K., Rosen, M. R., Bethge, M., & Euler, T. (2016). [The functional diversity of retinal ganglion cells in the mouse](https://doi.org/10.1038/nature16468). *Nature*, 529(7586), 345-350.
+
++ Reimer, J., McGinley, M. J., Liu, Y., Rodenkirch, C., Wang, Q., McCormick, D. A., & Tolias, A. S. (2016). [Pupil fluctuations track rapid changes in adrenergic and cholinergic activity in cortex](https://doi.org/10.1038/ncomms13289). *Nature Communications*, 7, 13289.
+
+## 2015
+
++ Jiang, X., Shen, S., Cadwell, C. R., Berens, P., Sinz, F., Ecker, A. S., Patel, S., & Tolias, A. S. (2015). [Principles of connectivity among morphologically defined cell types in adult neocortex](https://doi.org/10.1126/science.aac9462). *Science*, 350(6264), aac9462.
+
+## 2014
+
++ Froudarakis, E., Berens, P., Ecker, A. S., Cotton, R. J., Sinz, F. H., Yatsenko, D., Saggau, P., Bethge, M., & Tolias, A. S. (2014). [Population code in mouse V1 facilitates readout of natural scenes through increased sparseness](https://doi.org/10.1038/nn.3707). *Nature Neuroscience*, 17(6), 851-857.
+
++ Reimer, J., Froudarakis, E., Cadwell, C. R., Yatsenko, D., Denfield, G. H., & Tolias, A. S. (2014). [Pupil fluctuations track fast switching of cortical states during quiet wakefulness](https://doi.org/10.1016/j.neuron.2014.09.033). *Neuron*, 84(2), 355-362.
+
+
+---
+## File: about/versioning.md
+
+# Documentation Versioning
+
+This page explains how version information is indicated throughout the DataJoint documentation.
+
+## Documentation Scope
+
+**This documentation covers DataJoint 2.0 and later.** All code examples and tutorials use DataJoint 2.0+ syntax and APIs.
+
+**DataJoint 2.0 is the baseline.** Features and APIs introduced in 2.0 are documented without version markers, as they are the standard for this documentation.
+
+If you're using legacy DataJoint (version 0.14.x or earlier), please visit the [legacy documentation](https://datajoint.github.io/datajoint-python) or follow the [Migration Guide](../how-to/migrate-to-v20.md) to upgrade.
+
+## Version Indicators
+
+### Global Indicators
+
+**Site-wide banner:** Every page displays a banner indicating you're viewing documentation for DataJoint 2.0+, with a link to the migration guide for legacy users.
+
+**Footer:** The footer shows which version of DataJoint this documentation covers.
+
+### Feature-Level Indicators
+
+Version admonitions are used for features introduced **after 2.0** (i.e., version 2.1 and later):
+
+#### New Features
+
+!!! version-added "New in 2.1"
+
+    This indicates a feature that was introduced after the 2.0 baseline.
+
+**Example usage:**
+
+!!! version-added "New in 2.1"
+
+    The `dj.Top` operator with ordering support was introduced in DataJoint 2.1.
+
+**Note:** Features present in DataJoint 2.0 (the baseline) are not marked with version indicators.
+
+#### Changed Behavior
+
+!!! version-changed "Changed in 2.1"
+
+    This indicates behavior that changed in a post-2.0 release.
+
+**Example usage:**
+
+!!! version-changed "Changed in 2.1"
+
+    The `populate()` method now supports priority-based scheduling by default.
+
+    Use `priority=50` to control execution order when using `reserve_jobs=True`.
+
+#### Deprecated Features
+
+!!! version-deprecated "Deprecated in 2.1, removed in 3.0"
+
+    This indicates features that are deprecated and will be removed in future versions.
+
+**Example usage:**
+
+!!! version-deprecated "Deprecated in 2.1, removed in 3.0"
+
+    The `allow_direct_insert` parameter is deprecated. Use `dj.config['safemode']` instead.
+
+**Note:** Features deprecated at the 2.0 baseline (coming from pre-2.0) are documented in the [Migration Guide](../how-to/migrate-to-v20.md) rather than with admonitions, since this documentation assumes 2.0 as the baseline.
+
+### Inline Version Badges
+
+For features introduced **after 2.0**, inline version badges may appear in API reference:
+
+- `dj.Top()` <span class="version-badge">v2.1+</span> - Top N restriction with ordering
+- `some_method()` <span class="version-badge deprecated">deprecated</span> - Legacy method
+
+**Note:** Methods and features present in DataJoint 2.0 (the baseline) do not have version badges.
+
+## Checking Your Version
+
+To check which version of DataJoint you're using:
+
+```python
+import datajoint as dj
+print(dj.__version__)
+```
+
+- **Version 2.0 or higher:** You're on the current version
+- **Version 0.14.x or lower:** You're on legacy DataJoint
+
+## Migration Path
+
+If you're upgrading from legacy DataJoint (pre-2.0):
+
+1. **Review** the [What's New in 2.0](../explanation/whats-new-2.md) page to understand major changes
+2. **Follow** the [Migration Guide](../how-to/migrate-to-v20.md) for step-by-step upgrade instructions
+3. **Reference** this documentation for updated syntax and APIs
+
+## Legacy Documentation
+
+For DataJoint 0.x documentation, visit:
+
+**[datajoint.github.io/datajoint-python](https://datajoint.github.io/datajoint-python)**
+
+## Version History
+
+| Version | Release Date | Major Changes |
+|---------|--------------|---------------|
+| 2.0 | 2026 | Redesigned fetch API, unified stores, per-table jobs, semantic matching |
+| 0.14.x | 2020-2025 | Legacy version with external storage |
+| 0.13.x | 2019 | Legacy version |
+
+For complete version history, see the [changelog](https://github.com/datajoint/datajoint-python/releases).
 

--- a/src/llms.txt
+++ b/src/llms.txt
@@ -60,7 +60,7 @@
 - [Use Object Storage](/how-to/use-object-storage.md): External storage integration
 - [Create Custom Codecs](/how-to/create-custom-codec.md): Custom data types
 - [Manage Large Data](/how-to/manage-large-data.md): Scaling strategies
-- [Migrate from 0.x](/how-to/migrate-from-0x.md): Upgrading from DataJoint 0.14
+- [Migrate to v2.0](/how-to/migrate-to-v20.md): Upgrading from DataJoint 0.14
 - [Alter Tables](/how-to/alter-tables.md): Schema modifications
 - [Backup and Restore](/how-to/backup-restore.md): Data backup strategies
 


### PR DESCRIPTION
## Summary

Completes the fix for broken internal links by updating the LLM-specific documentation files.

## Changes

- **llms.txt**: Manually fixed migration guide reference from `migrate-from-0x.md` to `migrate-to-v20.md`
- **llms-full.txt**: Regenerated using `scripts/gen_llms_full.py` to pick up all corrected migration guide links from PR #107

## Verification

- Checked both files for remaining old references: none found
- Total link check: 350 links verified, 0 broken links found

## Context

After merging PR #107 which fixed migration guide links in the main documentation, the auto-generated LLM files still contained stale references. This PR ensures LLM consumers see the correct documentation links.

## Related

- Addresses remaining broken links found in link checking task
- Follows up on PR #107 (broken migration guide URLs)