### PR TITLE
docs(backends): state DB version support policy — LTS-targeted, scope out MySQL 9.x

### DIFF
--- a/src/reference/specs/database-backends.md
+++ b/src/reference/specs/database-backends.md
@@ -7,10 +7,23 @@ DataJoint supports multiple database backends through a unified adapter architec
 
 ## Supported Backends
 
-| Backend | Minimum Version | Default Port | Status |
-|---------|-----------------|--------------|--------|
-| MySQL | 8.0.13 | 3306 | Production |
-| PostgreSQL | 15 | 5432 | Production |
+| Backend | Minimum Version | Tested in CI | Default Port | Status |
+|---------|-----------------|--------------|--------------|--------|
+| MySQL | 8.0.13 | 8.0 (8.4 LTS in progress — [datajoint-python#1497](https://github.com/datajoint/datajoint-python/issues/1497)) | 3306 | Production |
+| PostgreSQL | 15 | 15 | 5432 | Production |
+
+### Version support policy
+
+DataJoint targets **long-term-support (LTS) database releases** — the versions offered by managed
+services such as AWS RDS:
+
+- **MySQL** — the **8.0** and **8.4** LTS lines. CI currently exercises 8.0; 8.4 coverage is tracked in
+  [datajoint-python#1497](https://github.com/datajoint/datajoint-python/issues/1497).
+- **PostgreSQL** — **15** and later.
+- **MySQL 9.x is not a supported target.** The 9.x series is a sequence of short-lived *Innovation*
+  releases — there is no 9.x LTS, and it is not offered as a standard managed-service engine. DataJoint
+  may run on it, but it is untested and support is best-effort only.
+- **MariaDB is not officially supported** in DataJoint 2.x; the client emits a warning on connection.
 
 ## Configuration
 

--- a/src/reference/specs/database-backends.md
+++ b/src/reference/specs/database-backends.md
@@ -9,16 +9,17 @@ DataJoint supports multiple database backends through a unified adapter architec
 
 | Backend | Minimum Version | Tested in CI | Default Port | Status |
 |---------|-----------------|--------------|--------------|--------|
-| MySQL | 8.0.13 | 8.0 (8.4 LTS in progress — [datajoint-python#1497](https://github.com/datajoint/datajoint-python/issues/1497)) | 3306 | Production |
+| MySQL | 8.0.13 | 8.0, 8.4 (LTS) | 3306 | Production |
 | PostgreSQL | 15 | 15 | 5432 | Production |
+| MariaDB | — | — | — | **Not supported** |
 
 ### Version support policy
 
 DataJoint targets **long-term-support (LTS) database releases** — the versions offered by managed
 services such as AWS RDS:
 
-- **MySQL** — the **8.0** and **8.4** LTS lines. CI currently exercises 8.0; 8.4 coverage is tracked in
-  [datajoint-python#1497](https://github.com/datajoint/datajoint-python/issues/1497).
+- **MySQL** — the **8.0** and **8.4** LTS lines; CI exercises both (see
+  [datajoint-python#1498](https://github.com/datajoint/datajoint-python/pull/1498)).
 - **PostgreSQL** — **15** and later.
 - **MySQL 9.x is not a supported target.** The 9.x series is a sequence of short-lived *Innovation*
   releases — there is no 9.x LTS, and it is not offered as a standard managed-service engine. DataJoint


### PR DESCRIPTION
Clarifies our database version compatibility claims (prompted by an engineering question about pg 14/15/16/17 and mysql 8.4/9.x).

Adds to `reference/specs/database-backends.md`:
- a **Tested in CI** column (accurate to today: MySQL 8.0, PostgreSQL 15);
- a **Version support policy** section: DataJoint targets **LTS** releases (MySQL 8.0 / 8.4, PostgreSQL 15+) — the versions offered by managed services such as AWS RDS;
- an explicit statement that **MySQL 9.x is not a supported target** (Innovation series, no LTS, not a standard managed-service engine → untested, best-effort);
- a note that **MariaDB is not officially supported** in 2.x.

Deliberately does **not** claim 8.4 is tested yet — that lands with the CI matrix work in datajoint-python#1497, to avoid documenting ahead of the code. Docs-only.