### PR TITLE
docs: fix terminology, core types, and codec examples

### DIFF
--- a/src/explanation/custom-codecs.md
+++ b/src/explanation/custom-codecs.md
@@ -42,7 +42,7 @@ class MyCodec(dj.Codec):
     """Store custom objects."""
     name = "mytype"  # Used as <mytype> in definitions
 
-    def get_dtype(self, is_external: bool) -> str:
+    def get_dtype(self, is_store: bool) -> str:
         """Return storage type."""
         return "<blob>"  # Chain to blob serialization
 
@@ -78,9 +78,9 @@ class GraphCodec(dj.Codec):
     """Store NetworkX graphs as adjacency data."""
     name = "graph"
 
-    def get_dtype(self, is_external: bool) -> str:
-        # Store as blob (internal) or hash-addressed (external)
-        return "<hash>" if is_external else "<blob>"
+    def get_dtype(self, is_store: bool) -> str:
+        # Store as blob (internal) or blob@ (external)
+        return "<blob@>" if is_store else "<blob>"
 
     def encode(self, graph, *, key=None, store_name=None):
         """Serialize graph to dict."""
@@ -136,10 +136,10 @@ class BamCodec(dj.Codec):
     """Store BAM alignments."""
     name = "bam"
 
-    def get_dtype(self, is_external: bool) -> str:
-        if not is_external:
+    def get_dtype(self, is_store: bool) -> str:
+        if not is_store:
             raise dj.DataJointError("<bam> requires external storage: use <bam@>")
-        return "<object>"  # Path-addressed storage for file structure
+        return "<object@>"  # Path-addressed storage for file structure
 
     def encode(self, alignments, *, key=None, store_name=None):
         """Write alignments to BAM format."""
@@ -162,8 +162,8 @@ class MedicalImageCodec(dj.Codec):
     """Store medical images with metadata."""
     name = "medimg"
 
-    def get_dtype(self, is_external: bool) -> str:
-        return "<hash>" if is_external else "<blob>"
+    def get_dtype(self, is_store: bool) -> str:
+        return "<blob@>" if is_store else "<blob>"
 
     def encode(self, image, *, key=None, store_name=None):
         """Serialize SimpleITK image."""
@@ -197,7 +197,7 @@ graph LR
 class CompressedGraphCodec(dj.Codec):
     name = "cgraph"
 
-    def get_dtype(self, is_external: bool) -> str:
+    def get_dtype(self, is_store: bool) -> str:
         return "<graph>"  # Chain to graph codec
 
     def encode(self, graph, *, key=None, store_name=None):
@@ -216,8 +216,8 @@ class CompressedGraphCodec(dj.Codec):
 class SmallDataCodec(dj.Codec):
     name = "small"
 
-    def get_dtype(self, is_external: bool) -> str:
-        if is_external:
+    def get_dtype(self, is_store: bool) -> str:
+        if is_store:
             raise dj.DataJointError("<small> is internal-only")
         return "json"
 ```
@@ -228,10 +228,10 @@ class SmallDataCodec(dj.Codec):
 class LargeDataCodec(dj.Codec):
     name = "large"
 
-    def get_dtype(self, is_external: bool) -> str:
-        if not is_external:
+    def get_dtype(self, is_store: bool) -> str:
+        if not is_store:
             raise dj.DataJointError("<large> requires @: use <large@>")
-        return "<object>"
+        return "<object@>"
 ```
 
 ### Both Modes
@@ -240,8 +240,8 @@ class LargeDataCodec(dj.Codec):
 class FlexibleCodec(dj.Codec):
     name = "flex"
 
-    def get_dtype(self, is_external: bool) -> str:
-        return "<hash>" if is_external else "<blob>"
+    def get_dtype(self, is_store: bool) -> str:
+        return "<blob@>" if is_store else "<blob>"
 ```
 
 ## Validation

--- a/src/how-to/create-custom-codec.md
+++ b/src/how-to/create-custom-codec.md
@@ -58,16 +58,16 @@ Return the storage type:
 ```python
 def get_dtype(self, is_store: bool) -> str:
     if is_store:
