### PR TITLE
docs: replace dead /sign-up Platform link with /contact

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -131,7 +131,7 @@ nav:
       - What's New in 2.0: about/whats-new-2.md
       - History: about/history.md
       - Documentation Versioning: about/versioning.md
-      - Platform: https://www.datajoint.com/sign-up
+      - Platform: https://www.datajoint.com/contact
       - Citation: about/citation.md
       - Publications: about/publications.md
       - Contributing: about/contributing.md

--- a/src/how-to/manage-pipeline-project.md
+++ b/src/how-to/manage-pipeline-project.md
@@ -13,7 +13,7 @@ A production DataJoint pipeline typically involves:
 
 This guide covers practical project organization. For conceptual background on pipeline architecture and the DAG structure, see [Data Pipelines](../explanation/data-pipelines.md/).
 
-For a fully managed solution, [request a DataJoint Platform account](https://www.datajoint.com/sign-up).
+For a fully managed solution, [contact us about the DataJoint Platform](https://www.datajoint.com/contact).
 
 ## Project Structure
 
@@ -364,7 +364,7 @@ Managing a team pipeline requires coordinating:
 | **Compute** | Worker deployment, job distribution, resource allocation |
 | **Monitoring** | Progress tracking, error alerting, audit logging |
 
-These challenges grow with team size and pipeline complexity. The [DataJoint Platform](https://www.datajoint.com/sign-up) provides integrated management for all these concerns.
+These challenges grow with team size and pipeline complexity. The [DataJoint Platform](https://www.datajoint.com/contact) provides integrated management for all these concerns.
 
 ## See Also
 


### PR DESCRIPTION
## Summary
- The `https://www.datajoint.com/sign-up` URL is dead. Replace it with `https://www.datajoint.com/contact` in the three places it appears in the docs sources.
- Update the in-body anchor text in `how-to/manage-pipeline-project.md` from "request a DataJoint Platform account" to "contact us about the DataJoint Platform", since `/contact` is a contact page rather than a sign-up flow.
- `src/llms.txt` and `src/llms-full.txt` are generated artifacts (gitignored) and will pick up the new URL on the next build.

## Test plan
- [ ] `grep -rn "datajoint.com/sign-up" src mkdocs.yaml` returns no results
- [ ] Build the docs and confirm the About → Platform nav entry points to `/contact`
- [ ] Confirm `https://www.datajoint.com/contact` loads in a browser