### PR TITLE
docs: Enhance type system diagram and storage terminology

### DIFF
--- a/src/explanation/type-system.md
+++ b/src/explanation/type-system.md
@@ -14,6 +14,7 @@ graph TB
         blob["‹blob›"]
         blob_at["‹blob@›"]
         attach["‹attach›"]
+        attach_at["‹attach@›"]
         npy["‹npy@›"]
         object["‹object@›"]
         hash["‹hash@›"]
@@ -38,8 +39,9 @@ graph TB
 
     blob --> bytes
     blob_at --> hash
-    hash --> json
     attach --> bytes
+    attach_at --> hash
+    hash --> json
     npy --> json
     object --> json
 

--- a/src/explanation/type-system.md
+++ b/src/explanation/type-system.md
@@ -18,7 +18,7 @@ graph TB
         npy["‹npy@›"]
         object["‹object@›"]
         hash["‹hash@›"]
-        custom["‹custom›"]
+        plugin["‹plugin›"]
     end
     subgraph "Layer 2: Core Types"
         int32

--- a/src/explanation/type-system.md
+++ b/src/explanation/type-system.md
@@ -17,6 +17,7 @@ graph TB
         attach_at["‹attach@›"]
         npy["‹npy@›"]
         object["‹object@›"]
+        filepath["‹filepath@›"]
         hash["‹hash@›"]
         plugin["‹plugin›"]
     end
@@ -44,6 +45,7 @@ graph TB
     hash --> json
     npy --> json
     object --> json
+    filepath --> json
 
     bytes --> BYTES_N
     json --> JSON_N

--- a/src/explanation/type-system.md
+++ b/src/explanation/type-system.md
@@ -49,8 +49,8 @@ graph TB
     object --> json
     hash --> json
 
-    bytes --> BLOB
-    bytes --> BYTEA
+    bytes -->|MySQL| BLOB
+    bytes -->|PostgreSQL| BYTEA
     json --> JSON_M
     json --> JSON_P
     int32 --> INT
@@ -59,11 +59,11 @@ graph TB
     float64 --> DOUBLE_P
     varchar --> VARCHAR_M
     varchar --> VARCHAR_P
-    uuid --> BIN16
-    uuid --> UUID_P
+    uuid -->|MySQL| BIN16
+    uuid -->|PostgreSQL| UUID_P
 ```
 
-Core types provide **portability** — the same table definition works on both MySQL and PostgreSQL. Native types can be used directly but sacrifice cross-backend compatibility.
+Core types provide **portability** — the same table definition works on both MySQL and PostgreSQL. For example, `bytes` maps to `LONGBLOB` on MySQL but `BYTEA` on PostgreSQL; `uuid` maps to `BINARY(16)` on MySQL but native `UUID` on PostgreSQL. Native types can be used directly but sacrifice cross-backend compatibility.
 
 ## Layer 1: Native Database Types
 

--- a/src/explanation/type-system.md
+++ b/src/explanation/type-system.md
@@ -24,13 +24,23 @@ graph TB
         varchar
         json
         bytes
+        uuid
     end
-    subgraph "Layer 1: Native"
+    subgraph "Layer 1: Native (MySQL)"
         INT["INT"]
         DOUBLE["DOUBLE"]
-        VARCHAR["VARCHAR"]
-        JSON_N["JSON"]
+        VARCHAR_M["VARCHAR"]
+        JSON_M["JSON"]
         BLOB["LONGBLOB"]
+        BIN16["BINARY(16)"]
+    end
+    subgraph "Layer 1: Native (PostgreSQL)"
+        INTEGER["INTEGER"]
+        DOUBLE_P["DOUBLE PRECISION"]
+        VARCHAR_P["VARCHAR"]
+        JSON_P["JSON"]
+        BYTEA["BYTEA"]
+        UUID_P["UUID"]
     end
 
     blob --> bytes
@@ -38,22 +48,40 @@ graph TB
     npy --> json
     object --> json
     hash --> json
+
     bytes --> BLOB
-    json --> JSON_N
+    bytes --> BYTEA
+    json --> JSON_M
+    json --> JSON_P
     int32 --> INT
+    int32 --> INTEGER
     float64 --> DOUBLE
-    varchar --> VARCHAR
+    float64 --> DOUBLE_P
+    varchar --> VARCHAR_M
+    varchar --> VARCHAR_P
+    uuid --> BIN16
+    uuid --> UUID_P
 ```
