### PR TITLE
docs: replace native 'int' with core type 'uint16' in custom-codecs tutorial

### DIFF
--- a/src/tutorials/advanced/custom-codecs.ipynb
+++ b/src/tutorials/advanced/custom-codecs.ipynb
@@ -113,7 +113,7 @@
     "@schema\n",
     "class Connectivity(dj.Manual):\n",
     "    definition = \"\"\"\n",
-    "    conn_id : int\n",
+    "    conn_id : uint16\n",
     "    ---\n",
     "    network : <graph>\n",
     "    \"\"\""
@@ -253,7 +253,7 @@
     "@schema\n",
     "class Unit(dj.Manual):\n",
     "    definition = \"\"\"\n",
-    "    unit_id : int\n",
+    "    unit_id : uint16\n",
     "    ---\n",
     "    spikes : <spike_train>\n",
     "    \"\"\"\n",


### PR DESCRIPTION
## Summary

Replaces native database type `int` with core DataJoint type `uint16` in the custom-codecs tutorial, following DataJoint 2.0 type system standards.

## Changes

### `src/tutorials/advanced/custom-codecs.ipynb`
- **Cell 4** (Connectivity table): `conn_id : int` → `conn_id : uint16`
- **Cell 9** (Unit table): `unit_id : int` → `unit_id : uint16`

**Not changed:**
- Cell 8: `SpikeTrain.unit_id: int` — This is a Python dataclass type annotation, not a DataJoint type, so it correctly remains `int`

## Rationale

Per TERMINOLOGY.md and Type System specification:

### Core DataJoint Types (Layer 2) - **Preferred**
- `uint8`, `uint16`, `int32`, `float32`, etc.
- Standardized, scientist-friendly
- Work identically across MySQL and PostgreSQL
- Include explicit size information

### Native Database Types (Layer 1) - **Discouraged**
- `INT`, `FLOAT`, `TINYINT UNSIGNED`, etc.
- Backend-specific
- Generate warnings at declaration time
- Not portable, lack size metadata

## Diff

Clean 2-line change:
```diff
-    conn_id : int
+    conn_id : uint16

-    unit_id : int
+    unit_id : uint16
```

## Related

- User report: Found native type `int` at https://docs.datajoint.com/tutorials/advanced/custom-codecs/
- Follows best practices from Type System documentation