### PR TITLE
docs: document Top(order_by="_name") in hidden-attribute matrix

### DIFF
--- a/src/reference/specs/table-declaration.md
+++ b/src/reference/specs/table-declaration.md
@@ -191,6 +191,7 @@ These columns are populated by DataJoint internals via raw SQL during the `popul
 | Natural-join namesake matching | Excluded |
 | Dict restriction `Table & {"_name": value}` | Silently ignored |
 | String restriction `Table & "_name = ..."` | Included (passes to SQL) |
+| `Top(order_by="_name")` | Allowed (passes through to SQL `ORDER BY`; no heading validation) |
 | `insert()`, `insert1()` | Rejected — ``KeyError("`_name` is not in the table heading")`` |
 | `update1()` | Rejected — ``DataJointError("Attribute `_name` not found.")`` |
 | `insert(..., ignore_extra_fields=True)` | Silently dropped (key not written) |


### PR DESCRIPTION
## Summary

Adds one row to the §3.4 hidden-attribute behavior matrix to document that `dj.Top(order_by="_name")` flows through to SQL `ORDER BY` without heading validation.

## Why this row is missing today

The current matrix (added in #162) covers reads (`fetch`/`proj`/`to_dicts`/...), writes (`insert`/`update1`), restrictions (dict and string), joins, `describe()`, and indexes — but not `Top`. Worth a row because `Top.order_by` behaves like the string-restriction case (passes the column name through to SQL untouched), so a hidden column can legitimately shape the result order even though its value can never return to Python.

## Code path

1. `Top.__post_init__` (`condition.py:142-148`) — type-checks `order_by` is a string or list of strings; **no name validation**.
2. `restrict()` (`expression.py:241-254`) — when the restriction is a `Top`, short-circuits with `return result` at line 254, before reaching the `heading.names` check at lines 260-262 that fires for non-Top conditions.
3. `sorting_clauses()` (`expression.py:133-145`) → `_flatten_attribute_list` (`:1580-1604`, only special-cases `"KEY"`) → `_wrap_attributes` (`:1607-1617`, regex `\b((?!asc|desc)\w+)\b` quotes the name as `` `_name` ``).
4. The quoted hidden-column name lands in `ORDER BY`. The `SELECT` list is still built from `heading.names` at `expression.py:163`, so the value never returns to Python.

## Worked example

```python
# Five most recently populated rows
MyTable & dj.Top(5, order_by="_job_start_time DESC")
```

Generated SQL (visible columns only in `SELECT`; hidden column referenced only in `ORDER BY`):

```sql
SELECT <visible cols>
FROM <table>
ORDER BY `_job_start_time` DESC
LIMIT 5
```

## Caveat

Because `Top` does no name check, a typoed column name passes DataJoint validation and fails as a SQL error from the DB. Not a hidden-attribute concern specifically, but worth knowing the failure mode if you mistype `_job_start_tine`.

## Test plan

- [x] `python scripts/gen_llms_full.py` regenerates cleanly.
- [x] Build the docs locally and confirm the new row renders correctly in the matrix.