+
+Core types provide **portability** — the same table definition works on both MySQL and PostgreSQL. Native types can be used directly but sacrifice cross-backend compatibility.
 
 ## Layer 1: Native Database Types
 
-Backend-specific types (MySQL, PostgreSQL). **Discouraged for direct use.**
+Backend-specific types. **Can be used directly at the cost of portability.**
 
 ```python
-# Native types (avoid)
-column : TINYINT UNSIGNED
-column : MEDIUMBLOB
+# Native types — work but not portable
+column : TINYINT UNSIGNED   # MySQL only
+column : MEDIUMBLOB         # MySQL only (use BYTEA on PostgreSQL)
+column : SERIAL             # PostgreSQL only
 ```
+
+| MySQL | PostgreSQL | Portable Alternative |
+|-------|------------|---------------------|
+| `LONGBLOB` | `BYTEA` | `bytes` |
+| `BINARY(16)` | `UUID` | `uuid` |
+| `SMALLINT` | `SMALLINT` | `int16` |
+| `DOUBLE` | `DOUBLE PRECISION` | `float64` |
 
 ## Layer 2: Core DataJoint Types
 

--- a/src/explanation/type-system.md
+++ b/src/explanation/type-system.md
@@ -12,6 +12,7 @@ database efficiency with Python convenience.
 graph TB
     subgraph "Layer 3: Codecs"
         blob["‹blob›"]
+        blob_at["‹blob@›"]
         attach["‹attach›"]
         npy["‹npy@›"]
         object["‹object@›"]
@@ -36,10 +37,11 @@ graph TB
     end
 
     blob --> bytes
+    blob_at --> hash
+    hash --> json
     attach --> bytes
     npy --> json
     object --> json
-    hash --> json
 
     bytes --> BYTES_N
     json --> JSON_N

--- a/src/explanation/type-system.md
+++ b/src/explanation/type-system.md
@@ -134,24 +134,24 @@ Codec types use angle bracket notation:
 
 ### Built-in Codecs
 
-| Codec | Database | Object Store | Returns |
-|-------|----------|--------------|---------|
-| `<blob>` | ✅ | ✅ `<blob@>` | Python object |
-| `<attach>` | ✅ | ✅ `<attach@>` | Local file path |
-| `<npy@>` | ❌ | ✅ | NpyRef (lazy) |
-| `<object@>` | ❌ | ✅ | ObjectRef |
-| `<hash@>` | ❌ | ✅ | bytes |
-| `<filepath@>` | ❌ | ✅ | ObjectRef |
+| Codec | Database | Object Store | Addressing | Returns |
+|-------|----------|--------------|------------|---------|
+| `<blob>` | ✅ | ✅ `<blob@>` | Hash | Python object |
+| `<attach>` | ✅ | ✅ `<attach@>` | Hash | Local file path |
+| `<npy@>` | ❌ | ✅ | Schema | NpyRef (lazy) |
+| `<object@>` | ❌ | ✅ | Schema | ObjectRef |
+| `<hash@>` | ❌ | ✅ | Hash | bytes |
+| `<filepath@>` | ❌ | ✅ | — | ObjectRef |
 
 ### Plugin Codecs
 
-Additional codecs are available as separately installed packages. This ecosystem is actively expanding—new codecs are added as community needs arise.
+Additional schema-addressed codecs are available as separately installed packages. This ecosystem is actively expanding—new codecs are added as community needs arise.
 
 | Package | Codec | Description | Repository |
 |---------|-------|-------------|------------|
