### PR TITLE
docs(#1458): fix FloatArrayCodec get_dtype example (`<hash>`, not `<hash@>`)

### DIFF
--- a/src/reference/specs/spark-adapter.md
+++ b/src/reference/specs/spark-adapter.md
@@ -109,7 +109,7 @@ class FloatArrayCodec(dj.Codec):
     name = "float_array"
 
     def get_dtype(self, is_store: bool) -> str:
-        return "longblob" if not is_store else "<hash@>"
+        return "longblob" if not is_store else "<hash>"
 
     def encode(self, value, *, key=None, store_name=None) -> bytes:
         return np.asarray(value, dtype=np.float64).tobytes()


### PR DESCRIPTION
Follow-up to #188.

The `FloatArrayCodec.get_dtype` example in `spark-adapter.md` returned `"<hash@>"` for the store branch. Codecs return the **base** dtype `"<hash>"` — the framework composes the `@` store modifier at declaration time, not the codec. This matches the built-in `BlobCodec.get_dtype`, which returns `"<hash>"`.

```diff
     def get_dtype(self, is_store: bool) -> str:
-        return "longblob" if not is_store else "<hash@>"
+        return "longblob" if not is_store else "<hash>"
```

Flagged by @MilagrosMarin in her review of #188 ("plugin authors copy-pasting the example may see divergent behavior").

Note: the two cosmetic residuals she also noted (stale `renderable.md`/`renderable-codecs.md` filename table and the "stays draft" framing) lived in the #188 PR description, not in the merged files, so nothing to fix in-tree for those.