### PR TITLE
docs: drop MariaDB, pin MySQL minimum to 8.0.13

### DIFF
--- a/src/how-to/define-tables.md
+++ b/src/how-to/define-tables.md
@@ -176,7 +176,7 @@ parameters : json             # JSON data (core type, no brackets)
 
 ## Native Database Types
 
-You can also use native MySQL/MariaDB types directly when needed:
+You can also use native database types directly when needed:
 
 ```python
 definition = """

--- a/src/how-to/installation.md
+++ b/src/how-to/installation.md
@@ -78,7 +78,7 @@ See [Configure Database Connection](configure-database.md) for connection setup.
 ## Requirements
 
 - Python 3.10+
-- MySQL 8.0+ or MariaDB 10.6+
+- MySQL 8.0.13+ or PostgreSQL 15+
 - Network access to database server
 
 ## Troubleshooting

--- a/src/reference/specs/database-backends.md
+++ b/src/reference/specs/database-backends.md
@@ -9,7 +9,7 @@ DataJoint supports multiple database backends through a unified adapter architec
 
 | Backend | Minimum Version | Default Port | Status |
 |---------|-----------------|--------------|--------|
-| MySQL | 8.0 | 3306 | Production |
+| MySQL | 8.0.13 | 3306 | Production |
 | PostgreSQL | 15 | 5432 | Production |
 
 ## Configuration


### PR DESCRIPTION
## Summary

DataJoint 2.x is officially MySQL/PostgreSQL only; MariaDB is no longer listed as a supported backend (it was never tested in CI and recent feature work has begun to require MySQL 8.0.13-only columns). PostgreSQL is reframed from "an alternative" to a peer production backend.

- `installation.md`: Requirements line lists `MySQL 8.0.13+ or PostgreSQL 15+` (was `MySQL 8.0+ or MariaDB 10.6+`).
- `database-backends.md`: MySQL row pinned to 8.0.13.
- `define-tables.md`: "native MySQL/MariaDB types" → "native database types".

Companion code PR: datajoint/datajoint-python#1439 — adds a `UserWarning` at connect time when the server reports MariaDB.

## Test plan

- [x] `gen_llms_full.py` regenerated `llms-full.txt` cleanly (verified the requirements line now reads `MySQL 8.0.13+ or PostgreSQL 15+`).
- [ ] Build the docs site locally and confirm the changed pages render correctly.