### PR TITLE
docs: Type system refinements and PostgreSQL notebook fix

### DIFF
--- a/src/explanation/type-system.md
+++ b/src/explanation/type-system.md
@@ -364,3 +364,21 @@ class Network(dj.Computed):
 2. **`<blob>`** for Python objects — NumPy arrays, dicts
 3. **`@` suffix** for object store — `<blob@>`, `<object@>`
 4. **Custom codecs** for domain-specific types
+
+## See Also
+
+**How-to Guides:**
+
+- [Choose a Storage Type](../how-to/choose-storage-type.md) — Decision guide for selecting the right type
+- [Configure Object Storage](../how-to/configure-storage.md) — Setting up stores for external data
+- [Use Object Storage](../how-to/use-object-storage.md) — Working with `<blob@>`, `<attach@>`, `<object@>`
+- [Use the npy Codec](../how-to/use-npy-codec.md) — Storing NumPy arrays as `.npy` files
+- [Use Plugin Codecs](../how-to/use-plugin-codecs.md) — Installing and using third-party codecs
+- [Create a Custom Codec](../how-to/create-custom-codec.md) — Building your own codec
+
+**Reference:**
+
+- [Type System Specification](../reference/specs/type-system.md) — Complete type reference
+- [Codec API](../reference/specs/codec-api.md) — Codec class interface
+- [npy Codec Specification](../reference/specs/npy-codec.md) — NpyRef and NpyCodec details
+- [Object Store Configuration](../reference/specs/object-store-configuration.md) — Store settings reference

--- a/src/explanation/type-system.md
+++ b/src/explanation/type-system.md
@@ -133,7 +133,7 @@ Codec types use angle bracket notation:
 | `<npy@>` | ❌ | ✅ | Schema | NpyRef (lazy) |
 | `<object@>` | ❌ | ✅ | Schema | ObjectRef |
 | `<hash@>` | ❌ | ✅ | Hash | bytes |
-| `<filepath@>` | ❌ | ✅ | — | ObjectRef |
+| `<filepath@>` | ❌ | ✅ | User-managed | ObjectRef |
 
 ### Plugin Codecs
 

--- a/src/explanation/type-system.md
+++ b/src/explanation/type-system.md
@@ -177,7 +177,10 @@ DataJoint loads these entry points on first use, making third-party codecs indis
 
 ### `<blob>` — Serialized Python Objects
 
-Stores NumPy arrays, dicts, lists, and other Python objects using DataJoint's custom binary serialization format.
+Stores NumPy arrays, dicts, lists, and other Python objects using DataJoint's custom binary serialization format. The blob type has been in continuous use in DataJoint pipelines for 15+ years and maintains full backward compatibility. It provides an efficient way to serialize complex objects into an opaque binary string.
+
+!!! note "Modern alternatives"
+    Schema-addressed codecs introduced in DataJoint 2.0 (`<npy@>`, `<object@>`, and plugin codecs) offer modern high-performance accessibility with transparent formats, lazy loading, and browsable storage paths—while maintaining rigorous data integrity and consistency. Consider these for new pipelines where interoperability and direct data access are priorities.
 
 **Serialization format:**
 

--- a/src/tutorials/domain/allen-ccf/allen-ccf.ipynb
+++ b/src/tutorials/domain/allen-ccf/allen-ccf.ipynb
@@ -43,10 +43,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:47.780865Z",
-     "iopub.status.busy": "2026-01-20T22:20:47.780437Z",
-     "iopub.status.idle": "2026-01-20T22:20:48.528133Z",
-     "shell.execute_reply": "2026-01-20T22:20:48.527828Z"
+     "iopub.execute_input": "2026-01-21T21:01:58.054842Z",
+     "iopub.status.busy": "2026-01-21T21:01:58.054581Z",
+     "iopub.status.idle": "2026-01-21T21:01:59.200342Z",
+     "shell.execute_reply": "2026-01-21T21:01:59.199462Z"
     }
    },
    "outputs": [
@@ -54,7 +54,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[2026-01-20 16:20:48,522][INFO]: DataJoint 2.1.0a2 connected to postgres@127.0.0.1:5432\n"
+      "[2026-01-21 15:01:59,189][INFO]: DataJoint 2.1.0a2 connected to postgres@127.0.0.1:5432\n"
      ]
     }
    ],
@@ -85,10 +85,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:48.548610Z",
-     "iopub.status.busy": "2026-01-20T22:20:48.548355Z",
-     "iopub.status.idle": "2026-01-20T22:20:48.565384Z",
-     "shell.execute_reply": "2026-01-20T22:20:48.565131Z"
+     "iopub.execute_input": "2026-01-21T21:01:59.216192Z",
+     "iopub.status.busy": "2026-01-21T21:01:59.215667Z",
+     "iopub.status.idle": "2026-01-21T21:01:59.248890Z",
+     "shell.execute_reply": "2026-01-21T21:01:59.248399Z"
     }
    },
    "outputs": [
@@ -350,10 +350,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:48.566701Z",
-     "iopub.status.busy": "2026-01-20T22:20:48.566581Z",
-     "iopub.status.idle": "2026-01-20T22:20:48.579433Z",
-     "shell.execute_reply": "2026-01-20T22:20:48.579132Z"
+     "iopub.execute_input": "2026-01-21T21:01:59.252549Z",
+     "iopub.status.busy": "2026-01-21T21:01:59.252342Z",
+     "iopub.status.idle": "2026-01-21T21:01:59.286479Z",
+     "shell.execute_reply": "2026-01-21T21:01:59.286141Z"
     }
    },
    "outputs": [],
