### PR TITLE
docs: opaque white background and larger annotations in pipeline.svg

### DIFF
--- a/src/images/pipeline.svg
+++ b/src/images/pipeline.svg
@@ -8,6 +8,10 @@
     </marker>
   </defs>
 
+  <!-- Opaque white background — keeps the whole illustration legible
+       on any page theme (e.g. GitHub dark-mode README rendering). -->
+  <rect width="100%" height="100%" fill="white"/>
+
   <!-- ============ LEFT PANEL: Pipeline diagram ============ -->
 
   <!-- Edges -->
@@ -90,7 +94,7 @@
   </g>
 
   <!-- ============ Annotations ============ -->
-  <g font-style="italic" fill="#5a5a5a" font-size="17">
+  <g font-style="italic" fill="#5a5a5a" font-size="19">
     <text x="1260" y="112">database link</text>
     <line x1="1255" y1="107" x2="690" y2="107"
           stroke="#bbb" stroke-width="0.7" stroke-dasharray="3,3"/>


### PR DESCRIPTION
## Summary

Mirrors the dark-mode fix from [datajoint-python#1448](https://github.com/datajoint/datajoint-python/pull/1448), addressing the same review feedback:

- Add an opaque white `<rect>` covering the full SVG viewBox so the entire illustration (annotations included) reads against white regardless of page theme. Previously the code panel had its own white rect but the surrounding annotations sat on transparent — black text on a black background made them invisible in dark mode.
- Bump annotation font size from 17 to 19 to keep effective rendered text in the 9–11 pt range at typical column widths.

## Test plan

- [ ] `mkdocs serve` and load `/` — confirm the illustration renders correctly.
- [ ] Toggle the docs site to dark mode (if supported) and confirm all five right-side annotations remain legible.
- [ ] Confirm annotation text is comfortably larger than before.