### PR TITLE
docs: Fix terminology inconsistencies

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -52,7 +52,6 @@ nav:
       - how-to/index.md
       - Setup:
           - Installation: how-to/installation.md
-          - Manage Secrets: how-to/manage-secrets.md
           - Configure Database: how-to/configure-database.md
           - Configure Object Storage: how-to/configure-storage.md
           - Command-Line Interface: how-to/use-cli.md
@@ -74,8 +73,6 @@ nav:
           - Handle Errors: how-to/handle-errors.md
           - Monitor Progress: how-to/monitor-progress.md
       - Object Storage:
-          - Overview: how-to/object-storage-overview.md
-          - Choose Storage Type: how-to/choose-storage-type.md
           - Use Object Storage: how-to/use-object-storage.md
           - Use NPY Codec: how-to/use-npy-codec.md
           - Use Plugin Codecs: how-to/use-plugin-codecs.md

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -52,6 +52,7 @@ nav:
       - how-to/index.md
       - Setup:
           - Installation: how-to/installation.md
+          - Manage Secrets: how-to/manage-secrets.md
           - Configure Database: how-to/configure-database.md
           - Configure Object Storage: how-to/configure-storage.md
           - Command-Line Interface: how-to/use-cli.md
@@ -73,6 +74,8 @@ nav:
           - Handle Errors: how-to/handle-errors.md
           - Monitor Progress: how-to/monitor-progress.md
       - Object Storage:
+          - Overview: how-to/object-storage-overview.md
+          - Choose Storage Type: how-to/choose-storage-type.md
           - Use Object Storage: how-to/use-object-storage.md
           - Use NPY Codec: how-to/use-npy-codec.md
           - Use Plugin Codecs: how-to/use-plugin-codecs.md

--- a/src/explanation/faq.md
+++ b/src/explanation/faq.md
@@ -88,7 +88,7 @@ Object-Relational Mappers treat large objects as opaque binary blobs or leave fi
 
 - Relational semantics apply: referential integrity, cascading deletes, query filtering
 - Multiple access patterns: lazy `ObjectRef`, streaming via fsspec, explicit download
-- Two addressing modes: path-addressed (by primary key) and hash-addressed (deduplicated)
+- Two addressing modes: schema-addressed (by primary key) and hash-addressed (deduplicated)
 
 The object store is part of the relational model — queryable and integrity-protected like any other attribute.
 

--- a/src/explanation/type-system.md
+++ b/src/explanation/type-system.md
@@ -315,7 +315,7 @@ class GraphCodec(dj.Codec):
     """Store NetworkX graphs."""
     name = "graph"
 
-    def get_dtype(self, is_external):
+    def get_dtype(self, is_store):
         return "<blob>"
 
     def encode(self, graph, *, key=None, store_name=None):

--- a/src/how-to/define-tables.md
+++ b/src/how-to/define-tables.md
@@ -160,7 +160,7 @@ Codecs serialize Python objects to database storage. Use angle brackets for code
 | `<blob@store>` | Serialized objects in object storage |
 | `<attach>` | File attachments in database |
 | `<attach@store>` | File attachments in object storage |
-| `<object@store>` | Files/folders via ObjectRef (path-addressed, supports Zarr/HDF5) |
+| `<object@store>` | Files/folders via ObjectRef (schema-addressed, supports Zarr/HDF5) |
 
 Example:
 

--- a/src/how-to/use-object-storage.md
+++ b/src/how-to/use-object-storage.md
@@ -149,7 +149,7 @@ class Dataset(dj.Manual):
     """
 ```
 
-Use path-addressed storage for:
+Use schema-addressed storage for:
 
 - Zarr arrays (chunked, appendable)
 - HDF5 files

--- a/src/reference/specs/type-system.md
+++ b/src/reference/specs/type-system.md
@@ -410,8 +410,8 @@ class FilepathCodec(dj.Codec):
     """Store-relative file references. External only."""
     name = "filepath"
 
-    def get_dtype(self, is_external: bool) -> str:
-        if not is_external:
+    def get_dtype(self, is_store: bool) -> str:
+        if not is_store:
             raise DataJointError("<filepath> requires @store")
         return "json"
 
@@ -512,8 +512,8 @@ class BlobCodec(dj.Codec):
     """Serialized Python objects. Supports internal and external."""
     name = "blob"
 
-    def get_dtype(self, is_external: bool) -> str:
-        return "<hash>" if is_external else "bytes"
+    def get_dtype(self, is_store: bool) -> str:
+        return "<hash>" if is_store else "bytes"
 
     def encode(self, value, *, key=None, store_name=None) -> bytes:
         from . import blob
@@ -551,8 +551,8 @@ class AttachCodec(dj.Codec):
     """File attachment with filename. Supports in-table and in-store."""
     name = "attach"
 
-    def get_dtype(self, is_external: bool) -> str:
-        return "<hash>" if is_external else "bytes"
+    def get_dtype(self, is_store: bool) -> str:
+        return "<hash>" if is_store else "bytes"
 
     def encode(self, filepath, *, key=None, store_name=None) -> bytes:
         path = Path(filepath)
@@ -662,7 +662,7 @@ def garbage_collect(store_name):
 2. **Core types are scientist-friendly**: `float32`, `int8`, `bool`, `bytes` instead of `FLOAT`, `TINYINT`, `LONGBLOB`
 3. **Codecs use angle brackets**: `<blob>`, `<object@store>`, `<filepath@main>` - distinguishes from core types
 4. **`@` indicates in-store storage**: No `@` = database, `@` present = object store
-5. **`get_dtype(is_external)` method**: Codecs resolve dtype at declaration time based on storage mode
+5. **`get_dtype(is_store)` method**: Codecs resolve dtype at declaration time based on storage mode
 6. **Codecs are composable**: `<blob@>` uses `<hash@>`, which uses `json`
 7. **Built-in in-store codecs use JSON dtype**: Stores metadata (path, hash, store name, etc.)
 8. **Two OAS regions**: object (PK-addressed) and hash (hash-addressed) within managed stores


### PR DESCRIPTION
## Summary

- Fix `is_external` → `is_store` parameter name in codec examples to match source code
- Complete `path-addressed` → `schema-addressed` terminology rename (missed in PR #132)

## Changes

### Codec Parameter Name (`is_external` → `is_store`)

The source code (`datajoint-python` `pre/v2.1`) uses `is_store: bool` but docs had `is_external`:

- `src/explanation/type-system.md` — GraphCodec example
- `src/reference/specs/type-system.md` — FilepathCodec, BlobCodec, AttachCodec examples (8 instances total)

### Terminology (`path-addressed` → `schema-addressed`)

PR #132 renamed this terminology but missed 3 instances:

- `src/explanation/faq.md` — Object storage addressing modes
- `src/how-to/use-object-storage.md` — Storage type guidance
- `src/how-to/define-tables.md` — Object type descriptions

## Test plan

- [ ] Verify docs build without errors
- [ ] Confirm terminology is consistent across docs

🤖 Generated with [Claude Code](https://claude.ai/code)