### PR TITLE
docs: add two 2026 publications using DataJoint

### DIFF
--- a/src/about/publications.md
+++ b/src/about/publications.md
@@ -10,7 +10,11 @@ If your work uses DataJoint or DataJoint Elements, please cite the respective
 
 + Donahue, S., Djuraskovic, I., Shah, K., Sinz, F., Chafetz, R. & Cotton, R. J. (2026). [Calibrated Uncertainty for Trustworthy Clinical Gait Analysis Using Probabilistic Multiview Markerless Motion Capture](https://doi.org/10.48550/arXiv.2601.22412). *arXiv*.
 
++ Evangelou, A., Diamantaki, M., Georgelou, K., Drakaki, Z., Ntanavara, L., Gerardos, G., Morou, S., Chatziris, N., Dogani, Z., Petsalaki, E. A., Raos, O. N., Gratsakis, A., Aliprantis, S., Papoutsi, A. & Froudarakis, E. (2026). [EthoPy provides an accessible platform for reproducible behavioral neuroscience](https://www.cell.com/cell-reports-methods/fulltext/S2667-2375(26)00121-9). *Cell Reports Methods*, 101421.
+
 + Fu, J., Shrinivasan, S., Baroni, L., Ding, Z., Fahey, P. G., Pierzchlewicz, P. A., Karantzas, N., Ponder, K., Froebe, R., Ntanavara, L., Muhammad, T., Willeke, K. F., Wang, E., Ding, Z., Tran, D., Papadopoulos, S., Patel, S., Reimer, J., Ecker, A. S., Pitkow, X., Antolik, J., Sinz, F. H., Haefner, R. M., Tolias, A. S. & Franke, K. (2026). [Statistics of natural scenes shape contextual modulation in the visual cortex](https://doi.org/10.1016/j.neuron.2026.02.022). *Neuron*.
+
++ Guidera, J. A., Gramling, D. P., Comrie, A. E., Joshi, A., Tseng, S.-Y., Denovellis, E. L., Smyth, C. N., Lee, K. H., Zhou, J., Thompson, P., Hernandez, J., Yorita, A., Haque, R., Kirst, C. & Frank, L. M. (2026). [Regional specialization in prefrontal cortex manifests in the reliability of task progression codes](https://www.cell.com/neuron/fulltext/S0896-6273(26)00048-6). *Neuron*, 114, 1152-1161.e8.
 
 + Sun, X., Comrie, A. E., Kahn, A. E., Monroe, E. J., Joshi, A., Guidera, J. A., Denovellis, E. L., Krausz, T. A., Zhou, J., Thompson, P., Hernandez, J., Yorita, A., Haque, R., Berke, J. D., Daw, N. D. & Frank, L. M. (2026). [Meta-learning is expressed through altered prefrontal cortical dynamics](https://doi.org/10.64898/2026.01.01.697272). *bioRxiv*.
 


### PR DESCRIPTION
## Summary

Adds two 2026 publications to `src/about/publications.md`, inserted in alphabetical order in the 2026 section:

- **Evangelou, A. et al. (2026).** [EthoPy provides an accessible platform for reproducible behavioral neuroscience](https://www.cell.com/cell-reports-methods/fulltext/S2667-2375(26)00121-9). *Cell Reports Methods*, 101421.
- **Guidera, J. A. et al. (2026).** [Regional specialization in prefrontal cortex manifests in the reliability of task progression codes](https://www.cell.com/neuron/fulltext/S0896-6273(26)00048-6). *Neuron*, 114, 1152–1161.e8.

Citation metadata (authors, volume, pages) sourced from Crossref via the article PIIs.

## Test plan

- [ ] Render `src/about/publications.md` (e.g. `mkdocs serve`) and confirm both new entries appear under the **2026** heading in alphabetical order between Donahue/Fu and Fu/Sun respectively.
- [ ] Click both links in the rendered page to confirm they resolve to the correct articles.
- [ ] Confirm formatting matches surrounding entries (author list, year in parentheses, italicized journal, page/article number).