### PR TITLE
docs(provenance): soften 'guarantee' to 'property' for make() contract

### DIFF
--- a/src/explanation/comparison-to-provenance-systems.md
+++ b/src/explanation/comparison-to-provenance-systems.md
@@ -38,7 +38,7 @@ Two properties follow:
   cascades to the results derived from it, so the graph always reflects the data
   as it currently is.
 
-This is the same guarantee the reproducibility contract describes: every row is
+This is the same property the reproducibility contract describes: every row is
 traceable to the declared inputs it was computed from.
 
 ## Complementary and orthogonal


### PR DESCRIPTION
Small terminology tweak in `comparison-to-provenance-systems.md:41`.

The surrounding section — "Lineage as a **structural property**" — argues that lineage is FK-graph-shaped (framework-enforced). The make() reproducibility contract at [`autopopulate.md:322`](https://github.com/datajoint/datajoint-docs/blob/main/src/reference/specs/autopopulate.md#L322), on the other hand, explicitly frames itself as *"a convention — observed by discipline, not enforced."*

Calling both the same "guarantee" in one sentence quietly conflates FK integrity (a real framework guarantee) with the make() contract (an author-observed convention). Swap to "property" — thematically consistent with the section title, no overpromise.