### PR TITLE
docs(#1454): document ~lineage auto-refresh on decoration

### DIFF
--- a/src/explanation/semantic-matching.md
+++ b/src/explanation/semantic-matching.md
@@ -158,6 +158,45 @@ This means you're trying to join tables that have a namesake attribute (`id`) wi
        """
    ```
 
+## The `~lineage` table
+
+Lineage is stored per-schema in a hidden table called `~lineage`. DataJoint writes one row per `(table, attribute)` pair recording the lineage string for that attribute, and consults `~lineage` whenever it needs to compare lineages across query expressions.
+
+`~lineage` is maintained as part of normal table declaration:
+
+- Declaring a new table inserts its lineage rows as the last step of `Table.declare()`.
+- When `@schema(MyTable)` runs on an already-declared table, DataJoint checks the heading's loaded lineage values for the symptom of missing rows — any primary-key attribute with `lineage=None`. The check is in memory, against values already loaded when the heading was constructed, so a healthy schema pays zero additional database queries on re-decoration. If the check fires, DataJoint refreshes the table's `~lineage` rows from the current foreign-key definition. *(New in DataJoint 2.3.)*
+
+This automatic check addresses the load-bearing failure mode: a partial declare or an upgrade that left some rows missing entirely. **It does not auto-heal stale-but-non-None entries** (e.g. older DataJoint versions that wrote lineage strings in a slightly different format). Those still require a manual rebuild — see below.
+
+### Manual lineage rebuild
+
+When the in-memory check is not enough — stale rows that exist but carry the wrong value, schemas whose tables have not been re-decorated under DataJoint 2.3+, or schemas in `create_tables=False` production mode — call `schema.rebuild_lineage()` or the equivalent migration helper:
+
+```python
+import datajoint as dj
+from datajoint import migrate
+
+schema = dj.Schema("my_schema")
+
+# Option 1: instance method
+schema.rebuild_lineage()
+
+# Option 2: migration helper with dry-run preview
+migrate.rebuild_lineage(schema, dry_run=True)   # show what would change
+migrate.rebuild_lineage(schema, dry_run=False)  # apply
+```
+
+This is also the recovery path when a join fails with:
+
+```
+DataJointError: Cannot join on attribute `X`: lineage missing on one side
+(None vs ...). This usually indicates a stale `~lineage` entry from an older
+DataJoint version or an incomplete declare. Run `schema.rebuild_lineage()` ...
+```
+
+`rebuild_lineage()` is safe to run on a healthy schema — it's idempotent and produces the same end state regardless of starting condition.
+
 ## Examples
 
 ### Valid Join (Shared Lineage)

--- a/src/reference/specs/semantic-matching.md
+++ b/src/reference/specs/semantic-matching.md
@@ -65,7 +65,10 @@ class Student(dj.Manual):
 
 ### Rebuilding Lineage for Existing Schemas
 
-If you have existing schemas created before DataJoint 2.0, rebuild their lineage tables:
+!!! version-added "New in 2.3"
+    `@schema` decoration now performs an **in-memory check** for missing `~lineage` rows when a table is already declared. The check inspects the heading's loaded lineage values (no extra DB queries on healthy schemas); if any primary-key attribute has `lineage=None`, the table's rows are refreshed automatically from the current foreign-key definition. This auto-heals the most common failure mode (partial declares, upgrades that left rows missing) without user action. The explicit `rebuild_lineage()` utility remains the path for cases the in-memory check cannot reach (see below).
+
+If your schema has any of the limitations below — or you want to apply a clean reset — rebuild explicitly:
 
 ```python
 import datajoint as dj
@@ -73,13 +76,19 @@ import datajoint as dj
 # Connect and get your schema
 schema = dj.Schema('my_database')
 
-# Rebuild lineage (do this once per schema)
+# Rebuild lineage
 schema.rebuild_lineage()
 
 # Restart Python kernel to pick up changes
 ```
 
 **Important**: If your schema references tables in other schemas, rebuild those upstream schemas first.
+
+**When you still need to call this explicitly:**
+
+- **Stale-but-non-None rows.** The 2.3 in-memory check fires only on missing rows (`lineage=None`). DataJoint versions older than 2.3 that wrote lineage strings in a different format leave non-None rows that look healthy to the check but no longer match what current code computes. Symptom: a join error of the form `different lineages (a.b.c vs a.b.c)` (values look right but compare unequal). Fix: `rebuild_lineage()`.
+- **Production mode (`create_tables=False`).** The auto-heal is suppressed when the schema disallows table creation, to keep production deployments read-only. Migrations to production should rebuild lineage before flipping the flag.
+- **Cross-schema upstream changes.** When an upstream schema's lineage was rebuilt, downstream schemas don't automatically pick up the new strings until they're re-decorated. Running `rebuild_lineage()` on the downstream schema propagates the change.
 
 ---
 


### PR DESCRIPTION
## Summary

Docs companion to [datajoint-python #1467](https://github.com/datajoint/datajoint-python/pull/1467). The python PR adds an **in-memory check** at \`@schema\` decoration time — when an already-declared table's heading shows any PK attribute with \`lineage=None\`, the table's \`~lineage\` rows are auto-refreshed. Healthy schemas pay zero extra DB queries; the refresh only fires when the symptom is in memory.

This PR documents the new behavior and the limitation (stale-but-non-None entries still require manual \`rebuild_lineage()\`). Closes the docs side of datajoint-python #1454.

| File | Change |
|---|---|
| \`src/explanation/semantic-matching.md\` | New \"The \`~lineage\` table\" section: how the table is maintained, the in-memory check on decoration (new in 2.3), the auto-heal scope, and explicit call-out of the stale-but-non-None limitation. Adds the \`dj.migrate.rebuild_lineage(schema, dry_run)\` helper as the alternative path with preview support. |
| \`src/reference/specs/semantic-matching.md\` | \`version-added\` admonition on \"Rebuilding Lineage\" updated to describe the in-memory check (not an unconditional refresh). \"When you still need to call this explicitly\" list reordered to lead with the stale-but-non-None case. |

## Why the lighter approach

The earlier draft of #1467 refreshed lineage on every decoration unconditionally, which would have added per-table DB queries on every schema activation (~50 queries for a 10-table schema). The current implementation guards the refresh on an in-memory check against the heading's already-loaded lineage values — zero extra cost on healthy schemas, auto-heal only when the bug's symptom (None lineage) is present.

The stale-but-non-None case (DJ version skew that wrote lineage in a different string format) is not auto-detected here. Users hit the improved error message in #1467 — \"...Run \`schema.rebuild_lineage()\`...\" — and run the explicit rebuild.

## Sequencing

Reviewable now. Should land **alongside or after** datajoint-python #1467 so the docs don't claim auto-heal before the code ships.

## Test plan

- [ ] \`mkdocs serve\` renders the new section under Concepts → Queries → Semantic Matching
- [ ] Wording stays consistent with the error message added in datajoint-python #1467
- [ ] Limitation call-outs are precise (stale-but-non-None case, production mode, cross-schema upstream)