### PR TITLE
docs(#1445): note single-pass GC concurrency semantics

### DIFF
--- a/src/how-to/garbage-collection.md
+++ b/src/how-to/garbage-collection.md
@@ -16,6 +16,15 @@ remain. This is by design:
 
 Run garbage collection periodically to reclaim storage space.
 
+!!! note "Concurrency semantics"
+    Garbage collection is single-pass and best-effort: it scans references,
+    then deletes objects the scan did not see referenced. If a row is inserted
+    between the scan and the delete, the object it references can be deleted
+    even though it is now in use — leaving the new row with a dangling
+    reference. A future release will add quarantine-based serialization to
+    close this window. Until then, prefer running GC during quiet periods, and
+    treat any single GC pass as best-effort rather than transactionally safe.
+
 ## Basic Usage
 
 ```python


### PR DESCRIPTION
## Summary

T3.1 of the 2.3 release plan defers the two-phase transaction-safe GC (#1445) to 2.4 (effort + design-needed). To avoid retracting stronger claims later, add a one-paragraph note to `how-to/garbage-collection.md` clarifying that the current GC is at-most-once: an object inserted between scan and delete may be briefly orphaned, and a future release will add quarantine-based serialization.

## Test plan
- [ ] `mkdocs serve` — note renders in the how-to and reads cleanly