### PR TITLE
Add Karantzas et al. (2026) eLife publication

### DIFF
--- a/src/about/publications.md
+++ b/src/about/publications.md
@@ -16,6 +16,8 @@ If your work uses DataJoint or DataJoint Elements, please cite the respective
 
 + Guidera, J. A., Gramling, D. P., Comrie, A. E., Joshi, A., Tseng, S.-Y., Denovellis, E. L., Smyth, C. N., Lee, K. H., Zhou, J., Thompson, P., Hernandez, J., Yorita, A., Haque, R., Kirst, C. & Frank, L. M. (2026). [Regional specialization in prefrontal cortex manifests in the reliability of task progression codes](https://doi.org/10.1016/j.neuron.2026.01.023). *Neuron*, 114, 1152-1161.e8.
 
++ Karantzas, N., Franke, K., Willeke, K. F., Diamantaki, M., Ramakrishnan, K., Bedel, H. A., Elumalai, P., Restivo, K., Fahey, P. G., Nealley, C., Shinn, T., Garcia, G., Patel, S., Ecker, A. S., Walker, E. Y., Froudarakis, E., Sanborn, S., Sinz, F. H. & Tolias, A. S. (2026). [Dual-feature selectivity enables bidirectional coding in visual cortical neurons](https://elifesciences.org/reviewed-preprints/109861v2). *eLife*.
+
 + Sun, X., Comrie, A. E., Kahn, A. E., Monroe, E. J., Joshi, A., Guidera, J. A., Denovellis, E. L., Krausz, T. A., Zhou, J., Thompson, P., Hernandez, J., Yorita, A., Haque, R., Berke, J. D., Daw, N. D. & Frank, L. M. (2026). [Meta-learning is expressed through altered prefrontal cortical dynamics](https://doi.org/10.64898/2026.01.01.697272). *bioRxiv*.
 
 + Willeke, K. F., Turishcheva, P., Gilbert, A., Chakrabarty, G., Bedel, H. A., Fahey, P. G., Qiu, Y., Weis, M. A., Vystrčilová, M., Muhammad, T., Ntanavara, L., Froebe, R. E., Ponder, K., Tan, Z. H., Orhan, E., Cobos, E., Sanborn, S., Franke, K., Sinz, F. H., Ecker, A. S. & Tolias, A. S. (2026). [OmniMouse: Scaling properties of multi-modal, multi-task Brain Models on 150B Neural Tokens](https://doi.org/10.48550/arXiv.2604.18827). *arXiv*.


### PR DESCRIPTION
Adds the reviewed preprint *Dual-feature selectivity enables bidirectional coding in visual cortical neurons* (Karantzas et al., eLife, 2026) to the 2026 section of the publications list, in alphabetical order by first author.

Link: https://elifesciences.org/reviewed-preprints/109861v2