-| `dj-zarr-codecs` | `<zarr@>` | Zarr arrays with lazy chunked access | [datajoint/dj-zarr-codecs](https://github.com/datajoint/dj-zarr-codecs) |
-| `dj-figpack-codecs` | `<figpack@>` | Interactive browser visualizations | [datajoint/dj-figpack-codecs](https://github.com/datajoint/dj-figpack-codecs) |
-| `dj-photon-codecs` | `<photon@>` | Photon imaging data formats | [datajoint/dj-photon-codecs](https://github.com/datajoint/dj-photon-codecs) |
+| `dj-zarr-codecs` | `<zarr@>` | Schema-addressed Zarr arrays with lazy chunked access | [datajoint/dj-zarr-codecs](https://github.com/datajoint/dj-zarr-codecs) |
+| `dj-figpack-codecs` | `<figpack@>` | Schema-addressed interactive browser visualizations | [datajoint/dj-figpack-codecs](https://github.com/datajoint/dj-figpack-codecs) |
+| `dj-photon-codecs` | `<photon@>` | Schema-addressed photon imaging data formats | [datajoint/dj-photon-codecs](https://github.com/datajoint/dj-photon-codecs) |
 
 **Installation and discovery:**
 
@@ -236,7 +236,7 @@ class Config(dj.Manual):
 
 ### `<npy@>` — NumPy Arrays as .npy Files
 
-Stores NumPy arrays as standard `.npy` files with lazy loading. Returns `NpyRef` which provides metadata access (shape, dtype) without downloading.
+Schema-addressed storage for NumPy arrays as standard `.npy` files. Returns `NpyRef` which provides metadata access (shape, dtype) without downloading.
 
 ```python
 class Recording(dj.Computed):
@@ -269,18 +269,20 @@ result = np.mean(ref)  # Downloads automatically
 - **Safe bulk fetch**: Fetching many rows doesn't download until needed
 - **Memory mapping**: `ref.load(mmap_mode='r')` for random access to large arrays
 
-### `<object@>` — Path-Addressed Storage
+### `<object@>` — Schema-Addressed Storage
 
-For large/complex file structures (Zarr, HDF5). Path derived from primary key.
+Schema-addressed storage for files and folders. Path mirrors the database structure: `{schema}/{table}/{pk}/{attribute}`.
 
 ```python
 class ProcessedData(dj.Computed):
     definition = """
     -> Recording
     ---
-    zarr_data : <object@>       # Stored at {schema}/{table}/{pk}/
+    results : <object@>       # Stored at {schema}/{table}/{pk}/results/
     """
 ```
+
+Accepts files, folders, or bytes. Returns `ObjectRef` for lazy access.
 
 ### `<filepath@store>` — Portable References
 
@@ -297,11 +299,17 @@ class RawData(dj.Manual):
 
 ## Storage Modes
 
-| Mode | Database | Object Store | Use Case |
-|------|----------|--------------|----------|
-| Database | Data | — | Small data |
-| Hash-addressed | Metadata | Deduplicated | Large/repeated data |
-| Path-addressed | Metadata | PK-based path | Complex files |
+Object store codecs use one of two addressing schemes:
+
+**Hash-addressed** — Path derived from content hash (e.g., `_hash/ab/cd/abcd1234...`). Provides automatic deduplication—identical content stored once. Used by `<blob@>`, `<attach@>`, `<hash@>`.
+
+**Schema-addressed** — Path mirrors database structure: `{schema}/{table}/{pk}/{attribute}`. Human-readable, browsable paths that reflect your data organization. No deduplication. Used by `<object@>`, `<npy@>`, and plugin codecs (`<zarr@>`, `<figpack@>`, `<photon@>`).
+
+| Mode | Database | Object Store | Deduplication | Use Case |
+|------|----------|--------------|---------------|----------|
+| Database | Data | — | — | Small data |
+| Hash-addressed | Metadata | Content hash path | ✅ Automatic | Large/repeated data |
+| Schema-addressed | Metadata | Schema-mirrored path | ❌ None | Complex files, browsable storage |
 
 ## Custom Codecs
 

--- a/src/explanation/type-system.md
+++ b/src/explanation/type-system.md
@@ -26,21 +26,13 @@ graph TB
         bytes
         uuid
     end
-    subgraph "Layer 1: Native (MySQL)"
-        INT["INT"]
-        DOUBLE["DOUBLE"]
-        VARCHAR_M["VARCHAR"]
-        JSON_M["JSON"]
-        BLOB["LONGBLOB"]
-        BIN16["BINARY(16)"]
-    end
-    subgraph "Layer 1: Native (PostgreSQL)"
-        INTEGER["INTEGER"]
-        DOUBLE_P["DOUBLE PRECISION"]
-        VARCHAR_P["VARCHAR"]
-        JSON_P["JSON"]
-        BYTEA["BYTEA"]
-        UUID_P["UUID"]
+    subgraph "Layer 1: Native Types"
+        INT["INT / INTEGER"]
+        DOUBLE["DOUBLE / DOUBLE PRECISION"]
+        VARCHAR_N["VARCHAR"]
+        JSON_N["JSON"]
+        BYTES_N["LONGBLOB (MySQL) / BYTEA (PG)"]
+        UUID_N["BINARY(16) (MySQL) / UUID (PG)"]
     end
 
     blob --> bytes
@@ -49,18 +41,12 @@ graph TB
     object --> json
     hash --> json
 
-    bytes -->|MySQL| BLOB
-    bytes -->|PostgreSQL| BYTEA
-    json --> JSON_M
-    json --> JSON_P
+    bytes --> BYTES_N
+    json --> JSON_N
     int32 --> INT
-    int32 --> INTEGER
     float64 --> DOUBLE
-    float64 --> DOUBLE_P
-    varchar --> VARCHAR_M
-    varchar --> VARCHAR_P
-    uuid -->|MySQL| BIN16
-    uuid -->|PostgreSQL| UUID_P
+    varchar --> VARCHAR_N
+    uuid --> UUID_N
 ```
 
 Core types provide **portability** — the same table definition works on both MySQL and PostgreSQL. For example, `bytes` maps to `LONGBLOB` on MySQL but `BYTEA` on PostgreSQL; `uuid` maps to `BINARY(16)` on MySQL but native `UUID` on PostgreSQL. Native types can be used directly but sacrifice cross-backend compatibility.

--- a/src/explanation/type-system.md
+++ b/src/explanation/type-system.md
@@ -27,13 +27,13 @@ graph TB
         bytes
         uuid
     end
-    subgraph "Layer 1: Native Types"
+    subgraph "Layer 1: Native Types (MySQL / PostgreSQL)"
         INT["INT / INTEGER"]
         DOUBLE["DOUBLE / DOUBLE PRECISION"]
         VARCHAR_N["VARCHAR"]
         JSON_N["JSON"]
-        BYTES_N["LONGBLOB (MySQL) / BYTEA (PG)"]
-        UUID_N["BINARY(16) (MySQL) / UUID (PG)"]
+        BYTES_N["LONGBLOB / BYTEA"]
+        UUID_N["BINARY(16) / UUID"]
     end
 
     blob --> bytes

--- a/src/reference/specs/npy-codec.md
+++ b/src/reference/specs/npy-codec.md
@@ -287,4 +287,4 @@ arr = np.load('/path/to/store/my_schema/recording/recording_id=1/waveform.npy')
 
 - [Type System Specification](type-system.md) - Complete type system overview
 - [Codec API](codec-api.md) - Creating custom codecs
-- [Object Storage](type-system.md#object--path-addressed-storage) - Path-addressed storage details
+- [Object Storage](type-system.md#object--schema-addressed-storage) - Schema-addressed storage details


### PR DESCRIPTION
## Summary

Enhances the **Three-Layer Architecture** mermaid diagram in `/explanation/type-system.md` and clarifies storage addressing terminology throughout.

## Changes

**Diagram enhancements (`/explanation/type-system.md`):**
- Combined native types layer showing MySQL / PostgreSQL variants (e.g., `LONGBLOB / BYTEA`)
- Added `uuid` core type mapping to `BINARY(16) / UUID`
- Added `<blob@>` and `<attach@>` showing codec chaining through `<hash@>`
- Cleaner layout with backend info in layer title

**Terminology fixes:**
- Renamed "path-addressed" → "schema-addressed" throughout
- Added clear definitions for hash-addressed vs schema-addressed storage
- Updated `<object@>` section header to "Schema-Addressed Storage"
- Fixed broken link in `npy-codec.md`

**Storage modes section:**
- Expanded with definitions and deduplication column
- Cross-references to which codecs use which addressing scheme

## Test plan

- [ ] Verify Three-Layer Architecture mermaid diagram renders correctly
- [ ] Check all internal links resolve
- [ ] Confirm terminology is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)