### PR TITLE
docs: Add missing nav entries for existing how-to guides

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -52,6 +52,7 @@ nav:
       - how-to/index.md
       - Setup:
           - Installation: how-to/installation.md
+          - Manage Secrets: how-to/manage-secrets.md
           - Configure Database: how-to/configure-database.md
           - Configure Object Storage: how-to/configure-storage.md
           - Command-Line Interface: how-to/use-cli.md
@@ -73,6 +74,8 @@ nav:
           - Handle Errors: how-to/handle-errors.md
           - Monitor Progress: how-to/monitor-progress.md
       - Object Storage:
+          - Overview: how-to/object-storage-overview.md
+          - Choose Storage Type: how-to/choose-storage-type.md
           - Use Object Storage: how-to/use-object-storage.md
           - Use NPY Codec: how-to/use-npy-codec.md
           - Use Plugin Codecs: how-to/use-plugin-codecs.md


### PR DESCRIPTION
## Summary

Restores navigation entries that were incorrectly removed in PR #134.

The files exist but were missing from the sidebar navigation:
- `how-to/manage-secrets.md` → Setup section
- `how-to/object-storage-overview.md` → Object Storage section
- `how-to/choose-storage-type.md` → Object Storage section

## Context

In PR #134, reviewer feedback indicated these files didn't exist. The nav entries were removed, but the files actually do exist (added in an earlier PR). This PR adds them back to the navigation.

## Test plan

- [ ] Verify docs build without errors
- [ ] Confirm new pages appear in sidebar navigation

🤖 Generated with [Claude Code](https://claude.ai/code)