@@ -384,10 +384,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:48.580937Z",
-     "iopub.status.busy": "2026-01-20T22:20:48.580823Z",
-     "iopub.status.idle": "2026-01-20T22:20:48.600780Z",
-     "shell.execute_reply": "2026-01-20T22:20:48.600495Z"
+     "iopub.execute_input": "2026-01-21T21:01:59.288799Z",
+     "iopub.status.busy": "2026-01-21T21:01:59.288566Z",
+     "iopub.status.idle": "2026-01-21T21:01:59.311285Z",
+     "shell.execute_reply": "2026-01-21T21:01:59.310976Z"
     }
    },
    "outputs": [],
@@ -439,10 +439,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:48.602273Z",
-     "iopub.status.busy": "2026-01-20T22:20:48.602153Z",
-     "iopub.status.idle": "2026-01-20T22:20:48.615846Z",
-     "shell.execute_reply": "2026-01-20T22:20:48.615520Z"
+     "iopub.execute_input": "2026-01-21T21:01:59.313027Z",
+     "iopub.status.busy": "2026-01-21T21:01:59.312900Z",
+     "iopub.status.idle": "2026-01-21T21:01:59.330067Z",
+     "shell.execute_reply": "2026-01-21T21:01:59.329682Z"
     }
    },
    "outputs": [],
@@ -499,10 +499,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:48.617317Z",
-     "iopub.status.busy": "2026-01-20T22:20:48.617174Z",
-     "iopub.status.idle": "2026-01-20T22:20:48.627317Z",
-     "shell.execute_reply": "2026-01-20T22:20:48.627059Z"
+     "iopub.execute_input": "2026-01-21T21:01:59.332227Z",
+     "iopub.status.busy": "2026-01-21T21:01:59.331950Z",
+     "iopub.status.idle": "2026-01-21T21:01:59.345322Z",
+     "shell.execute_reply": "2026-01-21T21:01:59.345024Z"
     }
    },
    "outputs": [],
@@ -536,10 +536,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:48.628703Z",
-     "iopub.status.busy": "2026-01-20T22:20:48.628588Z",
-     "iopub.status.idle": "2026-01-20T22:20:48.980465Z",
-     "shell.execute_reply": "2026-01-20T22:20:48.980000Z"
+     "iopub.execute_input": "2026-01-21T21:01:59.347057Z",
+     "iopub.status.busy": "2026-01-21T21:01:59.346894Z",
+     "iopub.status.idle": "2026-01-21T21:02:00.119227Z",
+     "shell.execute_reply": "2026-01-21T21:02:00.118748Z"
     }
    },
    "outputs": [
@@ -647,7 +647,7 @@
        "</svg>"
       ],
       "text/plain": [
-       "<datajoint.diagram.Diagram at 0x1a1206030>"
+       "<datajoint.diagram.Diagram at 0x1a58c6f00>"
       ]
      },
      "execution_count": 7,
