### PR TITLE
docs(delete): note that invalid part_integrity values raise ValueError

### DIFF
--- a/src/reference/specs/data-manipulation.md
+++ b/src/reference/specs/data-manipulation.md
@@ -320,6 +320,8 @@ def delete(
 | `"ignore"` | Allow deleting parts without masters (breaks integrity) |
 | `"cascade"` | Also delete masters when parts are deleted |
 
+Invalid values raise `ValueError`.
+
 **Returns:** Number of deleted rows from the primary table.
 
 ### 4.2 Cascade Behavior
@@ -404,6 +406,8 @@ Session.Recording.delete(part_integrity="cascade")
 | `"enforce"` | (default) Error if parts would be deleted without masters |
 | `"ignore"` | Allow deleting parts without masters (breaks integrity) |
 | `"cascade"` | Also delete masters when parts are deleted (maintains integrity) |
+
+Invalid values raise `ValueError`.
 
 ### 4.7 `delete_quick()` Method
 

--- a/src/reference/specs/master-part.md
+++ b/src/reference/specs/master-part.md
@@ -185,6 +185,8 @@ def delete(self, part_integrity: str = "enforce", ...) -> int
 | `"ignore"` | Allow deleting parts without masters (breaks integrity) |
 | `"cascade"` | Also delete masters when parts are deleted |
 
+Invalid values raise `ValueError`.
+
 ### 4.3 Default Behavior (enforce)
 
 ```python


### PR DESCRIPTION
The invalid-value contract for `part_integrity` — "any value other than `enforce` / `ignore` / `cascade` raises `ValueError`" — was documented only in [`diagram.md:157`](https://github.com/datajoint/datajoint-docs/blob/main/src/reference/specs/diagram.md#L157). Three other spec pages list the three valid values but never mention what happens on an invalid one.

## Changes

- `data-manipulation.md` §4.1 (delete signature): one-line note after the values table.
- `data-manipulation.md` §4.6 (Part.delete): same.
- `master-part.md` §4.2 (Part Integrity Parameter): same.

Note wording mirrors `diagram.md:157` verbatim: *"Invalid values raise `ValueError`."*

Docs-only.