### PR TITLE
docs: Document make_kwargs passed to make_fetch in tripartite pattern

### DIFF
--- a/src/explanation/computation-model.md
+++ b/src/explanation/computation-model.md
@@ -207,8 +207,11 @@ class SignalAverage(dj.Computed):
     avg_signal : float64
     """
 
-    def make_fetch(self, key):
-        """Step 1: Fetch input data (outside transaction)"""
+    def make_fetch(self, key, **kwargs):
+        """Step 1: Fetch input data (outside transaction).
+
+        kwargs are passed from populate(make_kwargs={...}).
+        """
         raw_signal = (RawSignal & key).fetch1("signal")
         return (raw_signal,)
 

--- a/src/how-to/run-computations.md
+++ b/src/how-to/run-computations.md
@@ -199,8 +199,11 @@ class LongComputation(dj.Computed):
     result : float64
     """
 
-    def make_fetch(self, key):
-        """Fetch input data (outside transaction)"""
+    def make_fetch(self, key, **kwargs):
+        """Fetch input data (outside transaction).
+
+        kwargs are passed from populate(make_kwargs={...}).
+        """
         data = (RawData & key).fetch1('data')
         return (data,)
 

--- a/src/reference/specs/autopopulate.md
+++ b/src/reference/specs/autopopulate.md
@@ -334,8 +334,11 @@ class HeavyComputation(dj.Computed):
     result : <blob>
     """
 
-    def make_fetch(self, key):
-        """Fetch all required data (runs in transaction)."""
+    def make_fetch(self, key, **kwargs):
+        """Fetch all required data (runs in transaction).
+
+        kwargs are passed from populate(make_kwargs={...}).
+        """
         return (Recording & key).fetch1('raw_data')
 
     def make_compute(self, key, data):
@@ -391,6 +394,15 @@ class ConfigurableAnalysis(dj.Computed):
 
 # Call with custom parameters
 ConfigurableAnalysis.populate(make_kwargs={'threshold': 0.8})
+```
+
+**Tripartite pattern:** When using the method-based tripartite pattern, `make_kwargs` are passed to `make_fetch()`:
+
+```python
+def make_fetch(self, key, verbose=False, **kwargs):
+    if verbose:
+        print(f"Fetching {key}")
+    return (Source & key).fetch1('data')
 ```
 
 **Anti-pattern warning:** Passing arguments that affect the computed result breaks reproducibility—all inputs should come from `fetch` calls inside `make()`. If a parameter affects results, it should be stored in a lookup table and referenced via foreign key.
@@ -973,8 +985,8 @@ def make(self, key):
     yield  # Re-acquire transaction
     self.insert1({**key, 'result': result})
 
-# Tripartite (methods)
-def make_fetch(self, key): return data
+# Tripartite (methods) - kwargs passed to make_fetch
+def make_fetch(self, key, **kwargs): return data
 def make_compute(self, key, data): return result
 def make_insert(self, key, result): self.insert1(...)
 ```


### PR DESCRIPTION
## Summary

Update tripartite pattern documentation to show that `make_fetch` receives `**kwargs` from `populate(make_kwargs={...})`.

## Changes

Updated examples in:
- `src/reference/specs/autopopulate.md` - Reference specification
- `src/how-to/run-computations.md` - How-to guide
- `src/explanation/computation-model.md` - Conceptual explanation

## Related

- datajoint/datajoint-python#1350 - Bug report
- datajoint/datajoint-python#1361 - Fix PR

🤖 Generated with [Claude Code](https://claude.ai/code)