### PR TITLE
docs(explanation): add 'Comparison to Provenance Systems'

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -18,6 +18,7 @@ nav:
           - Computation Model: explanation/computation-model.md
           - Schema as a Workflow Specification: explanation/schema-as-workflow-specification.md
           - Comparison to Workflow Languages: explanation/comparison-to-workflow-languages.md
+          - Comparison to Provenance Systems: explanation/comparison-to-provenance-systems.md
       - Queries:
           - Query Algebra: explanation/query-algebra.md
           - Semantic Matching: explanation/semantic-matching.md

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -16,6 +16,7 @@ nav:
           - Entity Integrity: explanation/entity-integrity.md
           - Normalization: explanation/normalization.md
           - Computation Model: explanation/computation-model.md
+          - Fan-Out Ingestion: explanation/fan-out-ingestion.md
           - Schema as a Workflow Specification: explanation/schema-as-workflow-specification.md
           - Comparison to Workflow Languages: explanation/comparison-to-workflow-languages.md
           - Comparison to Provenance Systems: explanation/comparison-to-provenance-systems.md

--- a/src/explanation/comparison-to-provenance-systems.md
+++ b/src/explanation/comparison-to-provenance-systems.md
@@ -40,6 +40,26 @@ Two properties follow:
 This is the same guarantee the reproducibility contract describes: every row is
 traceable to the declared inputs it was computed from.
 
+## What DataJoint leaves to provenance systems
+
+DataJoint tracks how results are *derived within* a pipeline. It does not try to
+own the separate concern of recording **how data first entered** the pipeline
+from outside — the file, instrument, API, or upstream system a value originated
+from, and the operational metadata around that arrival. That origin record is
+captured at the pipeline's entry-point tables: a Manual insert or an Imported
+`make()` records the source identity alongside the data, exactly as at any
+manual data-entry point. A single ingestion step may populate several such
+tables that carry no foreign-key dependency on each other (the *fan-out*
+pattern), each recording its own origin.
+
+Formalizing and standardizing that external-origin record — retention, actors,
+audit trails, cross-system exchange — is the province of dedicated provenance
+and governance systems, and DataJoint stays deliberately neutral there. Many
+pipelines run alongside such a system and let it capture origin provenance in
+its own terms. DataJoint's part is to provide the structural lineage *within*
+the pipeline and a clean surface to interoperate, not to reimplement the
+provenance system.
+
 ## Interoperability and standards
 
 The two approaches are complementary. DataJoint's lineage is internal to the

--- a/src/explanation/comparison-to-provenance-systems.md
+++ b/src/explanation/comparison-to-provenance-systems.md
@@ -3,8 +3,8 @@
 DataJoint is often compared with data-provenance and data-lineage systems,
 since both answer the question *"where did this result come from?"* As with the
 [comparison to workflow languages](comparison-to-workflow-languages.md), the
-point is not which is best: they take different approaches to the same concern,
-and they interoperate rather than compete.
+point is not which is best: they address complementary, largely orthogonal
+concerns and interoperate rather than compete.
 
 ## The landscape
 
@@ -41,33 +41,40 @@ Two properties follow:
 This is the same guarantee the reproducibility contract describes: every row is
 traceable to the declared inputs it was computed from.
 
-## What DataJoint leaves to provenance systems
+## Complementary and orthogonal
 
