### PR TITLE
docs: instance-based transaction idiom (schema.connection.transaction)

### DIFF
--- a/src/explanation/computation-model.md
+++ b/src/explanation/computation-model.md
@@ -396,7 +396,7 @@ raises an error:
 ```python
 def make(self, key):
     # WRONG — a transaction is already in progress, so this raises an error
-    with dj.conn().transaction:
+    with self.connection.transaction:
         self.insert(compute_multiple_results(key))
 ```
 

--- a/src/how-to/delete-data.md
+++ b/src/how-to/delete-data.md
@@ -87,7 +87,7 @@ Deletes are atomic—all cascading deletes succeed or none do:
 Within an existing transaction:
 
 ```python
-with dj.conn().transaction:
+with schema.connection.transaction:
     (Table1 & key1).delete(transaction=False)
     (Table2 & key2).delete(transaction=False)
     Table3.insert(rows)
@@ -170,7 +170,7 @@ key = {'subject_id': 'M001', 'session_idx': 1}
 (Session & key).delete(prompt=False)
 
 # 2. Reinsert with corrected data
-with dj.conn().transaction:
+with schema.connection.transaction:
     Session.insert1({**key, 'session_date': '2024-01-08', 'duration': 40.0})
     Session.Trial.insert(corrected_trials)
 

--- a/src/how-to/insert-data.md
+++ b/src/how-to/insert-data.md
@@ -60,7 +60,7 @@ Subject.insert(rows, ignore_extra_fields=True)
 Use a transaction to maintain compositional integrity:
 
 ```python
