### PR TITLE
docs: Update for DataJoint 2.0 stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository contains the source for the DataJoint documentation, organized u
 git clone https://github.com/datajoint/datajoint-docs.git
 cd datajoint-docs
 cd ..
-git clone -b pre/v2.0 https://github.com/datajoint/datajoint-python.git
+git clone https://github.com/datajoint/datajoint-python.git
 cd datajoint-docs
 
 # Start live preview at http://localhost:8000

--- a/src/how-to/installation.md
+++ b/src/how-to/installation.md
@@ -2,43 +2,31 @@
 
 Install DataJoint Python and set up your environment.
 
-!!! warning "Pre-Release Documentation"
-
-    This documentation covers **DataJoint 2.0**, which is currently in pre-release.
-
-    - **For production use:** Install the stable version (0.14.x) and use [legacy docs](https://datajoint.github.io/datajoint-python)
-    - **For testing 2.0:** Follow the pre-release installation instructions below
-    - **For migration:** See the [Migration Guide](migrate-to-v20.md)
-
-## Choose Your Installation
-
-### Pre-Release (2.0) — For Testing and Development
-
-**Note:** DataJoint 2.0 is not yet on PyPI/conda. Install from the pre-release branch:
-
-```bash
-git clone -b pre/v2.0 https://github.com/datajoint/datajoint-python.git
-cd datajoint-python
-pip install -e ".[dev]"
-```
-
-**With optional dependencies:**
-
-```bash
-# For polars DataFrame support
-pip install -e ".[polars]"
-
-# For all optional dependencies
-pip install -e ".[all]"
-```
-
-### Stable (0.14.x) — For Production Use
+## Install DataJoint 2.0
 
 ```bash
 pip install datajoint
 ```
 
-**Note:** This installs DataJoint 0.14.x. The tutorials and guides in this documentation are written for 2.0 and will not match the stable API. Use [legacy documentation](https://datajoint.github.io/datajoint-python) instead.
+**With optional dependencies:**
+
+```bash
+# For diagram visualization (matplotlib, ipython)
+pip install datajoint[viz]
+
+# For polars DataFrame support
+pip install datajoint[polars]
+
+# For cloud storage backends
+pip install datajoint[s3]    # AWS S3
+pip install datajoint[gcs]   # Google Cloud Storage
+pip install datajoint[azure] # Azure Blob Storage
+```
+
+!!! note "Upgrading from 0.14.x?"
+
+    See the [Migration Guide](migrate-to-v20.md) for breaking changes and upgrade instructions.
+    Legacy documentation for 0.14.x is available at [datajoint.github.io](https://datajoint.github.io/datajoint-python).
 
 ## Verify Installation
 
@@ -53,12 +41,11 @@ print(dj.__version__)
 - `2.0.0` or higher — You're ready to follow this documentation
 - `0.14.x` or lower — You have the stable version, use [legacy docs](https://datajoint.github.io/datajoint-python) instead
 
-### If You Have the Wrong Version
+### If You Have an Older Version
 
 | Your Situation | Action |
 |----------------|--------|
-| Installed 0.14.x but want to test 2.0 | Follow pre-release installation above |
-| Installed 2.0 but need production stability | `pip uninstall datajoint && pip install datajoint` |
+| Installed 0.14.x, want to upgrade | `pip install --upgrade datajoint` |
 | Have existing 0.14.x pipeline to upgrade | Follow [Migration Guide](migrate-to-v20.md) |
 
 ## Database Server

--- a/src/how-to/use-plugin-codecs.md
+++ b/src/how-to/use-plugin-codecs.md
@@ -237,7 +237,7 @@ Check compatibility with your DataJoint version:
 
 ```bash
 pip show dj-zarr-codecs
-# Requires: datajoint>=2.0.0a22
+# Requires: datajoint>=2.0.0
 ```
 
 Upgrade DataJoint if needed:
@@ -552,14 +552,14 @@ Add plugin codecs to your project dependencies:
 
 **requirements.txt:**
 ```
-datajoint>=2.0.0a22
+datajoint>=2.0.0
 dj-zarr-codecs>=0.1.0
 ```
 
 **pyproject.toml:**
 ```toml
 dependencies = [
-    "datajoint>=2.0.0a22",
+    "datajoint>=2.0.0",
     "dj-zarr-codecs>=0.1.0",
 ]
 ```
@@ -574,7 +574,7 @@ My Pipeline
 ===========
 
 Requirements:
-- datajoint>=2.0.0a22
+- datajoint>=2.0.0
 - dj-zarr-codecs>=0.1.0  # For waveform storage
 
 Install:

--- a/src/index.md
+++ b/src/index.md
@@ -1,12 +1,9 @@
 # DataJoint Documentation
 
-!!! info "Documentation for DataJoint 2.x (Pre-Release)"
+!!! tip "Upgrading from 0.14.x?"
 
-    This documentation covers **DataJoint 2.0–2.1**, currently in pre-release.
-
-    - **Using stable 0.14.x?** Visit [legacy docs](https://datajoint.github.io/datajoint-python)
-    - **Want to test 2.x?** See [Installation Guide](how-to/installation.md)
-    - **Migrating a pipeline?** Follow the [Migration Guide](how-to/migrate-to-v20.md)
+    - **Migration guide:** [Migrate to 2.0](how-to/migrate-to-v20.md)
+    - **Legacy docs:** [datajoint.github.io](https://datajoint.github.io/datajoint-python)
 
 ## About DataJoint
 


### PR DESCRIPTION
## Summary
Update documentation to reflect that DataJoint 2.0 is now a stable release.

### Changes
- Remove pre-release warnings and notices from index and installation pages
- Update installation instructions to use `pip install datajoint`
- Update version references from `2.0.0a22` to `2.0.0`
- Remove `pre/v2.0` branch references
- Add `[viz]` optional dependency documentation

### Files changed
- `src/index.md` - Remove pre-release notice
- `src/how-to/installation.md` - Update for stable release
- `src/how-to/use-plugin-codecs.md` - Update version references
- `README.md` - Remove branch reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)