### PR TITLE
Update database_prefix, logging docs, and 2.x version

### DIFF
--- a/src/how-to/deploy-production.md
+++ b/src/how-to/deploy-production.md
@@ -90,22 +90,22 @@ class NewTable(dj.Manual):
 NewTable()  # Creates the table
 ```
 
-## Use Schema Prefixes
+## Use Database Prefixes
 
 When multiple projects share a database server, use prefixes to avoid naming collisions and organize schemas.
 
-### Configure Project Prefix
+### Configure Database Prefix
 
 ```python
 import datajoint as dj
 
-dj.config.database.schema_prefix = 'myproject_'
+dj.config.database.database_prefix = 'myproject_'
 ```
 
 Or via environment variable:
 
 ```bash
-export DJ_SCHEMA_PREFIX=myproject_
+export DJ_DATABASE_PREFIX=myproject_
 ```
 
 Or in `datajoint.json`:
@@ -113,7 +113,7 @@ Or in `datajoint.json`:
 ```json
 {
   "database": {
-    "schema_prefix": "myproject_"
+    "database_prefix": "myproject_"
   }
 }
 ```
@@ -125,7 +125,7 @@ Use the prefix when creating schemas:
 ```python
 import datajoint as dj
 
-prefix = dj.config.database.schema_prefix  # 'myproject_'
+prefix = dj.config.database.database_prefix  # 'myproject_'
 
 # Schema names include prefix
 subject_schema = dj.Schema(prefix + 'subject')   # myproject_subject
@@ -197,7 +197,7 @@ export DJ_PASS=prod_password
 
 # Production mode
 export DJ_CREATE_TABLES=false
-export DJ_SCHEMA_PREFIX=myproject_
+export DJ_DATABASE_PREFIX=myproject_
 
 # Disable interactive prompts
 export DJ_SAFEMODE=false
@@ -215,7 +215,7 @@ services:
     environment:
       - DJ_HOST=db.example.com
       - DJ_CREATE_TABLES=false
-      - DJ_SCHEMA_PREFIX=prod_
+      - DJ_DATABASE_PREFIX=prod_
     volumes:
       # Mount secrets directory
       - type: bind
@@ -282,7 +282,7 @@ export DJ_PASS=<from-secret-manager>
 
 # Production behavior
 export DJ_CREATE_TABLES=false
-export DJ_SCHEMA_PREFIX=prod_
+export DJ_DATABASE_PREFIX=prod_
 export DJ_SAFEMODE=false
 
 # Logging
@@ -304,9 +304,9 @@ def verify_production_config():
     if dj.config.database.create_tables:
         errors.append("create_tables should be False in production")
 
-    # Check schema prefix is set
-    if not dj.config.database.schema_prefix:
-        errors.append("schema_prefix should be set in production")
+    # Check database prefix is set
+    if not dj.config.database.database_prefix:
+        errors.append("database_prefix should be set in production")
 
     # Check not pointing to localhost
     if dj.config.database.host == 'localhost':
@@ -330,7 +330,7 @@ if __name__ == '__main__':
 | Setting | Development | Production |
 |---------|-------------|------------|
 | `database.create_tables` | `true` | `false` |
-| `database.schema_prefix` | `""` or `dev_` | `prod_` |
+| `database.database_prefix` | `""` or `dev_` | `prod_` |
 | `safemode` | `true` | `false` (automated) |
 | `loglevel` | `DEBUG` | `WARNING` |
 

--- a/src/index.md
+++ b/src/index.md
@@ -1,11 +1,11 @@
 # DataJoint Documentation
 
-!!! info "Documentation for DataJoint 2.0 (Pre-Release)"
+!!! info "Documentation for DataJoint 2.x (Pre-Release)"
 
-    This documentation covers **DataJoint 2.0**, currently in pre-release.
+    This documentation covers **DataJoint 2.0–2.1**, currently in pre-release.
 
     - **Using stable 0.14.x?** Visit [legacy docs](https://datajoint.github.io/datajoint-python)
-    - **Want to test 2.0?** See [Installation Guide](how-to/installation.md)
+    - **Want to test 2.x?** See [Installation Guide](how-to/installation.md)
     - **Migrating a pipeline?** Follow the [Migration Guide](how-to/migrate-to-v20.md)
 
 ## About DataJoint

--- a/src/reference/configuration.md
+++ b/src/reference/configuration.md
@@ -21,7 +21,7 @@ Configuration is loaded in priority order:
 | `database.password` | `DJ_PASS` | — | Database password (required) |
 | `database.reconnect` | — | `True` | Auto-reconnect on connection loss |
 | `database.use_tls` | — | `None` | Enable TLS encryption |
-| `database.schema_prefix` | `DJ_SCHEMA_PREFIX` | `""` | Project-specific prefix for schema names |
+| `database.database_prefix` | `DJ_DATABASE_PREFIX` | `""` | Prefix for database/schema names |
 | `database.create_tables` | `DJ_CREATE_TABLES` | `True` | Default for `Schema(create_tables=)`. Set `False` for production mode |
 
 ## Connection Settings


### PR DESCRIPTION
## Summary

- **Front page**: Update to indicate DataJoint 2.0–2.1 pre-release coverage
- **Settings rename**: `database.schema_prefix` → `database.database_prefix`
- **Env var rename**: `DJ_SCHEMA_PREFIX` → `DJ_DATABASE_PREFIX`
- **Logging docs**: Document JOBS log level and DJ_LOG_STREAM env var

## Rationale

### database_prefix rename
Renames `database.schema_prefix` to `database.database_prefix` to avoid confusion with the store's `schema_prefix` setting (used for schema-addressed storage paths).

- In MySQL: schema = database
- In PostgreSQL: projects use dedicated databases
- `database_prefix` is technically accurate for both backends

### Logging documentation
Adds documentation for PR #1352 logging changes:
- JOBS log level (15) between DEBUG and INFO for job status visibility
- DJ_LOG_STREAM env var for stdout/stderr routing (default: stdout)

## Related

- datajoint-python PR #1351 — Implements the database_prefix rename
- datajoint-python PR #1352 — Implements the logging changes

## Files Changed

- `src/index.md` — Version banner update
- `src/reference/configuration.md` — Settings table, logging section
- `src/how-to/deploy-production.md` — database_prefix and logging updates
- `src/reference/specs/autopopulate.md` — Job status logging section

🤖 Generated with [Claude Code](https://claude.ai/code)