-with dj.conn().transaction:
+with schema.connection.transaction:
     Session.insert1({
         'subject_id': 'M001',
         'session_idx': 1,
@@ -134,7 +134,7 @@ for row in all_rows:
 ### Use transactions for related inserts
 
 ```python
-with dj.conn().transaction:
+with schema.connection.transaction:
     Parent.insert1(parent_row)
     Child.insert(child_rows)
 ```

--- a/src/how-to/manage-large-data.md
+++ b/src/how-to/manage-large-data.md
@@ -83,7 +83,7 @@ Insert large data efficiently:
 
 ```python
 # Good: single transaction for related data
-with dj.conn().transaction:
+with schema.connection.transaction:
     for item in large_batch:
         MyTable.insert1(item)
 ```

--- a/src/how-to/master-part.ipynb
+++ b/src/how-to/master-part.ipynb
@@ -337,7 +337,7 @@
     "Subject.insert1({'subject_id': 'M001', 'species': 'Mus musculus'})\n",
     "\n",
     "# Insert session and trials atomically\n",
-    "with dj.conn().transaction:\n",
+    "with schema.connection.transaction:\n",
     "    Session.insert1({\n",
     "        'subject_id': 'M001',\n",
     "        'session_idx': 1,\n",

--- a/src/reference/specs/autopopulate.md
+++ b/src/reference/specs/autopopulate.md
@@ -555,7 +555,7 @@ def make(self, key):
     data = (Source & key).to_dicts()
 
     # Explicit transaction for insert
-    with dj.conn().transaction:
+    with self.connection.transaction:
         self.insert1({**key, 'result': compute(data)})
         self.Part.insert(parts)
 ```

--- a/src/reference/specs/data-manipulation.md
+++ b/src/reference/specs/data-manipulation.md
@@ -553,7 +553,7 @@ Subject.delete()      # Atomic (by default)
 For multi-table operations:
 
 ```python
-with dj.conn().transaction:
+with schema.connection.transaction:
     Parent.insert1(parent_row)
     Child.insert(child_rows)
     # Commits on successful exit
@@ -629,7 +629,7 @@ Subject.insert(rows)
 ### 9.3 Use Transactions for Related Inserts
 
 ```python
-with dj.conn().transaction:
+with schema.connection.transaction:
     session_key = Session.insert1(session_data, skip_duplicates=True)
     Session.Recording.insert(recordings)
     Session.Stimulus.insert(stimuli)

--- a/src/reference/specs/master-part.md
+++ b/src/reference/specs/master-part.md
@@ -125,7 +125,7 @@ Session.Trial.insert([
 For atomic master+parts insertion, use transactions:
 
 ```python
-with dj.conn().transaction:
+with schema.connection.transaction:
     Session.insert1(master_data)
     Session.Trial.insert(trials_data)
 ```

--- a/src/tutorials/basics/03-data-entry.ipynb
+++ b/src/tutorials/basics/03-data-entry.ipynb
@@ -730,7 +730,7 @@
    ],
    "source": [
     "# Use a transaction to ensure master and parts are inserted atomically\n",
-    "with dj.conn().transaction:\n",
+    "with schema.connection.transaction:\n",
     "    Session.insert1({\n",
     "        'subject_id': 'M001',\n",
     "        'session_idx': 1,\n",
@@ -1136,7 +1136,7 @@
    ],
    "source": [
     "# Add more data for demonstration\n",
-    "with dj.conn().transaction:\n",
+    "with schema.connection.transaction:\n",
     "    Session.insert1({\n",
     "        'subject_id': 'M002',\n",
     "        'session_idx': 1,\n",
@@ -1187,7 +1187,7 @@
    ],
    "source": [
     "# Add a session with trials (using transaction for compositional integrity)\n",
-    "with dj.conn().transaction:\n",
+    "with schema.connection.transaction:\n",
     "    Session.insert1({\n",
     "        'subject_id': 'M003',\n",
     "        'session_idx': 1,\n",
@@ -1260,7 +1260,7 @@
     "(Session & key).delete(prompt=False)\n",
     "\n",
     "# 2. Reinsert with corrected data (using transaction)\n",
-    "with dj.conn().transaction:\n",
+    "with schema.connection.transaction:\n",
     "    Session.insert1({**key, 'session_date': '2026-01-08', 'duration': 40.0})\n",
     "    Session.Trial.insert([\n",
     "        {**key, 'trial_idx': 1, 'outcome': 'hit', 'reaction_time': 0.35},\n",
@@ -1393,7 +1393,7 @@
    ],
    "source": [
     "# Atomic transaction - all inserts succeed or none do\n",
-    "with dj.conn().transaction:\n",
+    "with schema.connection.transaction:\n",
     "    Session.insert1({\n",
     "        'subject_id': 'M007',\n",
     "        'session_idx': 1,\n",
@@ -1435,7 +1435,7 @@
     "\n",
     "```python\n",
     "# Ensures compositional integrity\n",
-    "with dj.conn().transaction:\n",
+    "with schema.connection.transaction:\n",
     "    Session.insert1(session_data)\n",
     "    Session.Trial.insert(trials)\n",
     "```\n",


### PR DESCRIPTION
## What

Global sweep of transaction examples from the global-singleton `dj.conn().transaction` to the **instance-based** form. 17 occurrences across 9 files.

- **Module-level examples → `schema.connection.transaction`** — the `schema` object is defined at module top in every pipeline (the `schema = dj.Schema(...)` / `@schema` convention), so it is in scope, and a transaction usually spans several tables in that schema.
- **In-method examples → `self.connection.transaction`** — where `self` is in scope (`explanation/computation-model.md` WRONG-nesting example; `reference/specs/autopopulate.md`).

## Why

`dj.conn()` returns the singleton `Connection`, and a `Schema` binds every table to that same object (`schemas.py:285` `table._connection = schema.connection`), so at runtime the two are identical **in the default single-connection case**. But `schema.connection.transaction`:

1. names the connection at the natural altitude (the schema owns the tables the transaction spans), rather than through an arbitrary table or a process-global accessor;
2. stays correct in genuinely instance-based setups — if tables live on a non-default connection (a second `dj.Instance`, an explicit `connection=` on the schema), `dj.conn()` returns the *default* singleton, a different object, and would wrap the wrong connection.

## Scope

Mechanical idiom change only. Other `dj.conn()` uses (the accessor itself, `.query(...)`, `.connect()`, thread-safe-mode references) are intentionally left untouched. Notebook edits are text-only (no re-execution). 

Note: the new explanation pages in #226/#227 (`transactions.md`, `master-part.md`, `insert-data.md`, `delete-data.md`) are not on `main` yet, so they are **not** covered here — they still use `dj.conn().transaction` and can be swept once they merge (or in those PRs). A one-line shared-connection caveat belongs on `transactions.md` (in #227); happy to add it there.