@@ -671,10 +671,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:48.982087Z",
-     "iopub.status.busy": "2026-01-20T22:20:48.981947Z",
-     "iopub.status.idle": "2026-01-20T22:20:48.990879Z",
-     "shell.execute_reply": "2026-01-20T22:20:48.990538Z"
+     "iopub.execute_input": "2026-01-21T21:02:00.121103Z",
+     "iopub.status.busy": "2026-01-21T21:02:00.120979Z",
+     "iopub.status.idle": "2026-01-21T21:02:00.131193Z",
+     "shell.execute_reply": "2026-01-21T21:02:00.130646Z"
     }
    },
    "outputs": [
@@ -821,10 +821,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:48.992307Z",
-     "iopub.status.busy": "2026-01-20T22:20:48.992195Z",
-     "iopub.status.idle": "2026-01-20T22:20:49.092338Z",
-     "shell.execute_reply": "2026-01-20T22:20:49.091976Z"
+     "iopub.execute_input": "2026-01-21T21:02:00.132933Z",
+     "iopub.status.busy": "2026-01-21T21:02:00.132725Z",
+     "iopub.status.idle": "2026-01-21T21:02:00.255613Z",
+     "shell.execute_reply": "2026-01-21T21:02:00.255164Z"
     }
    },
    "outputs": [
@@ -841,7 +841,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "BrainRegion: 100%|██████████| 1/1 [00:00<00:00, 14.73it/s]"
+      "BrainRegion: 100%|██████████| 1/1 [00:00<00:00, 13.26it/s]"
      ]
     },
     {
@@ -879,10 +879,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:49.093956Z",
-     "iopub.status.busy": "2026-01-20T22:20:49.093816Z",
-     "iopub.status.idle": "2026-01-20T22:20:49.098881Z",
-     "shell.execute_reply": "2026-01-20T22:20:49.098644Z"
+     "iopub.execute_input": "2026-01-21T21:02:00.257271Z",
+     "iopub.status.busy": "2026-01-21T21:02:00.257129Z",
+     "iopub.status.idle": "2026-01-21T21:02:00.262701Z",
+     "shell.execute_reply": "2026-01-21T21:02:00.262381Z"
     }
    },
    "outputs": [
@@ -1094,10 +1094,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:49.100179Z",
-     "iopub.status.busy": "2026-01-20T22:20:49.100032Z",
-     "iopub.status.idle": "2026-01-20T22:20:49.857119Z",
-     "shell.execute_reply": "2026-01-20T22:20:49.856831Z"
+     "iopub.execute_input": "2026-01-21T21:02:00.264483Z",
+     "iopub.status.busy": "2026-01-21T21:02:00.264321Z",
+     "iopub.status.idle": "2026-01-21T21:02:01.078458Z",
+     "shell.execute_reply": "2026-01-21T21:02:01.078205Z"
     }
    },
    "outputs": [
@@ -1114,7 +1114,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "RegionParent:   6%|▌         | 77/1327 [00:00<00:01, 766.01it/s]"
+      "RegionParent:   5%|▌         | 69/1327 [00:00<00:01, 686.97it/s]"
      ]
     },
     {
@@ -1129,7 +1129,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "RegionParent:  21%|██        | 275/1327 [00:00<00:00, 1474.28it/s]"
+      "RegionParent:  17%|█▋        | 229/1327 [00:00<00:00, 1218.80it/s]"
      ]
     },
     {
@@ -1137,7 +1137,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "RegionParent:  36%|███▌      | 474/1327 [00:00<00:00, 1706.81it/s]"
+      "RegionParent:  31%|███       | 410/1327 [00:00<00:00, 1485.64it/s]"
      ]
     },
     {
@@ -1145,7 +1145,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "RegionParent:  51%|█████     | 671/1327 [00:00<00:00, 1809.21it/s]"
+      "RegionParent:  45%|████▍     | 596/1327 [00:00<00:00, 1632.49it/s]"
      ]
     },
     {
@@ -1153,7 +1153,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "RegionParent:  65%|██████▌   | 864/1327 [00:00<00:00, 1850.86it/s]"
+      "RegionParent:  59%|█████▊    | 779/1327 [00:00<00:00, 1702.21it/s]"
      ]
     },
     {
@@ -1161,7 +1161,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "RegionParent:  80%|███████▉  | 1058/1327 [00:00<00:00, 1879.05it/s]"
+      "RegionParent:  72%|███████▏  | 955/1327 [00:00<00:00, 1721.29it/s]"
      ]
     },
     {
@@ -1169,7 +1169,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "RegionParent:  94%|█████████▍| 1246/1327 [00:00<00:00, 1877.42it/s]"
+      "RegionParent:  86%|████████▌ | 1143/1327 [00:00<00:00, 1770.38it/s]"
      ]
     },
     {
@@ -1177,7 +1177,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "RegionParent: 100%|██████████| 1327/1327 [00:00<00:00, 1783.84it/s]"
+      "RegionParent: 100%|██████████| 1327/1327 [00:00<00:00, 1660.03it/s]"
      ]
     },
     {
@@ -1217,10 +1217,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:49.858569Z",
-     "iopub.status.busy": "2026-01-20T22:20:49.858429Z",
-     "iopub.status.idle": "2026-01-20T22:20:49.862799Z",
-     "shell.execute_reply": "2026-01-20T22:20:49.862552Z"
+     "iopub.execute_input": "2026-01-21T21:02:01.079847Z",
+     "iopub.status.busy": "2026-01-21T21:02:01.079719Z",
+     "iopub.status.idle": "2026-01-21T21:02:01.083805Z",
+     "shell.execute_reply": "2026-01-21T21:02:01.083572Z"
     }
    },
    "outputs": [
@@ -1372,10 +1372,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:49.864059Z",
-     "iopub.status.busy": "2026-01-20T22:20:49.863968Z",
-     "iopub.status.idle": "2026-01-20T22:20:49.868932Z",
-     "shell.execute_reply": "2026-01-20T22:20:49.868654Z"
+     "iopub.execute_input": "2026-01-21T21:02:01.085120Z",
+     "iopub.status.busy": "2026-01-21T21:02:01.085017Z",
+     "iopub.status.idle": "2026-01-21T21:02:01.090020Z",
+     "shell.execute_reply": "2026-01-21T21:02:01.089750Z"
     }
    },
    "outputs": [
@@ -1544,10 +1544,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:49.870269Z",
-     "iopub.status.busy": "2026-01-20T22:20:49.870185Z",
-     "iopub.status.idle": "2026-01-20T22:20:49.878012Z",
-     "shell.execute_reply": "2026-01-20T22:20:49.877753Z"
+     "iopub.execute_input": "2026-01-21T21:02:01.091322Z",
+     "iopub.status.busy": "2026-01-21T21:02:01.091245Z",
+     "iopub.status.idle": "2026-01-21T21:02:01.099177Z",
+     "shell.execute_reply": "2026-01-21T21:02:01.098849Z"
     }
    },
    "outputs": [
@@ -1595,27 +1595,27 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:49.879217Z",
-     "iopub.status.busy": "2026-01-20T22:20:49.879136Z",
-     "iopub.status.idle": "2026-01-20T22:20:49.981694Z",
-     "shell.execute_reply": "2026-01-20T22:20:49.981400Z"
+     "iopub.execute_input": "2026-01-21T21:02:01.100589Z",
+     "iopub.status.busy": "2026-01-21T21:02:01.100505Z",
+     "iopub.status.idle": "2026-01-21T21:02:01.216506Z",
+     "shell.execute_reply": "2026-01-21T21:02:01.216196Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "([<matplotlib.axis.XTick at 0x1a2ea0620>,\n",
-       "  <matplotlib.axis.XTick at 0x1a2e67c20>,\n",
-       "  <matplotlib.axis.XTick at 0x1a2ea0200>,\n",
-       "  <matplotlib.axis.XTick at 0x1a30c3740>,\n",
-       "  <matplotlib.axis.XTick at 0x1a30c2c30>,\n",
-       "  <matplotlib.axis.XTick at 0x1a30c2000>,\n",
-       "  <matplotlib.axis.XTick at 0x1a30c1ca0>,\n",
-       "  <matplotlib.axis.XTick at 0x1a30c0f50>,\n",
-       "  <matplotlib.axis.XTick at 0x1a30c04d0>,\n",
-       "  <matplotlib.axis.XTick at 0x1a318fdd0>,\n",
-       "  <matplotlib.axis.XTick at 0x1a30c2390>],\n",
+       "([<matplotlib.axis.XTick at 0x1a7599e80>,\n",
+       "  <matplotlib.axis.XTick at 0x1a7599370>,\n",
+       "  <matplotlib.axis.XTick at 0x1a74c3bc0>,\n",
+       "  <matplotlib.axis.XTick at 0x1a7731850>,\n",
+       "  <matplotlib.axis.XTick at 0x1a7732f90>,\n",
+       "  <matplotlib.axis.XTick at 0x1a7732bd0>,\n",
+       "  <matplotlib.axis.XTick at 0x1a7730620>,\n",
+       "  <matplotlib.axis.XTick at 0x1a7733a70>,\n",
+       "  <matplotlib.axis.XTick at 0x1a77319a0>,\n",
+       "  <matplotlib.axis.XTick at 0x1a77e0080>,\n",
+       "  <matplotlib.axis.XTick at 0x1a77325d0>],\n",
        " [Text(0, 0, '0'),\n",
        "  Text(1, 0, '1'),\n",
        "  Text(2, 0, '2'),\n",
@@ -1671,62 +1671,183 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:49.983135Z",
-     "iopub.status.busy": "2026-01-20T22:20:49.983001Z",
-     "iopub.status.idle": "2026-01-20T22:20:50.247750Z",
-     "shell.execute_reply": "2026-01-20T22:20:50.247506Z"
+     "iopub.execute_input": "2026-01-21T21:02:01.217992Z",
+     "iopub.status.busy": "2026-01-21T21:02:01.217853Z",
+     "iopub.status.idle": "2026-01-21T21:02:01.227355Z",
+     "shell.execute_reply": "2026-01-21T21:02:01.227058Z"
     }
    },
    "outputs": [
     {
-     "ename": "UnknownAttributeError",
-     "evalue": "column \"%Visual%\" does not exist\nLINE 1: ...en_ccf\".\"_brain_region\" WHERE ( (region_name LIKE \"%Visual%\"...\n                                                             ^\n",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mUndefinedColumn\u001b[0m                           Traceback (most recent call last)",
-      "File \u001b[0;32m~/dev/datajoint-docs-migration/datajoint-python/src/datajoint/connection.py:364\u001b[0m, in \u001b[0;36mConnection._execute_query\u001b[0;34m(self, cursor, query, args, suppress_warnings)\u001b[0m\n\u001b[1;32m    363\u001b[0m             warnings\u001b[38;5;241m.\u001b[39msimplefilter(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mignore\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m--> 364\u001b[0m         \u001b[43mcursor\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43mquery\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43margs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    365\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n",
-      "\u001b[0;31mUndefinedColumn\u001b[0m: column \"%Visual%\" does not exist\nLINE 1: ...en_ccf\".\"_brain_region\" WHERE ( (region_name LIKE \"%Visual%\"...\n                                                             ^\n",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[0;31mUnknownAttributeError\u001b[0m                     Traceback (most recent call last)",
-      "File \u001b[0;32m/opt/anaconda3/lib/python3.12/site-packages/IPython/core/formatters.py:770\u001b[0m, in \u001b[0;36mPlainTextFormatter.__call__\u001b[0;34m(self, obj)\u001b[0m\n\u001b[1;32m    763\u001b[0m stream \u001b[38;5;241m=\u001b[39m StringIO()\n\u001b[1;32m    764\u001b[0m printer \u001b[38;5;241m=\u001b[39m pretty\u001b[38;5;241m.\u001b[39mRepresentationPrinter(stream, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mverbose,\n\u001b[1;32m    765\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmax_width, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mnewline,\n\u001b[1;32m    766\u001b[0m     max_seq_length\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmax_seq_length,\n\u001b[1;32m    767\u001b[0m     singleton_pprinters\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msingleton_printers,\n\u001b[1;32m    768\u001b[0m     type_pprinters\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtype_printers,\n\u001b[1;32m    769\u001b[0m     deferred_pprinters\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdeferred_printers)\n\u001b[0;32m--> 770\u001b[0m \u001b[43mprinter\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpretty\u001b[49m\u001b[43m(\u001b[49m\u001b[43mobj\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    771\u001b[0m printer\u001b[38;5;241m.\u001b[39mflush()\n\u001b[1;32m    772\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m stream\u001b[38;5;241m.\u001b[39mgetvalue()\n",
-      "File \u001b[0;32m/opt/anaconda3/lib/python3.12/site-packages/IPython/lib/pretty.py:419\u001b[0m, in \u001b[0;36mRepresentationPrinter.pretty\u001b[0;34m(self, obj)\u001b[0m\n\u001b[1;32m    408\u001b[0m                         \u001b[38;5;28;01mreturn\u001b[39;00m meth(obj, \u001b[38;5;28mself\u001b[39m, cycle)\n\u001b[1;32m    409\u001b[0m                 \u001b[38;5;28;01mif\u001b[39;00m (\n\u001b[1;32m    410\u001b[0m                     \u001b[38;5;28mcls\u001b[39m \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mobject\u001b[39m\n\u001b[1;32m    411\u001b[0m                     \u001b[38;5;66;03m# check if cls defines __repr__\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    417\u001b[0m                     \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28mcallable\u001b[39m(_safe_getattr(\u001b[38;5;28mcls\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m__repr__\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m))\n\u001b[1;32m    418\u001b[0m                 ):\n\u001b[0;32m--> 419\u001b[0m                     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43m_repr_pprint\u001b[49m\u001b[43m(\u001b[49m\u001b[43mobj\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcycle\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    421\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m _default_pprint(obj, \u001b[38;5;28mself\u001b[39m, cycle)\n\u001b[1;32m    422\u001b[0m \u001b[38;5;28;01mfinally\u001b[39;00m:\n",
-      "File \u001b[0;32m/opt/anaconda3/lib/python3.12/site-packages/IPython/lib/pretty.py:794\u001b[0m, in \u001b[0;36m_repr_pprint\u001b[0;34m(obj, p, cycle)\u001b[0m\n\u001b[1;32m    792\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"A pprint that just redirects to the normal repr function.\"\"\"\u001b[39;00m\n\u001b[1;32m    793\u001b[0m \u001b[38;5;66;03m# Find newlines and replace them with p.break_()\u001b[39;00m\n\u001b[0;32m--> 794\u001b[0m output \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mrepr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mobj\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    795\u001b[0m lines \u001b[38;5;241m=\u001b[39m output\u001b[38;5;241m.\u001b[39msplitlines()\n\u001b[1;32m    796\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m p\u001b[38;5;241m.\u001b[39mgroup():\n",
-      "File \u001b[0;32m~/dev/datajoint-docs-migration/datajoint-python/src/datajoint/expression.py:955\u001b[0m, in \u001b[0;36mQueryExpression.__repr__\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    947\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21m__repr__\u001b[39m(\u001b[38;5;28mself\u001b[39m):\n\u001b[1;32m    948\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    949\u001b[0m \u001b[38;5;124;03m    returns the string representation of a QueryExpression object e.g. ``str(q1)``.\u001b[39;00m\n\u001b[1;32m    950\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    953\u001b[0m \u001b[38;5;124;03m    :rtype: str\u001b[39;00m\n\u001b[1;32m    954\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 955\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28msuper\u001b[39m()\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__repr__\u001b[39m() \u001b[38;5;28;01mif\u001b[39;00m config[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mloglevel\u001b[39m\u001b[38;5;124m\"\u001b[39m]\u001b[38;5;241m.\u001b[39mlower() \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mdebug\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpreview\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/dev/datajoint-docs-migration/datajoint-python/src/datajoint/expression.py:959\u001b[0m, in \u001b[0;36mQueryExpression.preview\u001b[0;34m(self, limit, width)\u001b[0m\n\u001b[1;32m    957\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mpreview\u001b[39m(\u001b[38;5;28mself\u001b[39m, limit\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, width\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[1;32m    958\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\":return: a string of preview of the contents of the query.\"\"\"\u001b[39;00m\n\u001b[0;32m--> 959\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mpreview\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mlimit\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mwidth\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/dev/datajoint-docs-migration/datajoint-python/src/datajoint/preview.py:53\u001b[0m, in \u001b[0;36mpreview\u001b[0;34m(query_expression, limit, width)\u001b[0m\n\u001b[1;32m     51\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m width \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m     52\u001b[0m     width \u001b[38;5;241m=\u001b[39m config[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mdisplay.width\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n\u001b[0;32m---> 53\u001b[0m tuples \u001b[38;5;241m=\u001b[39m \u001b[43mrel\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mto_arrays\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlimit\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mlimit\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m+\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;241;43m1\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m     54\u001b[0m has_more \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mlen\u001b[39m(tuples) \u001b[38;5;241m>\u001b[39m limit\n\u001b[1;32m     55\u001b[0m tuples \u001b[38;5;241m=\u001b[39m tuples[:limit]\n",
-      "File \u001b[0;32m~/dev/datajoint-docs-migration/datajoint-python/src/datajoint/expression.py:825\u001b[0m, in \u001b[0;36mQueryExpression.to_arrays\u001b[0;34m(self, include_key, order_by, limit, offset, squeeze, *attrs)\u001b[0m\n\u001b[1;32m    822\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    823\u001b[0m     \u001b[38;5;66;03m# Fetch all columns as structured array\u001b[39;00m\n\u001b[1;32m    824\u001b[0m     get \u001b[38;5;241m=\u001b[39m partial(decode_attribute, squeeze\u001b[38;5;241m=\u001b[39msqueeze)\n\u001b[0;32m--> 825\u001b[0m     cursor \u001b[38;5;241m=\u001b[39m \u001b[43mexpr\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcursor\u001b[49m\u001b[43m(\u001b[49m\u001b[43mas_dict\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m)\u001b[49m\n\u001b[1;32m    826\u001b[0m     rows \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mlist\u001b[39m(cursor\u001b[38;5;241m.\u001b[39mfetchall())\n\u001b[1;32m    828\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m rows:\n",
-      "File \u001b[0;32m~/dev/datajoint-docs-migration/datajoint-python/src/datajoint/expression.py:945\u001b[0m, in \u001b[0;36mQueryExpression.cursor\u001b[0;34m(self, as_dict)\u001b[0m\n\u001b[1;32m    943\u001b[0m sql \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmake_sql()\n\u001b[1;32m    944\u001b[0m logger\u001b[38;5;241m.\u001b[39mdebug(sql)\n\u001b[0;32m--> 945\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mconnection\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mquery\u001b[49m\u001b[43m(\u001b[49m\u001b[43msql\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mas_dict\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mas_dict\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/dev/datajoint-docs-migration/datajoint-python/src/datajoint/connection.py:425\u001b[0m, in \u001b[0;36mConnection.query\u001b[0;34m(self, query, args, as_dict, suppress_warnings, reconnect)\u001b[0m\n\u001b[1;32m    423\u001b[0m cursor \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39madapter\u001b[38;5;241m.\u001b[39mget_cursor(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_conn, as_dict\u001b[38;5;241m=\u001b[39mas_dict)\n\u001b[1;32m    424\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 425\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_execute_query\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcursor\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mquery\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43msuppress_warnings\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    426\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m errors\u001b[38;5;241m.\u001b[39mLostConnectionError:\n\u001b[1;32m    427\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m reconnect:\n",
-      "File \u001b[0;32m~/dev/datajoint-docs-migration/datajoint-python/src/datajoint/connection.py:366\u001b[0m, in \u001b[0;36mConnection._execute_query\u001b[0;34m(self, cursor, query, args, suppress_warnings)\u001b[0m\n\u001b[1;32m    364\u001b[0m         cursor\u001b[38;5;241m.\u001b[39mexecute(query, args)\n\u001b[1;32m    365\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n\u001b[0;32m--> 366\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m translate_query_error(err, query, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39madapter)\n",
-      "\u001b[0;31mUnknownAttributeError\u001b[0m: column \"%Visual%\" does not exist\nLINE 1: ...en_ccf\".\"_brain_region\" WHERE ( (region_name LIKE \"%Visual%\"...\n                                                             ^\n"
-     ]
-    },
-    {
-     "ename": "UnknownAttributeError",
-     "evalue": "column \"%Visual%\" does not exist\nLINE 1: ...en_ccf\".\"_brain_region\" WHERE ( (region_name LIKE \"%Visual%\"...\n                                                             ^\n",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mUndefinedColumn\u001b[0m                           Traceback (most recent call last)",
-      "File \u001b[0;32m~/dev/datajoint-docs-migration/datajoint-python/src/datajoint/connection.py:364\u001b[0m, in \u001b[0;36mConnection._execute_query\u001b[0;34m(self, cursor, query, args, suppress_warnings)\u001b[0m\n\u001b[1;32m    363\u001b[0m             warnings\u001b[38;5;241m.\u001b[39msimplefilter(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mignore\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m--> 364\u001b[0m         \u001b[43mcursor\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43mquery\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43margs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    365\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n",
-      "\u001b[0;31mUndefinedColumn\u001b[0m: column \"%Visual%\" does not exist\nLINE 1: ...en_ccf\".\"_brain_region\" WHERE ( (region_name LIKE \"%Visual%\"...\n                                                             ^\n",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[0;31mUnknownAttributeError\u001b[0m                     Traceback (most recent call last)",
-      "File \u001b[0;32m/opt/anaconda3/lib/python3.12/site-packages/IPython/core/formatters.py:406\u001b[0m, in \u001b[0;36mBaseFormatter.__call__\u001b[0;34m(self, obj)\u001b[0m\n\u001b[1;32m    404\u001b[0m     method \u001b[38;5;241m=\u001b[39m get_real_method(obj, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mprint_method)\n\u001b[1;32m    405\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m method \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 406\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mmethod\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    407\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[1;32m    408\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n",
-      "File \u001b[0;32m~/dev/datajoint-docs-migration/datajoint-python/src/datajoint/expression.py:963\u001b[0m, in \u001b[0;36mQueryExpression._repr_html_\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    961\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21m_repr_html_\u001b[39m(\u001b[38;5;28mself\u001b[39m):\n\u001b[1;32m    962\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\":return: HTML to display table in Jupyter notebook.\"\"\"\u001b[39;00m\n\u001b[0;32m--> 963\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mrepr_html\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/dev/datajoint-docs-migration/datajoint-python/src/datajoint/preview.py:111\u001b[0m, in \u001b[0;36mrepr_html\u001b[0;34m(query_expression)\u001b[0m\n\u001b[1;32m    109\u001b[0m object_fields \u001b[38;5;241m=\u001b[39m []\n\u001b[1;32m    110\u001b[0m info \u001b[38;5;241m=\u001b[39m heading\u001b[38;5;241m.\u001b[39mtable_status\n\u001b[0;32m--> 111\u001b[0m tuples \u001b[38;5;241m=\u001b[39m \u001b[43mrel\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mto_arrays\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlimit\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mconfig\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mdisplay.limit\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m+\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;241;43m1\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m    112\u001b[0m has_more \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mlen\u001b[39m(tuples) \u001b[38;5;241m>\u001b[39m config[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mdisplay.limit\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n\u001b[1;32m    113\u001b[0m tuples \u001b[38;5;241m=\u001b[39m tuples[\u001b[38;5;241m0\u001b[39m : config[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mdisplay.limit\u001b[39m\u001b[38;5;124m\"\u001b[39m]]\n",
-      "File \u001b[0;32m~/dev/datajoint-docs-migration/datajoint-python/src/datajoint/expression.py:825\u001b[0m, in \u001b[0;36mQueryExpression.to_arrays\u001b[0;34m(self, include_key, order_by, limit, offset, squeeze, *attrs)\u001b[0m\n\u001b[1;32m    822\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    823\u001b[0m     \u001b[38;5;66;03m# Fetch all columns as structured array\u001b[39;00m\n\u001b[1;32m    824\u001b[0m     get \u001b[38;5;241m=\u001b[39m partial(decode_attribute, squeeze\u001b[38;5;241m=\u001b[39msqueeze)\n\u001b[0;32m--> 825\u001b[0m     cursor \u001b[38;5;241m=\u001b[39m \u001b[43mexpr\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcursor\u001b[49m\u001b[43m(\u001b[49m\u001b[43mas_dict\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m)\u001b[49m\n\u001b[1;32m    826\u001b[0m     rows \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mlist\u001b[39m(cursor\u001b[38;5;241m.\u001b[39mfetchall())\n\u001b[1;32m    828\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m rows:\n",
-      "File \u001b[0;32m~/dev/datajoint-docs-migration/datajoint-python/src/datajoint/expression.py:945\u001b[0m, in \u001b[0;36mQueryExpression.cursor\u001b[0;34m(self, as_dict)\u001b[0m\n\u001b[1;32m    943\u001b[0m sql \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmake_sql()\n\u001b[1;32m    944\u001b[0m logger\u001b[38;5;241m.\u001b[39mdebug(sql)\n\u001b[0;32m--> 945\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mconnection\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mquery\u001b[49m\u001b[43m(\u001b[49m\u001b[43msql\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mas_dict\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mas_dict\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/dev/datajoint-docs-migration/datajoint-python/src/datajoint/connection.py:425\u001b[0m, in \u001b[0;36mConnection.query\u001b[0;34m(self, query, args, as_dict, suppress_warnings, reconnect)\u001b[0m\n\u001b[1;32m    423\u001b[0m cursor \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39madapter\u001b[38;5;241m.\u001b[39mget_cursor(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_conn, as_dict\u001b[38;5;241m=\u001b[39mas_dict)\n\u001b[1;32m    424\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 425\u001b[0m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_execute_query\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcursor\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mquery\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43msuppress_warnings\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    426\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m errors\u001b[38;5;241m.\u001b[39mLostConnectionError:\n\u001b[1;32m    427\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m reconnect:\n",
-      "File \u001b[0;32m~/dev/datajoint-docs-migration/datajoint-python/src/datajoint/connection.py:366\u001b[0m, in \u001b[0;36mConnection._execute_query\u001b[0;34m(self, cursor, query, args, suppress_warnings)\u001b[0m\n\u001b[1;32m    364\u001b[0m         cursor\u001b[38;5;241m.\u001b[39mexecute(query, args)\n\u001b[1;32m    365\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n\u001b[0;32m--> 366\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m translate_query_error(err, query, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39madapter)\n",
-      "\u001b[0;31mUnknownAttributeError\u001b[0m: column \"%Visual%\" does not exist\nLINE 1: ...en_ccf\".\"_brain_region\" WHERE ( (region_name LIKE \"%Visual%\"...\n                                                             ^\n"
-     ]
+     "data": {
+      "text/html": [
+       "\n",
+       "    \n",
+       "    <style type=\"text/css\">\n",
+       "        .Table{\n",
+       "            border-collapse:collapse;\n",
+       "        }\n",
+       "        .Table th{\n",
+       "            background: #A0A0A0; color: #ffffff; padding:2px 4px; border:#f0e0e0 1px solid;\n",
+       "            font-weight: normal; font-family: monospace; font-size: 75%; text-align: center;\n",
+       "        }\n",
+       "        .Table th p{\n",
+       "            margin: 0;\n",
+       "        }\n",
+       "        .Table td{\n",
+       "            padding:2px 4px; border:#f0e0e0 1px solid; font-size: 75%;\n",
+       "        }\n",
+       "        .Table tr:nth-child(odd){\n",
+       "            background: #ffffff;\n",
+       "            color: #000000;\n",
+       "        }\n",
+       "        .Table tr:nth-child(even){\n",
+       "            background: #f3f1ff;\n",
+       "            color: #000000;\n",
+       "        }\n",
+       "        /* Tooltip container */\n",
+       "        .djtooltip {\n",
+       "        }\n",
+       "        /* Tooltip text */\n",
+       "        .djtooltip .djtooltiptext {\n",
+       "            visibility: hidden;\n",
+       "            width: 120px;\n",
+       "            background-color: black;\n",
+       "            color: #fff;\n",
+       "            text-align: center;\n",
+       "            padding: 5px 0;\n",
+       "            border-radius: 6px;\n",
+       "            /* Position the tooltip text - see examples below! */\n",
+       "            position: absolute;\n",
+       "            z-index: 1;\n",
+       "        }\n",
+       "        #primary {\n",
+       "            font-weight: bold;\n",
+       "            color: black;\n",
+       "        }\n",
+       "        #nonprimary {\n",
+       "            font-weight: normal;\n",
+       "            color: white;\n",
+       "        }\n",
+       "\n",
+       "        /* Show the tooltip text when you mouse over the tooltip container */\n",
+       "        .djtooltip:hover .djtooltiptext {\n",
+       "            visibility: visible;\n",
+       "        }\n",
+       "\n",
+       "        /* Dark mode support */\n",
+       "        @media (prefers-color-scheme: dark) {\n",
+       "            .Table th{\n",
+       "                background: #4a4a4a; color: #ffffff; border:#555555 1px solid; text-align: center;\n",
+       "            }\n",
+       "            .Table td{\n",
+       "                border:#555555 1px solid;\n",
+       "            }\n",
+       "            .Table tr:nth-child(odd){\n",
+       "                background: #2d2d2d;\n",
+       "                color: #e0e0e0;\n",
+       "            }\n",
+       "            .Table tr:nth-child(even){\n",
+       "                background: #3d3d3d;\n",
+       "                color: #e0e0e0;\n",
+       "            }\n",
+       "            .djtooltip .djtooltiptext {\n",
+       "                background-color: #555555;\n",
+       "                color: #ffffff;\n",
+       "            }\n",
+       "            #primary {\n",
+       "                color: #bd93f9;\n",
+       "            }\n",
+       "            #nonprimary {\n",
+       "                color: #e0e0e0;\n",
+       "            }\n",
+       "        }\n",
+       "    </style>\n",
+       "    \n",
+       "    <b>Brain region from Allen ontology</b>\n",
+       "        <div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "        <table border=\"1\" class=\"Table\">\n",
+       "            <thead> <tr> <th> <div class=\"djtooltip\">\n",
+       "                            <p id=\"primary\">ccf_id</p>\n",
+       "                            <span class=\"djtooltiptext\">None</span>\n",
+       "                        </div></th><th><div class=\"djtooltip\">\n",
+       "                            <p id=\"primary\">region_id</p>\n",
+       "                            <span class=\"djtooltiptext\">Allen structure ID</span>\n",
+       "                        </div></th><th><div class=\"djtooltip\">\n",
+       "                            <p id=\"nonprimary\">acronym</p>\n",
+       "                            <span class=\"djtooltiptext\">short name (e.g., 'VISp')</span>\n",
+       "                        </div></th><th><div class=\"djtooltip\">\n",
+       "                            <p id=\"nonprimary\">region_name</p>\n",
+       "                            <span class=\"djtooltiptext\">full name</span>\n",
+       "                        </div></th><th><div class=\"djtooltip\">\n",
+       "                            <p id=\"nonprimary\">color_hex</p>\n",
+       "                            <span class=\"djtooltiptext\">hex color code for visualization</span>\n",
+       "                        </div></th><th><div class=\"djtooltip\">\n",
+       "                            <p id=\"nonprimary\">structure_order</p>\n",
+       "                            <span class=\"djtooltiptext\">order in hierarchy</span>\n",
+       "                        </div> </th> </tr> </thead>\n",
+       "            <tbody> <tr> <td>1</td>\n",
+       "<td>457</td>\n",
+       "<td>VIS6a</td>\n",
+       "<td>Visual areas layer 6a</td>\n",
+       "<td>bytes</td>\n",
+       "<td>bytes</td></tr><tr><td>1</td>\n",
+       "<td>497</td>\n",
+       "<td>VIS6b</td>\n",
+       "<td>Visual areas layer 6b</td>\n",
+       "<td>bytes</td>\n",
+       "<td>bytes</td></tr><tr><td>1</td>\n",
+       "<td>561</td>\n",
+       "<td>VIS2/3</td>\n",
+       "<td>Visual areas layer 2/3</td>\n",
+       "<td>bytes</td>\n",
+       "<td>bytes</td></tr><tr><td>1</td>\n",
+       "<td>669</td>\n",
+       "<td>VIS</td>\n",
+       "<td>Visual areas</td>\n",
+       "<td>bytes</td>\n",
+       "<td>bytes</td></tr><tr><td>1</td>\n",
+       "<td>801</td>\n",
+       "<td>VIS1</td>\n",
+       "<td>Visual areas layer 1</td>\n",
+       "<td>bytes</td>\n",
+       "<td>bytes</td></tr><tr><td>1</td>\n",
+       "<td>913</td>\n",
+       "<td>VIS4</td>\n",
+       "<td>Visual areas layer 4</td>\n",
+       "<td>bytes</td>\n",
+       "<td>bytes</td></tr><tr><td>1</td>\n",
+       "<td>937</td>\n",
+       "<td>VIS5</td>\n",
+       "<td>Visual areas layer 5</td>\n",
+       "<td>bytes</td>\n",
+       "<td>bytes</td> </tr> </tbody>\n",
+       "        </table>\n",
+       "        \n",
+       "        <p>Total: 7</p></div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "*ccf_id    *region_id    acronym     region_name   \n",
+       "+--------+ +-----------+ +---------+ +------------+\n",
+       "1          457           VIS6a       Visual areas l\n",
+       "1          497           VIS6b       Visual areas l\n",
+       "1          561           VIS2/3      Visual areas l\n",
+       "1          669           VIS         Visual areas  \n",
+       "1          801           VIS1        Visual areas l\n",
+       "1          913           VIS4        Visual areas l\n",
+       "1          937           VIS5        Visual areas l\n",
+       " (Total: 7)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "# Find all visual-related regions\n",
-    "(BrainRegion & 'region_name LIKE \"%Visual%\"').proj('acronym', 'region_name')"
+    "(BrainRegion & \"region_name LIKE '%Visual%'\").proj('acronym', 'region_name')"
    ]
   },
   {
@@ -1761,10 +1882,10 @@
    "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:50.249149Z",
-     "iopub.status.busy": "2026-01-20T22:20:50.249024Z",
-     "iopub.status.idle": "2026-01-20T22:20:50.275941Z",
-     "shell.execute_reply": "2026-01-20T22:20:50.275695Z"
+     "iopub.execute_input": "2026-01-21T21:02:01.228668Z",
+     "iopub.status.busy": "2026-01-21T21:02:01.228583Z",
+     "iopub.status.idle": "2026-01-21T21:02:01.296125Z",
+     "shell.execute_reply": "2026-01-21T21:02:01.295836Z"
     }
    },
    "outputs": [
@@ -1970,10 +2091,10 @@
    "execution_count": 18,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:50.277427Z",
-     "iopub.status.busy": "2026-01-20T22:20:50.277303Z",
-     "iopub.status.idle": "2026-01-20T22:20:50.405374Z",
-     "shell.execute_reply": "2026-01-20T22:20:50.404993Z"
+     "iopub.execute_input": "2026-01-21T21:02:01.297578Z",
+     "iopub.status.busy": "2026-01-21T21:02:01.297453Z",
+     "iopub.status.idle": "2026-01-21T21:02:01.444587Z",
+     "shell.execute_reply": "2026-01-21T21:02:01.443936Z"
     }
    },
    "outputs": [
@@ -2101,7 +2222,7 @@
        "</svg>"
       ],
       "text/plain": [
-       "<datajoint.diagram.Diagram at 0x1a2ed05c0>"
+       "<datajoint.diagram.Diagram at 0x1a74ee750>"
       ]
      },
      "execution_count": 18,
@@ -2119,10 +2240,10 @@
    "execution_count": 19,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-01-20T22:20:50.406922Z",
-     "iopub.status.busy": "2026-01-20T22:20:50.406788Z",
-     "iopub.status.idle": "2026-01-20T22:20:50.414885Z",
-     "shell.execute_reply": "2026-01-20T22:20:50.414629Z"
+     "iopub.execute_input": "2026-01-21T21:02:01.446676Z",
+     "iopub.status.busy": "2026-01-21T21:02:01.446492Z",
+     "iopub.status.idle": "2026-01-21T21:02:01.457412Z",
+     "shell.execute_reply": "2026-01-21T21:02:01.456992Z"
     }
    },
    "outputs": [],


### PR DESCRIPTION
## Summary

- Improved type system documentation with historical context and cross-references
- Fixed PostgreSQL compatibility issue in allen-ccf tutorial notebook

## Changes

### Type System Documentation (`src/explanation/type-system.md`)
- Mark `<filepath@>` addressing as "User-managed" in Built-in Codecs table
- Add historical context for `<blob>` type (15+ years backward compatibility)
- Add callout explaining schema-addressed codecs as modern alternatives
- Add "See Also" section with cross-references to how-tos and specs

### Tutorial Fix (`src/tutorials/domain/allen-ccf/allen-ccf.ipynb`)
- Fix SQL LIKE pattern to use single quotes for PostgreSQL compatibility
- Re-executed notebook against PostgreSQL and saved outputs

## Test plan
- [ ] Type system page renders correctly
- [ ] All cross-reference links work
- [ ] Allen-ccf notebook executes successfully against PostgreSQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)