### PR TITLE
docs: extend datajoint.migrate timeline to 2.4 or 2.5

### DIFF
--- a/src/how-to/migrate-to-v20.md
+++ b/src/how-to/migrate-to-v20.md
@@ -7,7 +7,7 @@ Upgrade existing pipelines from legacy DataJoint (pre-2.0) to DataJoint 2.0.
 
 !!! warning "Temporary module"
 
-    The `datajoint.migrate` module is provided temporarily to assist with migration. It will be deprecated in DataJoint 2.1 and removed in 2.2. Complete your migration while on 2.0.
+    The `datajoint.migrate` module is provided temporarily to assist with migration and is scheduled for removal in DataJoint 2.4 or 2.5. We recommend completing your migration while on DataJoint 2.3 or earlier.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

The "Temporary module" warning at the top of [Migrate to DataJoint 2.0](https://docs.datajoint.com/how-to/migrate-to-v20/) was authored before the timeline slipped. It said the `datajoint.migrate` module would be deprecated in 2.1 and removed in 2.2, but the module is still present on master at 2.2.x and 2.3 is about to ship with it intact.

Update to the current plan:

| | Was | Now |
|---|---|---|
| Removal target | 2.2 | **2.4 or 2.5** |
| Safe migration window | while on 2.0 | **while on 2.3 or earlier** |

```diff
-    The `datajoint.migrate` module is provided temporarily to assist with migration. It will be deprecated in DataJoint 2.1 and removed in 2.2. Complete your migration while on 2.0.
+    The `datajoint.migrate` module is provided temporarily to assist with migration and is scheduled for removal in DataJoint 2.4 or 2.5. We recommend completing your migration while on DataJoint 2.3 or earlier.
```

A matching docstring update for `datajoint-python/src/datajoint/migrate.py` (which currently says "deprecated in 2.1 and removed in 2.3. Complete your migrations while on 2.0.") is in a separate PR — keeping the source and docs in lockstep.

## Test plan
- [ ] After deploy, confirm the warning admonition at the top of `/how-to/migrate-to-v20/` reflects the new timeline
- [ ] No other links or anchors changed