### PR TITLE
docs: Fix codec notation and add plugin codecs guide

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -74,6 +74,7 @@ nav:
       - Object Storage:
           - Use Object Storage: how-to/use-object-storage.md
           - Use NPY Codec: how-to/use-npy-codec.md
+          - Use Plugin Codecs: how-to/use-plugin-codecs.md
           - Create Custom Codecs: how-to/create-custom-codec.md
           - Manage Large Data: how-to/manage-large-data.md
           - Clean Up Storage: how-to/garbage-collection.md

--- a/src/how-to/index.md
+++ b/src/how-to/index.md
@@ -39,6 +39,7 @@ they assume you understand the basics and focus on getting things done.
 ## Object Storage
 
 - [Use Object Storage](use-object-storage.md) — When and how
+- [Use Plugin Codecs](use-plugin-codecs.md) — Install codec packages via entry points
 - [Create Custom Codecs](create-custom-codec.md) — Domain-specific types
 - [Manage Large Data](manage-large-data.md) — Blobs, streaming, efficiency
 - [Clean Up External Storage](garbage-collection.md) — Garbage collection

--- a/src/how-to/use-plugin-codecs.md
+++ b/src/how-to/use-plugin-codecs.md
@@ -1,0 +1,330 @@
+# Use Plugin Codecs
+
+Install and use plugin codec packages to extend DataJoint's type system.
+
+## Overview
+
+Plugin codecs are distributed as separate Python packages that extend DataJoint's type system. They add support for domain-specific data types without modifying DataJoint itself. Once installed, they register automatically via Python's entry point system and work seamlessly with DataJoint.
+
+**Benefits:**
+- Automatic registration via entry points - no code changes needed
+- Domain-specific types maintained independently
+- Clean separation of core framework from specialized formats
+- Easy to share across projects and teams
+
+## Quick Start
+
+### 1. Install the Codec Package
+
+```bash
+pip install dj-zarr-codecs
+```
+
+### 2. Use in Table Definitions
+
+```python
+import datajoint as dj
+
+schema = dj.Schema('my_schema')
+
+@schema
+class Recording(dj.Manual):
+    definition = """
+    recording_id : int
+    ---
+    waveform : <zarr@>  # Automatically available after install
+    """
+```
+
+That's it! No imports or registration needed. The codec is automatically discovered via Python's entry point system.
+
+## Example: Zarr Array Storage
+
+The `dj-zarr-codecs` package adds support for storing NumPy arrays in Zarr format with schema-addressed paths.
+
+### Installation
+
+```bash
+pip install dj-zarr-codecs
+```
+
+### Configuration
+
+Configure object storage for external data:
+
+```python
+import datajoint as dj
+
+dj.config['stores'] = {
+    'mystore': {
+        'protocol': 's3',
+        'endpoint': 's3.amazonaws.com',
+        'bucket': 'my-bucket',
+        'location': 'data',
+    }
+}
+```
+
+### Basic Usage
+
+```python
+import numpy as np
+
+schema = dj.Schema('neuroscience')
+
+@schema
+class Recording(dj.Manual):
+    definition = """
+    recording_id : int
+    ---
+    waveform : <zarr@mystore>  # Store as Zarr array
+    """
+
+# Insert NumPy array
+Recording.insert1({
+    'recording_id': 1,
+    'waveform': np.random.randn(1000, 32),
+})
+
+# Fetch returns zarr.Array (read-only)
+zarr_array = (Recording & {'recording_id': 1}).fetch1('waveform')
+
+# Use with NumPy
+mean_waveform = np.mean(zarr_array, axis=0)
+
+# Access Zarr features
+print(zarr_array.shape)   # (1000, 32)
+print(zarr_array.chunks)  # Zarr chunking info
+print(zarr_array.dtype)   # float64
+```
+
+### Storage Structure
+
+Zarr arrays are stored with schema-addressed paths that mirror your database structure:
+
+```
+s3://my-bucket/data/
+└── neuroscience/           # Schema name
+    └── recording/          # Table name
+        └── recording_id=1/ # Primary key
+            └── waveform.zarr/  # Field name + .zarr extension
+                ├── .zarray
+                └── 0.0
+```
+
+This organization makes external storage browsable and self-documenting.
+
+### When to Use `<zarr@>`
+
+**Use `<zarr@>` when:**
+- Arrays are large (> 10 MB)
+- You need chunked access patterns
+- Compression is beneficial
+- Cross-language compatibility matters (any Zarr library can read)
+- You want browsable, organized storage paths
+
+**Use `<npy@>` instead when:**
+- You need lazy loading with metadata inspection before download
+- Memory mapping is important
+- Storage format simplicity is preferred
+
+**Use `<blob@>` instead when:**
+- Arrays are small (< 10 MB)
+- Deduplication of repeated values is important
+- Storing mixed Python objects (not just arrays)
+
+## Finding Plugin Codecs
+
+### DataJoint-Maintained Codecs
+
+- **[dj-zarr-codecs](https://github.com/datajoint/dj-zarr-codecs)** — Zarr array storage
+- **[anscombe-transform](https://github.com/datajoint/anscombe-transform)** — Anscombe variance stabilization for imaging
+
+### Community Codecs
+
+Check PyPI for packages with the `datajoint` keyword:
+
+```bash
+pip search datajoint codec
+```
+
+Or browse GitHub: https://github.com/topics/datajoint
+
+### Domain-Specific Examples
+
+**Neuroscience:**
+- Spike train formats (NEO, NWB)
+- Neural network models
+- Connectivity matrices
+
+**Imaging:**
+- OME-TIFF, OME-ZARR
+- DICOM medical images
+- Point cloud data
+
+**Genomics:**
+- BAM/SAM alignments
+- VCF variant calls
+- Phylogenetic trees
+
+## Verifying Installation
+
+Check that a codec is registered:
+
+```python
+import datajoint as dj
+
+# List all available codecs
+print(dj.list_codecs())
+# ['blob', 'attach', 'hash', 'object', 'npy', 'filepath', 'zarr', ...]
+
+# Check specific codec
+assert 'zarr' in dj.list_codecs()
+```
+
+## How Auto-Registration Works
+
+Plugin codecs use Python's entry point system for automatic discovery. When you install a codec package, it registers itself via `pyproject.toml`:
+
+```toml
+[project.entry-points."datajoint.codecs"]
+zarr = "dj_zarr_codecs:ZarrCodec"
+```
+
+DataJoint discovers these entry points at import time, so the codec is immediately available after `pip install`.
+
+**No manual registration needed** — unlike DataJoint 0.x which required `dj.register_codec()`.
+
+## Troubleshooting
+
+### "Unknown codec: \<zarr\>"
+
+The codec package is not installed or not found. Verify installation:
+
+```bash
+pip list | grep dj-zarr-codecs
+```
+
+If installed but not working:
+
+```python
+# Force entry point reload
+import importlib.metadata
+importlib.metadata.entry_points().select(group='datajoint.codecs')
+```
+
+### Codec Not Found After Installation
+
+Restart your Python session or kernel. Entry points are discovered at import time:
+
+```python
+# Restart kernel, then:
+import datajoint as dj
+print('zarr' in dj.list_codecs())  # Should be True
+```
+
+### Version Conflicts
+
+Check compatibility with your DataJoint version:
+
+```bash
+pip show dj-zarr-codecs
+# Requires: datajoint>=2.0.0a22
+```
+
+Upgrade DataJoint if needed:
+
+```bash
+pip install --upgrade datajoint
+```
+
+## Creating Your Own Codecs
+
+If you need a codec that doesn't exist yet, see:
+
+- [Create Custom Codecs](create-custom-codec.md) — Step-by-step guide
+- [Codec API Specification](../reference/specs/codec-api.md) — Technical reference
+- [Custom Codecs Explanation](../explanation/custom-codecs.md) — Design concepts
+
+Consider publishing your codec as a package so others can benefit!
+
+## Best Practices
+
+### 1. Install Codecs with Your Project
+
+Add plugin codecs to your project dependencies:
+
+**requirements.txt:**
+```
+datajoint>=2.0.0a22
+dj-zarr-codecs>=0.1.0
+```
+
+**pyproject.toml:**
+```toml
+dependencies = [
+    "datajoint>=2.0.0a22",
+    "dj-zarr-codecs>=0.1.0",
+]
+```
+
+### 2. Document Codec Requirements
+
+In your pipeline documentation, specify required codecs:
+
+```python
+"""
+My Pipeline
+===========
+
+Requirements:
+- datajoint>=2.0.0a22
+- dj-zarr-codecs>=0.1.0  # For waveform storage
+
+Install:
+    pip install datajoint dj-zarr-codecs
+"""
+```
+
+### 3. Pin Versions for Reproducibility
+
+Use exact versions in production:
+
+```
+dj-zarr-codecs==0.1.0  # Exact version
+```
+
+Use minimum versions in libraries:
+
+```
+dj-zarr-codecs>=0.1.0  # Minimum version
+```
+
+### 4. Test Codec Availability
+
+Add checks in your pipeline setup:
+
+```python
+import datajoint as dj
+
+REQUIRED_CODECS = ['zarr']
+
+def check_requirements():
+    available = dj.list_codecs()
+    missing = [c for c in REQUIRED_CODECS if c not in available]
+
+    if missing:
+        raise ImportError(
+            f"Missing required codecs: {missing}\n"
+            f"Install with: pip install dj-zarr-codecs"
+        )
+
+check_requirements()
+```
+
+## See Also
+
+- [Use Object Storage](use-object-storage.md) — Object storage configuration
+- [Create Custom Codecs](create-custom-codec.md) — Build your own codecs
+- [Type System](../reference/specs/type-system.md) — Complete type reference
+- [dj-zarr-codecs Repository](https://github.com/datajoint/dj-zarr-codecs) — Example implementation

--- a/src/reference/specs/type-system.md
+++ b/src/reference/specs/type-system.md
@@ -635,7 +635,7 @@ def garbage_collect(store_name):
 |---------|----------|------------|-------------|--------------|---------------|
 | Storage modes | Both | Both | External only | External only | External only |
 | Internal dtype | `bytes` | `bytes` | N/A | N/A | N/A |
-| External dtype | `<hash>` | `<hash>` | `json` | `json` | `json` |
+| External dtype | `<hash@>` | `<hash@>` | `json` | `json` | `json` |
 | Addressing | Hash | Hash | Primary key | Hash | Relative path |
 | Deduplication | Yes (external) | Yes (external) | No | Yes | No |
 | Structure | Single blob | Single file | Files, folders | Single blob | Any |


### PR DESCRIPTION
## Summary

1. Fix incorrect codec notation in type-system.md comparison table
2. Add comprehensive how-to guide for using plugin codecs
3. Reference both dj-zarr-codecs and dj-photon-codecs as examples

## Changes

### 1. Fix Codec Notation

**File**: `src/reference/specs/type-system.md` (line 638)

Changed the "External dtype" row in the codec comparison table from `<hash>` to `<hash@>` to match the correct store-only notation.

**Before:**
```markdown
| External dtype | `<hash>` | `<hash>` | `json` | `json` | `json` |
```

**After:**
```markdown
| External dtype | `<hash@>` | `<hash@>` | `json` | `json` | `json` |
```

### 2. Add Plugin Codecs Documentation

**New file**: `src/how-to/use-plugin-codecs.md` (334 lines)

Comprehensive guide for using plugin codec packages that extend DataJoint via entry point discovery.

**Key sections:**
- Installation and automatic registration via Python entry points
- Complete dj-zarr-codecs usage example with Zarr array storage
- Schema-addressed storage structure explanation
- Finding DataJoint-maintained and community codecs (including dj-photon-codecs)
- Comparison with built-in codecs (`<npy@>`, `<blob@>`)
- Best practices for dependency management
- Troubleshooting common issues

**Terminology:** Uses "plugin codecs" instead of "external/third-party" to accurately describe the architectural pattern (separate packages with entry point discovery) without implying ownership.

**Updated navigation:**
- `src/how-to/index.md` - Added entry
- `mkdocs.yaml` - Added to Object Storage section

### 3. Reference Plugin Codecs in Explanations

**File**: `src/explanation/custom-codecs.md`

Added "Before Creating Your Own" section that directs readers to check existing plugin codecs before implementing custom solutions:
- dj-zarr-codecs — General numpy arrays with Zarr
- dj-photon-codecs — Photon-limited movies with Anscombe + compression
- anscombe-transform — Variance stabilization

## Context

The `<hash@>` codec is external-only and requires the `@` modifier. The original table incorrectly showed `<hash>` (without `@`) in the "External dtype" row.

The plugin codecs guide provides documentation for the plugin codec pattern used by dj-zarr-codecs and dj-photon-codecs, establishing terminology and best practices for both DataJoint-maintained and community-developed codec packages.

## Related

- datajoint-python PR #1334 - Clarifies dual-mode codecs in builtin_codecs.py docstring
- dj-zarr-codecs repository - https://github.com/datajoint/dj-zarr-codecs
- dj-photon-codecs repository - https://github.com/datajoint/dj-photon-codecs