### PR TITLE
docs: diagram operations — fold cascade/trace/restrict derivation into the specs (WIP)

### DIFF
--- a/src/explanation/diagram-operations.md
+++ b/src/explanation/diagram-operations.md
@@ -1,0 +1,33 @@
+# Diagram Operations: Cascade, Trace, and Restrict
+
+`dj.Diagram` exposes three operations that traverse the dependency graph —
+`cascade`, `trace`, and `restrict` (with `self.upstream` inside `make()` being a
+form of `trace`). They are usually met one at a time, in separate contexts —
+delete impact, lineage, export — so they can look like three unrelated features.
+
+They are not. All three are **one propagation engine aimed in different
+directions**. Their rules — which convergence each uses (`cascade`/`trace` are
+OR closures; `restrict` is an AND selection), when the engine walks up from a
+part to its master (only when the operation *mutates*), and when a restriction
+must be frozen to literal keys (only when the same operation deletes rows it
+depends on first) — are all *derived* from two things: the operational meaning of
+the master–part relationship, and whether the operation reads or mutates.
+
+That derivation is a low-level design rationale, so it lives with the normative
+specification rather than here, and the implementation is re-derived from it:
+
+- **[Diagram spec → Design Rationale](../reference/specs/diagram.md#design-rationale)**
+  — the full first-principles derivation (one engine, OR-vs-AND, part→master
+  walk, materialization) and its conformance / open items.
+- **[Cascade spec](../reference/specs/cascade.md)** — the normative forward
+  (F1–F3) and upward (U1–U3) propagation rules, `part_integrity` modes, and
+  materialization.
+- **[Upstream Trace spec](../reference/specs/trace.md)** — `Diagram.trace` and
+  `self.upstream`, the `make()` read/write boundary.
+- **[Master-Part spec](../reference/specs/master-part.md)** — structure and the
+  principle that a dependency on a master is a dependency on all of its parts.
+
+For the conceptual grounding this rationale builds on, see
+[Relational Workflow Model](relational-workflow-model.md) (why foreign keys are
+execution order and lineage is structural) and
+[Comparison to Provenance Systems](comparison-to-provenance-systems.md).

--- a/src/reference/specs/diagram.md
+++ b/src/reference/specs/diagram.md
@@ -484,6 +484,122 @@ If visualization dependencies are missing, `dj.Diagram` displays a warning and p
 
 ---
 
+## Design Rationale
+
+`Diagram.cascade`, `Diagram.trace`, and `Diagram.restrict` (with `self.upstream` inside `make()` being a form of `trace`) are usually met one at a time — delete impact, lineage, export — and can look like three unrelated features. They are not: all three are **one propagation engine aimed in different directions**, and their rules — which convergence they use, when they walk up from a part to its master, when a restriction must be frozen to literal keys — are *derived* from two things: the operational meaning of the master–part relationship, and whether the operation reads or mutates. This section records that derivation so the implementation can be re-derived from it. The normative rule tables live in the [Cascade spec](cascade.md) (forward F1–F3, upward U1–U3) and are referenced, not duplicated, here.
+
+!!! note "Lineage here means data lineage"
+    Throughout, *lineage* refers to the derivation of rows through the pipeline (what `trace` recovers), as in [Comparison to Provenance Systems](../../explanation/comparison-to-provenance-systems.md). This is distinct from the *attribute lineage* used by [Semantic Matching](../../explanation/semantic-matching.md) to trace a column to its defining table.
+
+### First principle: the master–part relationship
+
+A part table declares `-> master` in its primary key, so a part row's key is the master's key plus additional attributes. A part row is therefore a *refinement* of a master row's identity, and — by the foreign key's `ON DELETE RESTRICT` — a part row cannot exist without its master row. The [Master-Part spec](master-part.md) states this as **existence, cohesion, and atomicity**.
+
+The consequence the rest of this rationale rests on is:
+
+> **A dependency on a master is a dependency on all of its parts.** The master and its parts are declared and populated as one atomic unit (a single `make()` writes the master row and its part rows in one transaction), so referencing a master presupposes its whole part-group. Symmetrically, a part implies its master (the foreign key).
+
+This forces a distinction between two integrity notions that are easy to conflate:
+
+| Integrity | Guarantee | Scope |
+|---|---|---|
+| **Referential** | Every foreign key resolves to an existing parent row. | Local, pairwise (one edge). |
+| **Compositional** | A master together with **all** of its parts forms one entity. | Global to the unit. |
+
+Referential integrity is necessary but **not sufficient** for compositional integrity. A master row that has lost one of its parts, or survives with none, can still satisfy every foreign key yet no longer represent a valid entity — a recording missing some of its channels. That gap is exactly where the open items below live.
+
+!!! note "Compositional nesting is one level by declaration"
+    A part table is not declared *inside* another part table, so the master→parts grouping is one level deep as declared. Foreign-key *chains* that pass through a part table (a part referenced as a parent by a further table) still exist in the graph and are walked as ordinary edges — the "Part-of-Part chain" the [Cascade](cascade.md) and [Trace](trace.md) specs handle — not a contradiction of the one-level declaration rule.
+
+### The three operations are one engine
+
+Each operation starts from a **seed** (a restricted table expression), propagates a set-membership predicate along foreign-key edges of the dependency DAG, and then either returns the trimmed diagram (`trace`, `restrict`) or drives deletes (`cascade`). They differ along exactly three axes:
+
+| Operation | Direction | Convergence | Reads or mutates | Question it answers |
+|---|---|---|---|---|
+| `cascade` | downstream (descendants) | **OR** | drives `delete` | "What is affected if these rows are deleted?" |
+| `trace` | upstream (ancestors) | **OR** | read-only | "What contributed to these rows?" |
+| `restrict` | downstream (descendants) | **AND** | read-only | "What subset satisfies all of these conditions?" |
+| `self.upstream` | upstream | OR | read-only | *is* `trace(self & key)` inside `make()` |
+
+Everything else follows from these axes.
+
+#### Why OR for cascade and trace, AND for restrict
+
+The convergence is fixed by whether the operation computes a **closure** or a **selection**.
+
+- `cascade` and `trace` compute *inclusion closures*. Delete-impact must miss nothing: a row is affected if **any** restricted ancestor taints it. Lineage must miss nothing: an ancestor contributed if it lies on **any** foreign-key path. A closure that must be complete is a **union → OR**.
+- `restrict` computes a *selection*: "narrow this diagram to the rows meeting every stated condition," so a row survives only if it satisfies **all** conditions reaching it. A selection is an **intersection → AND**.
+
+Making `cascade` conjunctive would let it miss affected rows; making `restrict` disjunctive would return a union no one asked for.
+
+#### Why cascade/trace trim the diagram but restrict preserves it
+
+`cascade` and `trace` *are* their reachable sets — the trimmed subgraph (seed + descendants, or seed + ancestors) is the answer. `restrict` instead *narrows an existing diagram* and is **chainable**: you can `restrict` again from a different seed to build a multi-condition subset, so it must keep the full graph. This is why `restrict` and `cascade` are **mutually exclusive on one diagram** — OR-convergence and AND-convergence cannot coexist in a single propagation without an ill-defined meaning at a node reached by both.
+
+### Derived rule 1 — propagation across an edge
+
+Across one foreign-key edge `parent → child`, the child inherits the parent's restriction *mapped through the foreign key*. The three concrete forms are the forward rules **F1–F3** (and their upstream duals **U1–U3**); see the [Cascade spec](cascade.md). The **master → part edge is just a downstream foreign key** whose parent (master) primary key is a subset of the child (part) primary key — rule F1, a direct copy. This is the mechanism behind the first principle: restricting or including a master automatically restricts/includes **every** part row whose master key matches. No special master-part logic is needed on the way *down*.
+
+### Derived rule 2 — when to walk up from part to master
+
+Part → master is an **upstream** step. A purely downstream operation never traverses it, so we ask, per operation, whether it needs to:
+
+- **Read-only downstream flow (`restrict`, cascade *preview*).** Propagation visits nodes in topological order, so a master is reached **before** its parts and its whole part-group is included by rule 1. Nothing is mutated. **No upward walk is required.**
+- **Mutating downstream flow (`cascade` *delete*).** Deletion runs in **reverse** topological order (leaves first), so parts are deleted **before** their master. Deleting part rows without deleting their master — and its sibling parts — would leave a compositionally broken unit. The engine must walk **up** from each restricted part to its master, then re-propagate that master restriction **down** to all siblings. This is the sole place a downstream operation walks upward, enabled by `part_integrity="cascade"`; the `"enforce"` (post-hoc check) and `"ignore"` alternatives are in the [Cascade spec](cascade.md).
+
+The asymmetry is the point: **`restrict` needs no part→master walk because it does not mutate; `cascade` delete needs one because it does.**
+
+### Derived rule 3 — when a restriction must be materialized
+
+A restriction defines a set of rows *relative to a database state*:
+
+> A restriction may remain lazy if evaluated against a **stable** state. It must be **materialized** — frozen to literal primary-key values — if the **same operation** will delete rows it depends on **before** it is evaluated.
+
+Read-only operations (`trace`, `restrict`, cascade preview/`counts`) see a stable state, so restrictions stay lazy. For `cascade` delete (reverse-topological order):
+
+- A restriction referencing an **ancestor** (deleted *later*) is still valid live → **no materialization**.
+- A restriction referencing a **descendant** (deleted *earlier*) goes stale → **must be materialized** first.
+
+Two restrictions reference a descendant and must be materialized: (1) the engine-created part → master inversion (rule 2 — the master's keys are frozen at plan time, while the part still exists); and (2) a user-supplied seed that semijoins a descendant, e.g. `(Session & (Analysis & 'flag="bad"')).delete()`, where `Analysis` is deleted first and the live subquery would empty.
+
+!!! warning "MySQL error 1093 is a symptom, not the reason"
+    On MySQL the self-referential sub-case trips error 1093 ("can't reference the target table in a subquery"), but that is incidental. The requirement is backend-independent: PostgreSQL permits the self-referential DELETE and strands the row **silently**. Materialization must **never** be made conditional on the backend.
+
+### Composability
+
+- **`restrict ∘ restrict`** accumulates with AND, chainable from different seeds; the intersection is order-independent.
+- **`cascade` and `trace`** are closure operations — monotone and idempotent: re-applying adds nothing.
+- **`cascade` and `restrict` do not compose** on one diagram (incompatible convergence).
+- **`trace` is the upstream dual of `cascade`**, and **`self.upstream` is `trace(self & key)`** — the read channel the framework builds inside each `make()`.
+
+### Conformance and open items
+
+The implementation (`datajoint-python`, `src/datajoint/diagram.py`; the dependency graph is an `nx.MultiDiGraph` as of the 2.4 line) conforms to this derivation except on three points, each an open design question with a filed issue — the places where **referential integrity holds but compositional integrity is not yet guaranteed**.
+
+**Conforms:**
+
+| Derived rule | Status in the implementation |
+|---|---|
+| cascade = downstream, OR | ✅ seed + all descendants; OR store (`_cascade_restrictions`) |
+| trace = upstream, OR | ✅ seed + all ancestors; separate upstream walk, OR |
+| restrict = downstream, AND | ✅ AND store (`_restrict_conditions`); chainable |
+| master→part pulls the whole group (rule 1, F1) | ✅ ordinary downstream edge |
+| part→master walk only for mutating cascade (rule 2) | ✅ gated on `part_integrity="cascade"` **and** cascade mode |
+| engine materializes the master inversion before delete (rule 3) | ✅ master keys frozen at plan time, on every backend |
+| cascade ⊕ restrict mutually exclusive | ✅ enforced |
+| read-only ops stay lazy | ✅ trace/restrict/preview do not materialize |
+
+**Open — not yet meeting the derivation:**
+
+- **Seed restriction referencing a descendant is not materialized** ([#1496](https://github.com/datajoint/datajoint-python/issues/1496)). Rule 3 requires materializing (or uniformly refusing) the seed case above. Today the seed stays a live subquery: MySQL fails closed (error 1093), while PostgreSQL can **silently strand** the seed row. The 2.4 direction is to materialize any restriction referencing an earlier-deleted table; a safe minimum is a legible guard with guidance to pre-materialize (`keys = (A & (B & cond)).fetch("KEY"); (A & keys).delete()`).
+- **`restrict` can produce partial part-groups** ([#1501](https://github.com/datajoint/datajoint-python/issues/1501)). Because `restrict` never lifts a part condition to its master, a chain like `Diagram(s).restrict(Master & 'm=1').restrict(Master.Part & 'p>3')` keeps the master whole but only a subset of its parts — referential integrity intact, **compositional integrity broken**. The read-only analogue of cascade's delete-atomicity: a condition on a part should lift **existentially** to its master and bring in **all** of that master's parts. Deferred to 2.4; blast radius is small (`Diagram.restrict` has no internal callers).
+- **`trace` does not descend from an ancestor master into its parts** ([#1481](https://github.com/datajoint/datajoint-python/issues/1481)). The first principle says a dependency on a master is a dependency on all its parts, so `trace`/`self.upstream` arguably should surface an ancestor master's parts. Today `trace` includes such a part only when it is *itself* on a foreign-key path to the seed (see the [Trace spec](trace.md)). This is a deliberate current contract — a test pins the non-descending behavior — with the fuller capability tracked for a later release.
+
+All three share a root: they are the points where referential integrity holds but compositional integrity is not yet guaranteed. The derivation predicts exactly these as the places the operators need to grow.
+
+---
+
 ## See Also
 
 - [How to Read Diagrams](../../how-to/read-diagrams.ipynb)

--- a/src/reference/specs/master-part.md
+++ b/src/reference/specs/master-part.md
@@ -84,7 +84,7 @@ Master-Part relationships enforce **compositional integrity**:
 1. **Existence**: Parts cannot exist without their master
 2. **Cohesion**: Parts should be deleted/dropped with their master
 3. **Atomicity**: Master and parts form a logical unit
-4. **Transitive completeness**: a dependency on the master is a dependency on all of its parts
+4. **Transitive completeness**: a foreign key to the master is, in effect, a dependency on the entire composite — the master *and* all of its parts
 
 For Computed and Imported tables, a master and its parts are inserted
 atomically: `populate()` wraps each `make()` call in a transaction, so the
@@ -94,11 +94,13 @@ guarantee — insert the master and its parts within a single transaction
 (`with schema.connection.transaction:`) to preserve it. Deletion cascades in either
 case: deleting a master also deletes its parts.
 
-Because a populated master therefore reaches a complete composite, downstream
-tables *typically* reference the master alone and rely on the whole composite
-being present. A foreign key to a specific part is still legal — and common in
-practice — but is often unnecessary when the composite as a whole is what
-matters.
+Because `populate()` fills a master and all of its parts atomically, a master row
+always stands for a complete composite. A downstream table therefore references **the
+master alone**: declaring a foreign key to a master effectively declares a dependency
+on all of its parts as well — the master reference binds the dependent to the whole
+composite. Parts need not, and generally should not, be referenced individually. (A
+foreign key to a specific part remains legal for the rare case where a dependent
+genuinely needs just one part.)
 
 ### 2.2 Foreign Key Behavior
 
@@ -177,9 +179,19 @@ class ProcessedSession(dj.Computed):
 
 ## 4. Delete Operations
 
+Deletion is executed by the cascade engine. `Table.delete()` runs a cascade that
+propagates the restriction from the seed table **downstream** across every foreign-key
+edge, so the delete reaches a master and all of its dependents — its parts included —
+consistently. The same propagation without mutation is previewed via
+`Diagram.cascade(table_expr, part_integrity=...).counts()`. Because a part holds a
+foreign key to its master, the master → part edge is an ordinary downstream edge, so
+deleting a master reaches its parts through normal forward propagation. See the
+[Cascade Specification](cascade.md) for the full propagation rules and the role of
+`part_integrity`.
+
 ### 4.1 Cascade from Master
 
-Deleting from master cascades to parts:
+Deleting from master cascades to parts (forward propagation along the master → part edge):
 
 ```python
 # Deletes session AND all its trials
@@ -218,6 +230,7 @@ Session.Trial.delete()
 ```
 
 **Use cases:**
+
 - Removing specific invalid trials
 - Partial data cleanup
 - Testing/debugging
@@ -231,9 +244,9 @@ Session.Trial.delete()
 (Session.Trial & condition).delete(part_integrity="cascade")
 ```
 
-**Behavior:** The restriction propagates **upward** from the part to its master. Specifically, the restricted part rows identify which master rows are affected, and those masters receive a restriction. The master restriction then propagates back **downstream** through the normal cascade, reaching all sibling parts. The result is that the entire compositional unit — master plus all its parts — is deleted, not just the originally restricted part rows.
+**Behavior:** `part_integrity="cascade"` enables **upward propagation** in the cascade engine. When `Diagram.cascade` reaches (or starts at) a part, it walks the foreign-key chain up to the master — applying the upward rules (U1–U3) — materializes the master's affected rows, then forward-cascades from the master back **downstream** to **all** of its parts. The entire compositional unit — master plus all its parts — is deleted, not just the originally restricted part rows.
 
-This upward propagation may trigger further rounds: if the master itself is a part of a higher-level master, the restriction continues upward. The cascade engine iterates until no new restrictions are produced.
+The upward walk may trigger further rounds: if the master is itself a part of a higher-level master, propagation continues upward, and the engine iterates until no new master is pulled in. See [Part-to-Master upward propagation](cascade.md#part-to-master-upward-propagation) for the details.
 
 ### 4.6 Behavior Matrix
 
@@ -325,6 +338,7 @@ Session.aggr(
 ### 7.1 When to Use Part Tables
 
 **Good use cases:**
+
 - Trials within sessions
 - Electrodes within probes
 - Cells within imaging fields
@@ -332,6 +346,7 @@ Session.aggr(
 - Rows within files
 
 **Avoid when:**
+
 - Parts have independent meaning (use regular FK instead)
 - Need to query parts without master context
 - Parts reference multiple masters


### PR DESCRIPTION
**Status: WIP / draft.**

Reorganizes the diagram-operations documentation on one principle: low-level technical definitions belong in the **specs** (with implementation re-derived from the spec), and **explanation** stays conceptual.

## Changes
- **`reference/specs/master-part.md`** — sharpen the transitive-dependency definition (a foreign key to a master is, in effect, a dependency on the whole composite — master + all parts; downstream tables reference the master alone). Express the Delete Operations rules through the cascade engine (`Diagram.cascade`: master→part is an ordinary downstream edge; `part_integrity="cascade"` = upward U1–U3 walk + materialize + forward re-cascade), cross-linking `cascade.md`. Fix §7.1/§4.4 bold-label list rendering.
- **`reference/specs/diagram.md`** — new **Design Rationale** section: the first-principles derivation that `cascade`/`trace`/`restrict` are one propagation engine (OR-vs-AND, part→master walk only when mutating, materialization), plus **Conformance and open items** (#1496 / #1501 / #1481). Moved here from the explanation doc so the design lives with the normative spec.
- **`explanation/diagram-operations.md`** — reduced to a short conceptual pointer that redirects to the Diagram spec's Design Rationale and the cascade/trace/master-part specs.

## Still to do (WIP)
- `mkdocs.yaml` nav entry for the reduced explanation pointer is **not** in this PR yet.
- `cascade.md` still describes the dependency graph as `networkx.DiGraph`; should read `nx.MultiDiGraph` (2.4 line) to match the derivation.
- Final review of the open-item framing (#1496 / #1501 / #1481).