-DataJoint tracks how results are *derived within* a pipeline. It does not try to
-own the separate concern of recording **how data first entered** the pipeline
-from outside — the file, instrument, API, or upstream system a value originated
-from, and the operational metadata around that arrival. That origin record is
-captured at the pipeline's entry-point tables: a Manual insert or an Imported
-`make()` records the source identity alongside the data, exactly as at any
-manual data-entry point. A single ingestion step may populate several such
-tables that carry no foreign-key dependency on the loader (the
+DataJoint and dedicated provenance systems address **orthogonal concerns**, and
+they **compose**. DataJoint tracks how results are *derived within* a pipeline —
+the structural lineage of the foreign-key graph. A dedicated provenance system
+records and standardizes metadata *about* data, including how it first entered
+from outside — the file, instrument, API, or upstream system a value came from,
+and the operational metadata around that arrival. Neither replaces the other:
+within-pipeline derivation and external-origin provenance are different
+questions, and a complete record often wants both.
+
+Inside DataJoint, the origin of externally-sourced data is recorded at the
+pipeline's entry-point tables — a Manual insert or an Imported `make()` records
+the source identity alongside the data, exactly as at any manual data-entry
+point. A single ingestion step may populate several such tables that carry no
+foreign-key dependency on the loader (the
 [fan-out ingestion pattern](fan-out-ingestion.md)), each recording its own origin.
 
-Formalizing and standardizing that external-origin record — retention, actors,
-audit trails, cross-system exchange — is the province of dedicated provenance
-and governance systems, and DataJoint stays deliberately neutral there. Many
-pipelines run alongside such a system and let it capture origin provenance in
-its own terms. DataJoint's part is to provide the structural lineage *within*
-the pipeline and a clean surface to interoperate, not to reimplement the
-provenance system.
+At the boundary, the two integrate **in both directions** — when explicitly
+configured:
+
+- **Inbound:** provenance records from upstream systems can be *ingested* into
+  the pipeline, so externally-sourced data arrives already carrying its origin.
+- **Outbound:** the pipeline's lineage can be *emitted* to downstream provenance,
+  catalog, and governance systems in their own terms.
+
+This integration is opt-in and configured explicitly; it is not automatic.
 
 ## Interoperability and standards
 
-The two approaches are complementary. DataJoint's lineage is internal to the
-pipeline and expressed in its own schema; for interchange with external
-governance, audit, and cataloging systems that speak industry lineage and
-provenance standards such as OpenLineage or W3C PROV, that lineage can be
-exported. Compliance with
+Interchange in either direction uses the standards the surrounding ecosystem
+speaks. DataJoint's lineage is expressed in its own schema; where it is exchanged
+with external governance, audit, and cataloging systems, it maps to industry
+lineage and provenance standards such as OpenLineage or W3C PROV. Compliance with
 industry provenance standards is ensured by the DataJoint Platform.
 
 ## See also

--- a/src/explanation/comparison-to-provenance-systems.md
+++ b/src/explanation/comparison-to-provenance-systems.md
@@ -49,8 +49,8 @@ from, and the operational metadata around that arrival. That origin record is
 captured at the pipeline's entry-point tables: a Manual insert or an Imported
 `make()` records the source identity alongside the data, exactly as at any
 manual data-entry point. A single ingestion step may populate several such
-tables that carry no foreign-key dependency on each other (the *fan-out*
-pattern), each recording its own origin.
+tables that carry no foreign-key dependency on the loader (the
+[fan-out ingestion pattern](fan-out-ingestion.md)), each recording its own origin.
 
 Formalizing and standardizing that external-origin record — retention, actors,
 audit trails, cross-system exchange — is the province of dedicated provenance
@@ -72,5 +72,6 @@ industry provenance standards is ensured by the DataJoint Platform.
 
 - [Relational Workflow Model](relational-workflow-model.md) — the conceptual basis for treating the schema as the pipeline specification
 - [Entity Integrity](entity-integrity.md) — the referential-integrity guarantees that make lineage structural
-- [Computation Model](computation-model.md) — the `make()` reproducibility contract
+- [Computation Model](computation-model.md) — the `make()` contract and `populate()`
+- [Fan-Out Ingestion](fan-out-ingestion.md) — how one source populates several entry-point tables, and where origin is recorded
 - [Comparison to Workflow Languages](comparison-to-workflow-languages.md) — the companion comparison for pipeline and orchestration tools

--- a/src/explanation/comparison-to-provenance-systems.md
+++ b/src/explanation/comparison-to-provenance-systems.md
@@ -1,0 +1,56 @@
+# Comparison to Provenance Systems
+
+DataJoint is often compared with data-provenance and data-lineage systems,
+since both answer the question *"where did this result come from?"* As with the
+[comparison to workflow languages](comparison-to-workflow-languages.md), the
+point is not which is best: they take different approaches to the same concern,
+and they interoperate rather than compete.
+
+## The landscape
+
+Dedicated provenance systems — the W3C **PROV** standard, OpenLineage, and the
+lineage features built into data catalogs and governance tools — record
+provenance as **metadata *about* data**. Derivation is captured during or after
+execution and stored alongside the data as logs, tags, or sidecar records;
+questions about where a result came from are answered by reading that recorded
+metadata.
+
+## Lineage as a structural property
+
+In the [relational workflow model](relational-workflow-model.md), derivation is
+not a separate record kept about the data — it is a property of the data
+structure itself. Foreign-key dependencies, the table tiers, the
+[`make()` reproducibility contract](../reference/specs/autopopulate.md#43-the-make-reproducibility-contract),
+and [referential integrity](entity-integrity.md) together mean a computed row
+cannot exist unless the upstream rows it derives from are present and valid. The
+dependency graph *is* the lineage: it is declared in the schema, upheld by the
+database, and queryable directly through the same algebra used for data
+(`Diagram.trace`, and `self.upstream` inside `make()`).
+
+Two properties follow:
+
+- **Declared and upheld, not observed after the fact.** Dependencies are
+  declared in the schema before computation and maintained by referential
+  integrity, rather than reconstructed from logs afterward.
+- **Consistent by construction.** Because lineage is structural rather than a
+  parallel record, it cannot drift out of step with the data — deleting an input
+  cascades to the results derived from it, so the graph always reflects the data
+  as it currently is.
+
+This is the same guarantee the reproducibility contract describes: every row is
+traceable to the declared inputs it was computed from.
+
+## Interoperability and standards
+
+The two approaches are complementary. DataJoint's lineage is internal to the
+pipeline and expressed in its own schema; for interchange with external
+governance, audit, and cataloging systems that speak industry provenance
+standards such as W3C PROV, that lineage can be exported. Compliance with
+industry provenance standards is ensured by the DataJoint Platform.
+
+## See also
+
+- [Relational Workflow Model](relational-workflow-model.md) — the conceptual basis for treating the schema as the pipeline specification
+- [Entity Integrity](entity-integrity.md) — the referential-integrity guarantees that make lineage structural
+- [Computation Model](computation-model.md) — the `make()` reproducibility contract
+- [Comparison to Workflow Languages](comparison-to-workflow-languages.md) — the companion comparison for pipeline and orchestration tools

--- a/src/explanation/comparison-to-provenance-systems.md
+++ b/src/explanation/comparison-to-provenance-systems.md
@@ -8,9 +8,10 @@ and they interoperate rather than compete.
 
 ## The landscape
 
-Dedicated provenance systems — the W3C **PROV** standard, OpenLineage, and the
-lineage features built into data catalogs and governance tools — record
-provenance as **metadata *about* data**. Derivation is captured during or after
+Dedicated provenance systems — the W3C **PROV** model, **OpenLineage** (a widely
+adopted open standard for lineage interchange across the data-tooling
+ecosystem), and the lineage features built into data catalogs and governance
+tools — record provenance as **metadata *about* data**. Derivation is captured during or after
 execution and stored alongside the data as logs, tags, or sidecar records;
 questions about where a result came from are answered by reading that recorded
 metadata.
@@ -64,8 +65,9 @@ provenance system.
 
 The two approaches are complementary. DataJoint's lineage is internal to the
 pipeline and expressed in its own schema; for interchange with external
-governance, audit, and cataloging systems that speak industry provenance
-standards such as W3C PROV, that lineage can be exported. Compliance with
+governance, audit, and cataloging systems that speak industry lineage and
+provenance standards such as OpenLineage or W3C PROV, that lineage can be
+exported. Compliance with
 industry provenance standards is ensured by the DataJoint Platform.
 
 ## See also

--- a/src/explanation/comparison-to-workflow-languages.md
+++ b/src/explanation/comparison-to-workflow-languages.md
@@ -126,3 +126,4 @@ structure.
 - [Schema as a Workflow Specification](schema-as-workflow-specification.md) — the formal language properties (grammar, semantics, algebra) that make the schema queryable as a pipeline spec
 - [Computation Model](computation-model.md) — the `make()` contract and `populate()`
 - [Semantic Matching](semantic-matching.md) — lineage-based join resolution that workflow languages cannot express
+- [Comparison to Provenance Systems](comparison-to-provenance-systems.md) — the companion comparison for data-provenance and lineage tools

--- a/src/explanation/fan-out-ingestion.md
+++ b/src/explanation/fan-out-ingestion.md
@@ -1,0 +1,89 @@
+# The Fan-Out Ingestion Pattern
+
+Sometimes a single ingestion step reads one external source and produces rows in
+several tables at once — for example, parsing one acquisition file into
+`Subject`, `Session`, and `Recording` records. This is the **fan-out ingestion**
+pattern. It is a deliberate, sanctioned exception to DataJoint's usual dependency
+structure. This page explains what it steps outside of, and the responsibility it
+carries in return.
+
+## The shape
+
+An ingestion routine — typically an `Imported` table's `make()`, or a manual
+loader — reads one source and inserts into several **entry-point tables**
+(`Manual` or `Imported`) that are *not* foreign-key children of the ingesting
+table:
+
+```python
+@schema
+class RecordingFile(dj.Manual):        # the source record
+    definition = """
+    file_id : uuid
+    ---
+    path    : varchar(255)
+    """
+
+@schema
+class Ingest(dj.Imported):
+    definition = """
+    -> RecordingFile
+    """
+    def make(self, key):
+        meta = parse(RecordingFile & key)
+        # fan out into several entry-point tables that have no FK back to Ingest
+        Subject.insert1({**meta.subject, "source_file": key["file_id"]})
+        Session.insert1({**meta.session, "source_file": key["file_id"]})
+        Recording.insert1({**meta.recording, "source_file": key["file_id"]})
+        self.insert1(key)
+```
+
+## It steps outside direct referential integrity — explicitly
+
+Normally every derived row is a foreign-key child of the rows it came from, so
+the [dependency graph itself is the record](comparison-to-provenance-systems.md)
+of what produced what. In fan-out ingestion, the tables the routine populates
+carry **no foreign key back to the ingesting table**. The link from a `Subject`
+row to the file it was parsed from is therefore *not* established in the schema
+graph — direct referential integrity to the source is deliberately not created.
+
+This is done on purpose, and being explicit is what makes it acceptable. Binding
+these entry-point tables by foreign key to a fast-moving ingestion step would
+marry the stable domain model to changeable infrastructure — every change to how
+data is loaded would become a schema migration, and every row would permanently
+carry whichever loader existed when it was created. The pattern avoids that by
+*declining* the FK on purpose, rather than letting an undeclared dependency slip
+in unnoticed.
+
+## The responsibility it carries: record where the data came from
+
+Because the foreign-key link to the source is absent, the traceability it would
+have provided must be supplied another way. **Each table the pattern populates is
+responsible for recording its own origin** — the source identity the row was
+derived from (file path, checksum, instrument session, operator, timestamp,
+external record id). This is the same responsibility every `Manual` and
+`Imported` entry-point table already carries: data entering the pipeline from
+outside must record where it came from, because the pipeline's own structure
+cannot vouch for it.
+
+Recording that origin at the point of entry is all DataJoint asks. Formalizing
+and standardizing it beyond that — retention, audit trails, cross-system
+exchange — is left to the provenance and governance systems a pipeline
+interoperates with; see [Comparison to Provenance Systems](comparison-to-provenance-systems.md).
+
+## When to use it
+
+- **Use fan-out** when one source legitimately populates several independent
+  entity tables, and making those tables foreign-key children of the loader would
+  distort the domain model or turn every ingestion change into a schema migration.
+- **Prefer ordinary foreign-key dependencies** when the produced rows are genuine
+  derived results *within* the pipeline — there the structural link is exactly
+  what you want, and fan-out would throw away traceability you could have kept.
+
+Reserve fan-out for the ingestion boundary, where the pipeline meets the outside
+world; keep everything downstream of that boundary bound by foreign keys.
+
+## See also
+
+- [Computation Model](computation-model.md) — the `make()` contract and `populate()`
+- [Comparison to Provenance Systems](comparison-to-provenance-systems.md) — the external-origin concern DataJoint leaves to provenance systems
+- [Entity Integrity](entity-integrity.md) — the referential-integrity guarantees fan-out deliberately steps outside


### PR DESCRIPTION
Adds a brief conceptual explainer distinguishing DataJoint from dedicated **provenance systems**, paralleling the existing [Comparison to Workflow Languages](https://docs.datajoint.com/explanation/comparison-to-workflow-languages/).

## What it says
- **Provenance systems** (W3C PROV, OpenLineage, catalog/governance lineage) record provenance as metadata *about* data — captured during/after execution and stored as logs/tags/sidecar records.
- **DataJoint** makes derivation a **structural property** of the schema: foreign-key dependencies + the `make()` reproducibility contract + referential integrity mean a computed row cannot exist without its upstream rows, and the dependency graph itself is queryable **lineage** (`Diagram.trace`, `self.upstream`). Declared-and-upheld rather than observed; consistent by construction (cascade deletes keep it in step).
- The two **interoperate** (lineage can be exported); they do not compete.

## Terminology / scope
- Uses **lineage / reproducibility** for DataJoint's core; reserves **"provenance"** for the industry category (per the framework docs convention).
- Neutral, descriptive framing — no "which is best."
- Deliberately says nothing about *how* the platform handles provenance; the only platform reference is: *compliance with industry provenance standards is ensured by the DataJoint Platform.*

Nav entry + reciprocal See-also link added.