### PR TITLE
docs(schema-as-workflow): spell out DDL on first use

### DIFF
--- a/src/explanation/schema-as-workflow-specification.md
+++ b/src/explanation/schema-as-workflow-specification.md
@@ -33,7 +33,8 @@ semantics.
 
 A DataJoint schema is declared as a set of table definitions. Each
 table carries a tier — `Manual`, `Lookup`, `Imported`, or `Computed` —
-and a `definition` string that uses a compact DDL. The DDL distinguishes
+and a `definition` string that uses a compact data definition language (DDL).
+The DDL distinguishes
 primary key attributes (above `---`) from secondary attributes (below
 `---`), declares attribute types, and writes foreign keys as
 `-> ReferencedTable`. A faithful excerpt from a calcium-imaging


### PR DESCRIPTION
On [explanation/schema-as-workflow-specification](https://docs.datajoint.com/explanation/schema-as-workflow-specification/), the acronym **DDL** was used without expansion. Spelled it out as "data definition language (DDL)" at the first occurrence; later uses keep the acronym.