-        return "<hash>"  # Hash-addressed storage
-    return "bytes"       # Inline database blob
+        return "<blob@>"  # Blob in object storage
+    return "bytes"        # Inline database blob
 ```
 
 Common return values:
 
 - `"bytes"` — Binary in database
 - `"json"` — JSON in database
-- `"<blob>"` — Chain to blob codec (hash-addressed when `@`)
-- `"<hash>"` — Hash-addressed storage
+- `"<blob>"` — Chain to blob codec (internal storage)
+- `"<blob@>"` — Blob in object storage
 
 ### `encode(value, *, key=None, store_name=None)`
 
@@ -135,7 +135,7 @@ class ZarrCodec(dj.Codec):
     def get_dtype(self, is_store: bool) -> str:
         if not is_store:
             raise DataJointError("<zarr> requires @ (store only)")
-        return "<object>"  # Schema-addressed storage
+        return "<object@>"  # Schema-addressed storage
 
     def encode(self, path, *, key=None, store_name=None):
         return path  # Path to zarr directory

--- a/src/tutorials/advanced/custom-codecs.ipynb
+++ b/src/tutorials/advanced/custom-codecs.ipynb
@@ -113,7 +113,7 @@
     "@schema\n",
     "class Connectivity(dj.Manual):\n",
     "    definition = \"\"\"\n",
-    "    conn_id : int\n",
+    "    conn_id : uint16\n",
     "    ---\n",
     "    network : <graph>\n",
     "    \"\"\""
@@ -253,7 +253,7 @@
     "@schema\n",
     "class Unit(dj.Manual):\n",
     "    definition = \"\"\"\n",
-    "    unit_id : int\n",
+    "    unit_id : uint16\n",
     "    ---\n",
     "    spikes : <spike_train>\n",
     "    \"\"\"\n",

--- a/src/tutorials/advanced/sql-comparison.ipynb
+++ b/src/tutorials/advanced/sql-comparison.ipynb
@@ -1235,7 +1235,7 @@
     "# Restriction: filters Session to rows matching the Subject query  \n",
     "Session & (Subject & {'species': 'mouse'})\n",
     "\n",
-    "# Antijoin: Session rows NOT matching any Subject (none here, all subjects exist)\n",
+    "# Anti-restriction: Session rows NOT matching any Subject (none here, all subjects exist)\n",
     "Session - Subject"
    ]
   },
@@ -2583,7 +2583,7 @@
     "| `WHERE condition` | `& {'col': value}` or `& 'expr'` | Restriction |\n",
     "| `JOIN ... USING` | `Table1 * Table2` | Natural join |\n",
     "| `GROUP BY ... AGG()` | `.aggr(Table, alias='agg()')` | Aggregation |\n",
-    "| `NOT IN (subquery)` | `Table1 - Table2` | Antijoin |\n",
+    "| `NOT IN (subquery)` | `Table1 - Table2` | Anti-restriction |\n",
     "| `UNION` | `Table1 + Table2` | Union |"
    ]
   },


### PR DESCRIPTION
## Summary

Three documentation fixes for DataJoint 2.0 standards:
1. Replace deprecated "antijoin" terminology with "anti-restriction"
2. Replace native `int` type with core type `uint16`
3. Fix custom codec examples to use correct storage types and API

## Changes

### `src/tutorials/advanced/sql-comparison.ipynb`
- **Line 1238**: `# Antijoin:` → `# Anti-restriction:`
- **Line 2586**: `| Antijoin |` → `| Anti-restriction |`

### `src/tutorials/advanced/custom-codecs.ipynb`
- **Line 116**: `conn_id : int` → `conn_id : uint16`
- **Line 256**: `unit_id : int` → `unit_id : uint16`

### `src/explanation/custom-codecs.md`
- All occurrences: `is_external` → `is_store` (8 instances)
- GraphCodec, MedicalImageCodec, FlexibleCodec: `return "<hash>"` → `return "<blob@>"`
- BamCodec, LargeDataCodec: `return "<object>"` → `return "<object@>"`

### `src/how-to/create-custom-codec.md`
- Example code: `return "<hash>"` → `return "<blob@>"`
- Documentation: Updated return value descriptions
- ZarrCodec: `return "<object>"` → `return "<object@>"`

## Rationale

### Terminology (TERMINOLOGY.md)
- **Anti-restriction** (`-` operator): Filter rows NOT matching condition
- **Restriction** (`&` operator): Filter rows matching condition
- "Antijoin" and "semijoin" are SQL-specific terms, not part of DataJoint's canonical vocabulary

### Core Types (Type System specification)
Core DataJoint types (Layer 2) are **preferred**:
- `uint8`, `uint16`, `int32`, `float32` — Standardized, portable, explicit size
- Native types like `int`, `float` are **discouraged** — Backend-specific, lack size metadata

### Codec API (DataJoint 2.0)
- Parameter: `is_store` (not `is_external`)
- External blob storage: `<blob@>` (not `<hash>`)
- Schema-addressed storage: `<object@>` (not `<object>`)
- Internal storage: `<blob>`, `bytes`, `json`

## Key Fixes

**Storage type corrections:**
- `<hash>` was an internal implementation detail, not a public API
- `<blob@>` is the correct public API for external blob storage
- `<object@>` is required for schema-addressed storage (plain `<object>` is invalid)

**Parameter name:**
- `is_store` reflects the boolean nature (True = use object store)
- More accurate than `is_external` which was ambiguous

## Verification

- ✅ No other "antijoin" or "semijoin" occurrences
- ✅ Python dataclass `SpikeTrain.unit_id: int` correctly unchanged (Python type, not DataJoint type)
- ✅ All codec examples now use correct API
- ✅ Storage type documentation updated

## Related

- User reports from docs.datajoint.com
- Aligns with TERMINOLOGY.md, Type System specification, and Codec API