### PR TITLE
docs(deploy): note set_replica_identity partial-failure semantics

### DIFF
--- a/src/reference/specs/deploy-operations.md
+++ b/src/reference/specs/deploy-operations.md
@@ -68,6 +68,8 @@ Both `default` and `full` produce explicit `ALTER` statements. `default` is **no
 
 The underlying ALTER is metadata-only, instant, and idempotent at the PostgreSQL layer (re-applying the same mode is a no-op at the storage layer).
 
+The operation is **not atomic**: tables are altered one at a time, so if execution raises on table _N_ of _M_, the first _N_−1 ALTERs have already committed and the exception propagates without returning a summary — re-run to converge (each ALTER is idempotent).
+
 ## Design rationale
 
 Three structural decisions distinguish `dj.deploy` from alternatives that were considered and rejected. Each is informed by the failure modes the alternative would have produced.


### PR DESCRIPTION
One-line addition to the `set_replica_identity` spec (`deploy-operations.md`), following the #1466 implementation landing on `datajoint-python` master.

The spec's **Behavior** section documented idempotency but omitted the failure mode: the operation is **not atomic** — tables are altered one at a time, so if execution raises on table _N_ of _M_, the first _N_−1 ALTERs have already committed and the exception propagates without returning a summary. This matches the behavior already documented in `deploy.py`'s docstring; re-running converges since each ALTER is idempotent.

Surfaced during a spec-vs-implementation consistency check of datajoint/datajoint-python#1466.