### PR TITLE
docs(readme): fix stale citation; note PostgreSQL as a peer backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ MODE="LIVE" docker compose up --build
 # MODE="BUILD" docker compose up --build
 ```
 
-The Docker environment includes MySQL, MinIO, and all dependencies.
+The Docker environment includes MySQL, PostgreSQL, MinIO, and all dependencies.
 
 ### Native Python
 
-**Prerequisites:** Python 3.10+, MySQL 8.0+
+**Prerequisites:** Python 3.10+, and a supported backend — MySQL 8.0+ or PostgreSQL (peer backends)
 
 ```bash
 # Setup
@@ -104,7 +104,7 @@ python scripts/check_notebook_versions.py
 
 ## Citation
 
-> Yatsenko D, Walker EY, Tolias AS. DataJoint: A Simpler Relational Data Model. arXiv:2303.00102. 2023. doi: [10.48550/arXiv.2303.00102](https://doi.org/10.48550/arXiv.2303.00102)
+> Yatsenko D, Nguyen TT. DataJoint 2.0: A Computational Substrate for Agentic Scientific Workflows. arXiv:2602.16585. 2026. doi: [10.48550/arXiv.2602.16585](https://doi.org/10.48550/arXiv.2602.16585) — [RRID:SCR_014543](https://scicrunch.org/resolver/SCR_014543)
 
 Full citation information: [docs.datajoint.com/about/citation/](https://docs.datajoint.com/about/citation/)
 


### PR DESCRIPTION
Two stale items in the top-level `README.md`:

1. **Citation was wrong.** It cited *"DataJoint: A Simpler Relational Data Model. arXiv:2303.00102. 2023"* — an arXiv id that matches nothing in `src/about/citation.md` (the "simpler relational data model" paper is arXiv:1807.11104/2018). Replaced with the **current canonical DataJoint 2.0 citation** the docs designate for 2.0 / the Relational Workflow Model: *Yatsenko D, Nguyen TT. DataJoint 2.0: A Computational Substrate for Agentic Scientific Workflows. arXiv:2602.16585 (2026)*, incl. `RRID:SCR_014543` — matching `about/citation.md`.
2. **PostgreSQL wasn't mentioned.** The compose stack runs a `postgres:15` service with `MODE=EXECUTE_PG`, and PostgreSQL is a peer backend — but the README said "includes MySQL, MinIO" and listed only "MySQL 8.0+". Now notes MySQL **and** PostgreSQL in the Docker environment and native prerequisites.

Everything else referenced in the README was verified current (`pip_requirements.txt`, `scripts/check_notebook_versions.py`, the compose MODE options, Diátaxis links).

Docs-only, top-level README.