### PR TITLE
docs: fix misleading deprecation example in versioning guide

### DIFF
--- a/src/about/versioning.md
+++ b/src/about/versioning.md
@@ -58,7 +58,7 @@ Version admonitions are used for features introduced **after 2.0** (i.e., versio
 
 !!! version-deprecated "Deprecated in 2.1, removed in 3.0"
 
-    The `allow_direct_insert` parameter is deprecated. Use `dj.config['safemode']` instead.
+    The `old_method()` is deprecated. Use `new_method()` instead.
 
 **Note:** Features deprecated at the 2.0 baseline (coming from pre-2.0) are documented in the [Migration Guide](../how-to/migrate-to-v20.md) rather than with admonitions, since this documentation assumes 2.0 as the baseline.
 


### PR DESCRIPTION
The `version-deprecated` admonition example in `about/versioning.md` claimed `allow_direct_insert` is deprecated in favor of `dj.config['safemode']`. Both claims are incorrect:

- **`allow_direct_insert` is not deprecated** — it is a current `insert()` parameter (`table.py:795`, enforced at `table.py:830`) that guards direct inserts into auto-populated tables outside their `make()` method.
- **`safemode` is unrelated** — it gates the delete/drop confirmation prompt (`table.py:1064`/`1224`), not inserts.

Since this block only illustrates the admonition *style*, replace it with a generic `old_method()`/`new_method()` placeholder so it can't be misread as a factual deprecation claim.