### PR TITLE
docs: Add temporary module notice for datajoint.migrate

### DIFF
--- a/src/how-to/migrate-to-v20.md
+++ b/src/how-to/migrate-to-v20.md
@@ -5,6 +5,10 @@ Upgrade existing pipelines from legacy DataJoint (pre-2.0) to DataJoint 2.0.
 > **This guide is optimized for AI coding assistants.** Point your AI agent at this
 > document and it will execute the migration with your oversight.
 
+!!! warning "Temporary module"
+
+    The `datajoint.migrate` module is provided temporarily to assist with migration. It will be deprecated in DataJoint 2.1 and removed in 2.2. Complete your migration while on 2.0.
+
 ## Requirements
 
 ### System Requirements


### PR DESCRIPTION
## Summary
- Add warning that `datajoint.migrate` module is temporary
- Will be deprecated in 2.1 and removed in 2.2

Related to datajoint-python PR #1373

🤖 Generated with [Claude Code](https://claude.com/claude-code)