### PR TITLE
docs: Add plugin codecs guide and fix codec notation

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -74,6 +74,7 @@ nav:
       - Object Storage:
           - Use Object Storage: how-to/use-object-storage.md
           - Use NPY Codec: how-to/use-npy-codec.md
+          - Use Plugin Codecs: how-to/use-plugin-codecs.md
           - Create Custom Codecs: how-to/create-custom-codec.md
           - Manage Large Data: how-to/manage-large-data.md
           - Clean Up Storage: how-to/garbage-collection.md

--- a/src/explanation/custom-codecs.md
+++ b/src/explanation/custom-codecs.md
@@ -334,3 +334,13 @@ Custom codecs enable:
 
 The codec system makes DataJoint extensible to any scientific domain without
 modifying the core framework.
+
+## Before Creating Your Own
+
+Check for existing plugin codecs that may already solve your needs:
+
+- **[dj-zarr-codecs](https://github.com/datajoint/dj-zarr-codecs)** — General numpy arrays with Zarr storage
+- **[dj-photon-codecs](https://github.com/datajoint/dj-photon-codecs)** — Photon-limited movies with Anscombe transformation
+- **[anscombe-transform](https://github.com/datajoint/anscombe-transform)** — Variance stabilization for imaging
+
+See the [Use Plugin Codecs](../how-to/use-plugin-codecs.md) guide for installation and usage of existing codec packages. Creating a custom codec is straightforward, but reusing existing ones saves time and ensures compatibility.

--- a/src/explanation/custom-codecs.md
+++ b/src/explanation/custom-codecs.md
@@ -340,7 +340,6 @@ modifying the core framework.
 Check for existing plugin codecs that may already solve your needs:
 
 - **[dj-zarr-codecs](https://github.com/datajoint/dj-zarr-codecs)** — General numpy arrays with Zarr storage
-- **[dj-photon-codecs](https://github.com/datajoint/dj-photon-codecs)** — Photon-limited movies with Anscombe transformation
-- **[anscombe-transform](https://github.com/datajoint/anscombe-transform)** — Variance stabilization for imaging
+- **[dj-photon-codecs](https://github.com/datajoint/dj-photon-codecs)** — Photon-limited movies with Anscombe transformation and compression
 
 See the [Use Plugin Codecs](../how-to/use-plugin-codecs.md) guide for installation and usage of existing codec packages. Creating a custom codec is straightforward, but reusing existing ones saves time and ensures compatibility.

--- a/src/explanation/type-system.md
+++ b/src/explanation/type-system.md
@@ -111,7 +111,20 @@ Codecs provide `encode()`/`decode()` semantics for complex Python objects.
 
 ### `<blob>` — Serialized Python Objects
 
-Stores NumPy arrays, dicts, lists, and other Python objects.
+Stores NumPy arrays, dicts, lists, and other Python objects using DataJoint's custom binary serialization format.
+
+**Serialization format:**
+- **Protocol headers**: `mYm` (MATLAB-compatible) or `dj0` (Python-extended)
+- **Optional compression**: zlib compression for data > 1KB
+- **Type-specific encoding**: Each Python type has a specific serialization code
+- **Version detection**: Protocol header embedded in blob enables format detection
+
+**Supported types:**
+- NumPy arrays (numeric, structured, recarrays)
+- Collections (dict, list, tuple, set)
+- Scalars (int, float, bool, complex, str, bytes)
+- Date/time objects (datetime, date, time)
+- UUID, Decimal
 
 ```python
 class Results(dj.Computed):
@@ -123,6 +136,10 @@ class Results(dj.Computed):
     raw_data : <blob@archive>   # External, 'archive' store
     """
 ```
+
+**Storage modes:**
+- `<blob>` — Stored in database as LONGBLOB (up to ~1GB depending on MySQL config)
+- `<blob@>` — Stored externally via `<hash@>` with MD5 deduplication
 
 ### `<attach>` — File Attachments
 

--- a/src/explanation/type-system.md
+++ b/src/explanation/type-system.md
@@ -114,7 +114,9 @@ Codecs provide `encode()`/`decode()` semantics for complex Python objects.
 Stores NumPy arrays, dicts, lists, and other Python objects using DataJoint's custom binary serialization format.
 
 **Serialization format:**
-- **Protocol headers**: `mYm` (MATLAB-compatible) or `dj0` (Python-extended)
+- **Protocol headers**:
+  - `mYm` — MATLAB-compatible format (see [mYm on MATLAB FileExchange](https://www.mathworks.com/matlabcentral/fileexchange/81208-mym) and [mym on GitHub](https://github.com/datajoint/mym))
+  - `dj0` — Python-extended format supporting additional types
 - **Optional compression**: zlib compression for data > 1KB
 - **Type-specific encoding**: Each Python type has a specific serialization code
 - **Version detection**: Protocol header embedded in blob enables format detection

--- a/src/how-to/index.md
+++ b/src/how-to/index.md
@@ -42,6 +42,7 @@ they assume you understand the basics and focus on getting things done.
 - [Object Storage Overview](object-storage-overview.md) — Navigation guide for all storage docs
 - [Choose a Storage Type](choose-storage-type.md) — Decision guide for codecs
 - [Use Object Storage](use-object-storage.md) — When and how
+- [Use Plugin Codecs](use-plugin-codecs.md) — Install codec packages via entry points
 - [Create Custom Codecs](create-custom-codec.md) — Domain-specific types
 - [Manage Large Data](manage-large-data.md) — Blobs, streaming, efficiency
 - [Clean Up External Storage](garbage-collection.md) — Garbage collection

--- a/src/how-to/use-plugin-codecs.md
+++ b/src/how-to/use-plugin-codecs.md
@@ -139,7 +139,6 @@ This organization makes external storage browsable and self-documenting.
 
 - **[dj-zarr-codecs](https://github.com/datajoint/dj-zarr-codecs)** — Zarr array storage for general numpy arrays
 - **[dj-photon-codecs](https://github.com/datajoint/dj-photon-codecs)** — Photon-limited movies with Anscombe transformation and compression
-- **[anscombe-transform](https://github.com/datajoint/anscombe-transform)** — Anscombe variance stabilization (Zarr/Numcodecs integration)
 
 ### Community Codecs
 

--- a/src/how-to/use-plugin-codecs.md
+++ b/src/how-to/use-plugin-codecs.md
@@ -243,9 +243,28 @@ pip install --upgrade datajoint
 
 Plugin codecs evolve over time. Following versioning best practices ensures your data remains accessible across codec updates.
 
+### Built-in vs Plugin Codec Versioning
+
+**Built-in codecs** (`<blob>`, `<npy@>`, `<object@>`, etc.) are versioned with DataJoint:
+- ✅ Shipped with datajoint-python
+- ✅ Versioned by DataJoint release (2.0.0, 2.1.0, 3.0.0)
+- ✅ Upgraded when you upgrade DataJoint
+- ✅ Stability guaranteed by DataJoint's semantic versioning
+- ❌ **No explicit codec_version field needed** - DataJoint version is the codec version
+
+**Plugin codecs** (dj-zarr-codecs, dj-photon-codecs, etc.) have independent lifecycles:
+- ✅ Installed separately from DataJoint
+- ✅ Independent version numbers (0.1.0 → 1.0.0 → 2.0.0)
+- ✅ Users choose when to upgrade
+- ✅ **Must include explicit codec_version field** for backward compatibility
+
+**Why the difference?**
+
+Plugin codecs evolve independently and need to handle data encoded by different plugin versions. Built-in codecs are part of DataJoint's API surface and evolve with the framework itself. When you upgrade DataJoint 2.0 → 3.0, you expect potential breaking changes. When you upgrade a plugin 1.0 → 2.0 while keeping DataJoint 2.0, backward compatibility is critical.
+
 ### Version Strategy
 
-**Two version numbers matter:**
+**Two version numbers matter for plugin codecs:**
 
 1. **Package version** (semantic versioning: `0.1.0`, `1.0.0`, `2.0.0`)
    - For codec package releases

--- a/src/how-to/use-plugin-codecs.md
+++ b/src/how-to/use-plugin-codecs.md
@@ -137,8 +137,9 @@ This organization makes external storage browsable and self-documenting.
 
 ### DataJoint-Maintained Codecs
 
-- **[dj-zarr-codecs](https://github.com/datajoint/dj-zarr-codecs)** — Zarr array storage
-- **[anscombe-transform](https://github.com/datajoint/anscombe-transform)** — Anscombe variance stabilization for imaging
+- **[dj-zarr-codecs](https://github.com/datajoint/dj-zarr-codecs)** — Zarr array storage for general numpy arrays
+- **[dj-photon-codecs](https://github.com/datajoint/dj-photon-codecs)** — Photon-limited movies with Anscombe transformation and compression
+- **[anscombe-transform](https://github.com/datajoint/anscombe-transform)** — Anscombe variance stabilization (Zarr/Numcodecs integration)
 
 ### Community Codecs
 
@@ -158,6 +159,7 @@ Or browse GitHub: https://github.com/topics/datajoint
 - Connectivity matrices
 
 **Imaging:**
+- Photon-limited movies (calcium imaging, low-light microscopy)
 - OME-TIFF, OME-ZARR
 - DICOM medical images
 - Point cloud data
@@ -327,4 +329,5 @@ check_requirements()
 - [Use Object Storage](use-object-storage.md) — Object storage configuration
 - [Create Custom Codecs](create-custom-codec.md) — Build your own codecs
 - [Type System](../reference/specs/type-system.md) — Complete type reference
-- [dj-zarr-codecs Repository](https://github.com/datajoint/dj-zarr-codecs) — Example implementation
+- [dj-zarr-codecs Repository](https://github.com/datajoint/dj-zarr-codecs) — General Zarr array storage
+- [dj-photon-codecs Repository](https://github.com/datajoint/dj-photon-codecs) — Photon-limited movies with compression

--- a/src/how-to/use-plugin-codecs.md
+++ b/src/how-to/use-plugin-codecs.md
@@ -262,6 +262,17 @@ Plugin codecs evolve over time. Following versioning best practices ensures your
 
 Plugin codecs evolve independently and need to handle data encoded by different plugin versions. Built-in codecs are part of DataJoint's API surface and evolve with the framework itself. When you upgrade DataJoint 2.0 → 3.0, you expect potential breaking changes. When you upgrade a plugin 1.0 → 2.0 while keeping DataJoint 2.0, backward compatibility is critical.
 
+**How built-in codecs handle versioning:**
+
+Built-in formats have **intrinsic versioning** - the format version is embedded in the data itself:
+
+- `<blob>` — Protocol header (`mYm\0` or `dj0\0`) at start of blob
+- `<npy@>` — NumPy format version in `.npy` file header
+- `<object@>` — Self-describing directory structure
+- `<attach>` — Filename + content (format-agnostic)
+
+When DataJoint needs to change a built-in codec's format, it can detect the old format from the embedded version information and handle migration transparently. This is why built-in codecs don't need an explicit `codec_version` field in database metadata.
+
 ### Version Strategy
 
 **Two version numbers matter for plugin codecs:**

--- a/src/how-to/use-plugin-codecs.md
+++ b/src/how-to/use-plugin-codecs.md
@@ -1,0 +1,330 @@
+# Use Plugin Codecs
+
+Install and use plugin codec packages to extend DataJoint's type system.
+
+## Overview
+
+Plugin codecs are distributed as separate Python packages that extend DataJoint's type system. They add support for domain-specific data types without modifying DataJoint itself. Once installed, they register automatically via Python's entry point system and work seamlessly with DataJoint.
+
+**Benefits:**
+- Automatic registration via entry points - no code changes needed
+- Domain-specific types maintained independently
+- Clean separation of core framework from specialized formats
+- Easy to share across projects and teams
+
+## Quick Start
+
+### 1. Install the Codec Package
+
+```bash
+pip install dj-zarr-codecs
+```
+
+### 2. Use in Table Definitions
+
+```python
+import datajoint as dj
+
+schema = dj.Schema('my_schema')
+
+@schema
+class Recording(dj.Manual):
+    definition = """
+    recording_id : int
+    ---
+    waveform : <zarr@>  # Automatically available after install
+    """
+```
+
+That's it! No imports or registration needed. The codec is automatically discovered via Python's entry point system.
+
+## Example: Zarr Array Storage
+
+The `dj-zarr-codecs` package adds support for storing NumPy arrays in Zarr format with schema-addressed paths.
+
+### Installation
+
+```bash
+pip install dj-zarr-codecs
+```
+
+### Configuration
+
+Configure object storage for external data:
+
+```python
+import datajoint as dj
+
+dj.config['stores'] = {
+    'mystore': {
+        'protocol': 's3',
+        'endpoint': 's3.amazonaws.com',
+        'bucket': 'my-bucket',
+        'location': 'data',
+    }
+}
+```
+
+### Basic Usage
+
+```python
+import numpy as np
+
+schema = dj.Schema('neuroscience')
+
+@schema
+class Recording(dj.Manual):
+    definition = """
+    recording_id : int
+    ---
+    waveform : <zarr@mystore>  # Store as Zarr array
+    """
+
+# Insert NumPy array
+Recording.insert1({
+    'recording_id': 1,
+    'waveform': np.random.randn(1000, 32),
+})
+
+# Fetch returns zarr.Array (read-only)
+zarr_array = (Recording & {'recording_id': 1}).fetch1('waveform')
+
+# Use with NumPy
+mean_waveform = np.mean(zarr_array, axis=0)
+
+# Access Zarr features
+print(zarr_array.shape)   # (1000, 32)
+print(zarr_array.chunks)  # Zarr chunking info
+print(zarr_array.dtype)   # float64
+```
+
+### Storage Structure
+
+Zarr arrays are stored with schema-addressed paths that mirror your database structure:
+
+```
+s3://my-bucket/data/
+└── neuroscience/           # Schema name
+    └── recording/          # Table name
+        └── recording_id=1/ # Primary key
+            └── waveform.zarr/  # Field name + .zarr extension
+                ├── .zarray
+                └── 0.0
+```
+
+This organization makes external storage browsable and self-documenting.
+
+### When to Use `<zarr@>`
+
+**Use `<zarr@>` when:**
+- Arrays are large (> 10 MB)
+- You need chunked access patterns
+- Compression is beneficial
+- Cross-language compatibility matters (any Zarr library can read)
+- You want browsable, organized storage paths
+
+**Use `<npy@>` instead when:**
+- You need lazy loading with metadata inspection before download
+- Memory mapping is important
+- Storage format simplicity is preferred
+
+**Use `<blob@>` instead when:**
+- Arrays are small (< 10 MB)
+- Deduplication of repeated values is important
+- Storing mixed Python objects (not just arrays)
+
+## Finding Plugin Codecs
+
+### DataJoint-Maintained Codecs
+
+- **[dj-zarr-codecs](https://github.com/datajoint/dj-zarr-codecs)** — Zarr array storage
+- **[anscombe-transform](https://github.com/datajoint/anscombe-transform)** — Anscombe variance stabilization for imaging
+
+### Community Codecs
+
+Check PyPI for packages with the `datajoint` keyword:
+
+```bash
+pip search datajoint codec
+```
+
+Or browse GitHub: https://github.com/topics/datajoint
+
+### Domain-Specific Examples
+
+**Neuroscience:**
+- Spike train formats (NEO, NWB)
+- Neural network models
+- Connectivity matrices
+
+**Imaging:**
+- OME-TIFF, OME-ZARR
+- DICOM medical images
+- Point cloud data
+
+**Genomics:**
+- BAM/SAM alignments
+- VCF variant calls
+- Phylogenetic trees
+
+## Verifying Installation
+
+Check that a codec is registered:
+
+```python
+import datajoint as dj
+
+# List all available codecs
+print(dj.list_codecs())
+# ['blob', 'attach', 'hash', 'object', 'npy', 'filepath', 'zarr', ...]
+
+# Check specific codec
+assert 'zarr' in dj.list_codecs()
+```
+
+## How Auto-Registration Works
+
+Plugin codecs use Python's entry point system for automatic discovery. When you install a codec package, it registers itself via `pyproject.toml`:
+
+```toml
+[project.entry-points."datajoint.codecs"]
+zarr = "dj_zarr_codecs:ZarrCodec"
+```
+
+DataJoint discovers these entry points at import time, so the codec is immediately available after `pip install`.
+
+**No manual registration needed** — unlike DataJoint 0.x which required `dj.register_codec()`.
+
+## Troubleshooting
+
+### "Unknown codec: \<zarr\>"
+
+The codec package is not installed or not found. Verify installation:
+
+```bash
+pip list | grep dj-zarr-codecs
+```
+
+If installed but not working:
+
+```python
+# Force entry point reload
+import importlib.metadata
+importlib.metadata.entry_points().select(group='datajoint.codecs')
+```
+
+### Codec Not Found After Installation
+
+Restart your Python session or kernel. Entry points are discovered at import time:
+
+```python
+# Restart kernel, then:
+import datajoint as dj
+print('zarr' in dj.list_codecs())  # Should be True
+```
+
+### Version Conflicts
+
+Check compatibility with your DataJoint version:
+
+```bash
+pip show dj-zarr-codecs
+# Requires: datajoint>=2.0.0a22
+```
+
+Upgrade DataJoint if needed:
+
+```bash
+pip install --upgrade datajoint
+```
+
+## Creating Your Own Codecs
+
+If you need a codec that doesn't exist yet, see:
+
+- [Create Custom Codecs](create-custom-codec.md) — Step-by-step guide
+- [Codec API Specification](../reference/specs/codec-api.md) — Technical reference
+- [Custom Codecs Explanation](../explanation/custom-codecs.md) — Design concepts
+
+Consider publishing your codec as a package so others can benefit!
+
+## Best Practices
+
+### 1. Install Codecs with Your Project
+
+Add plugin codecs to your project dependencies:
+
+**requirements.txt:**
+```
+datajoint>=2.0.0a22
+dj-zarr-codecs>=0.1.0
+```
+
+**pyproject.toml:**
+```toml
+dependencies = [
+    "datajoint>=2.0.0a22",
+    "dj-zarr-codecs>=0.1.0",
+]
+```
+
+### 2. Document Codec Requirements
+
+In your pipeline documentation, specify required codecs:
+
+```python
+"""
+My Pipeline
+===========
+
+Requirements:
+- datajoint>=2.0.0a22
+- dj-zarr-codecs>=0.1.0  # For waveform storage
+
+Install:
+    pip install datajoint dj-zarr-codecs
+"""
+```
+
+### 3. Pin Versions for Reproducibility
+
+Use exact versions in production:
+
+```
+dj-zarr-codecs==0.1.0  # Exact version
+```
+
+Use minimum versions in libraries:
+
+```
+dj-zarr-codecs>=0.1.0  # Minimum version
+```
+
+### 4. Test Codec Availability
+
+Add checks in your pipeline setup:
+
+```python
+import datajoint as dj
+
+REQUIRED_CODECS = ['zarr']
+
+def check_requirements():
+    available = dj.list_codecs()
+    missing = [c for c in REQUIRED_CODECS if c not in available]
+
+    if missing:
+        raise ImportError(
+            f"Missing required codecs: {missing}\n"
+            f"Install with: pip install dj-zarr-codecs"
+        )
+
+check_requirements()
+```
+
+## See Also
+
+- [Use Object Storage](use-object-storage.md) — Object storage configuration
+- [Create Custom Codecs](create-custom-codec.md) — Build your own codecs
+- [Type System](../reference/specs/type-system.md) — Complete type reference
+- [dj-zarr-codecs Repository](https://github.com/datajoint/dj-zarr-codecs) — Example implementation

--- a/src/reference/specs/type-system.md
+++ b/src/reference/specs/type-system.md
@@ -503,7 +503,7 @@ Serializes Python objects using DataJoint's custom binary serialization format. 
 **Serialization format:**
 
 - **Protocol headers**:
-  - `mYm` — Original MATLAB-compatible format for numeric arrays, structs, cells
+  - `mYm` — Original MATLAB-compatible format for numeric arrays, structs, cells (see [mYm on MATLAB FileExchange](https://www.mathworks.com/matlabcentral/fileexchange/81208-mym) and [mym on GitHub](https://github.com/datajoint/mym))
   - `dj0` — Extended format supporting Python-specific types (UUID, Decimal, datetime, etc.)
 - **Compression**: Automatic zlib compression for data > 1KB
 - **Type codes**: Each Python type has a specific serialization code:

--- a/src/reference/specs/type-system.md
+++ b/src/reference/specs/type-system.md
@@ -636,7 +636,7 @@ def garbage_collect(store_name):
 |---------|----------|------------|-------------|--------------|---------------|
 | Storage modes | Both | Both | External only | External only | External only |
 | Internal dtype | `bytes` | `bytes` | N/A | N/A | N/A |
-| External dtype | `<hash>` | `<hash>` | `json` | `json` | `json` |
+| External dtype | `<hash@>` | `<hash@>` | `json` | `json` | `json` |
 | Addressing | Hash | Hash | Primary key | Hash | Relative path |
 | Deduplication | Yes (external) | Yes (external) | No | Yes | No |
 | Structure | Single blob | Single file | Files, folders | Single blob | Any |


### PR DESCRIPTION
## Summary

1. Fix incorrect codec notation in type-system.md comparison table
2. Add comprehensive how-to guide for using plugin codecs
3. Reference dj-zarr-codecs and dj-photon-codecs as DataJoint plugin codec examples

**Note:** This PR targets `main` branch. The same changes were previously merged to `pre/v2.0` via PR #121.

## Changes

### 1. Fix Codec Notation

**File**: `src/reference/specs/type-system.md` (line 638)

Changed the "External dtype" row in the codec comparison table from `<hash>` to `<hash@>` to match the correct store-only notation.

**Before:**
```markdown
| External dtype | `<hash>` | `<hash>` | `json` | `json` | `json` |
```

**After:**
```markdown
| External dtype | `<hash@>` | `<hash@>` | `json` | `json` | `json` |
```

### 2. Add Plugin Codecs Documentation

**New file**: `src/how-to/use-plugin-codecs.md` (332 lines)

Comprehensive guide for using plugin codec packages that extend DataJoint via entry point discovery.

**Key sections:**
- Installation and automatic registration via Python entry points
- Complete dj-zarr-codecs usage example with Zarr array storage
- Schema-addressed storage structure explanation
- Finding DataJoint-maintained codecs (dj-zarr-codecs, dj-photon-codecs)
- Comparison with built-in codecs (`<npy@>`, `<blob@>`)
- Best practices for dependency management
- Troubleshooting common issues

**Terminology:** Uses "plugin codecs" instead of "external/third-party" to accurately describe the architectural pattern (separate packages with entry point discovery) without implying ownership.

**DataJoint Plugin Codecs:**
- **dj-zarr-codecs** - Zarr array storage for general numpy arrays
- **dj-photon-codecs** - Photon-limited movies with Anscombe transformation and compression

Note: anscombe-transform is a Zarr/Numcodecs codec (dependency), not a DataJoint plugin codec.

**Updated navigation:**
- `src/how-to/index.md` - Added entry
- `mkdocs.yaml` - Added to Object Storage section

### 3. Reference Plugin Codecs in Explanations

**File**: `src/explanation/custom-codecs.md`

Added "Before Creating Your Own" section that directs readers to check existing plugin codecs before implementing custom solutions:
- dj-zarr-codecs — General numpy arrays with Zarr
- dj-photon-codecs — Photon-limited movies with Anscombe + compression

## Context

The `<hash@>` codec is external-only and requires the `@` modifier. The original table incorrectly showed `<hash>` (without `@`) in the "External dtype" row.

The plugin codecs guide establishes terminology and best practices for DataJoint plugin codecs - packages that register via `datajoint.codecs` entry points. Both dj-zarr-codecs and dj-photon-codecs follow this pattern.

## Related

- PR #121 (merged to pre/v2.0) - Same changes
- datajoint-python PR #1334 - Clarifies dual-mode codecs in builtin_codecs.py docstring
- dj-zarr-codecs repository - https://github.com/datajoint/dj-zarr-codecs
- dj-photon-codecs repository - https://github.com/datajoint/dj-photon-codecs