### PR TITLE
docs: state platform support (Linux/macOS/Windows)

### DIFF
--- a/src/how-to/installation.md
+++ b/src/how-to/installation.md
@@ -93,6 +93,15 @@ See [Configure Database Connection](configure-database.md) for connection setup.
 - Python 3.10+
 - MySQL 8.0.13+ or PostgreSQL 15+
 - Network access to database server
+- Linux, macOS, or Windows (see [Platform support](#platform-support))
+
+## Platform support
+
+DataJoint runs on **Linux, macOS, and Windows**.
+
+- CI validates the **full test suite — including database integration** — on Linux, across both ends of the supported Python range (3.10 and 3.14).
+- The **unit-test suite additionally runs on Windows** (Python 3.10 and 3.14). This covers OS-specific behavior — notably filesystem path handling for file-protocol object stores and garbage collection, where native path separators must not leak into store paths.
+- macOS is a supported development platform.
 
 ## Troubleshooting
 


### PR DESCRIPTION
> ⚠️ **Do not merge until datajoint-python #1521 and #1522 land.** This documents Windows as a CI-backed supported platform; the claim about the Windows unit-test leg is only accurate once #1522 (the `unit-tests-windows` job) merges, and the underlying file-path fix is #1521.

Records the decision to keep **Windows a supported platform** for DataJoint — including file-protocol object stores and garbage collection — backed by CI, rather than documenting it as unsupported. Consistent with the existing "supported == what we test in CI" framing (the DB version-support policy in `database-backends.md`, from #1497).

## Change

Adds a **Platform support** section to `how-to/installation.md` (plus a Requirements line), stating what CI validates on each OS:
- Full suite incl. DB integration on Linux (Python 3.10 & 3.14).
- Unit suite additionally on Windows (Python 3.10 & 3.14) — covering file-protocol path handling and garbage collection (the class of bug in datajoint-python #1520).
- macOS as a supported development platform.

Wording is deliberately precise about *what runs where* so it doesn't overclaim (Windows runs the unit suite, not the DB-backed integration tests).

## Related
- datajoint-python #1520 (bug), #1521 (fix), #1522 (Windows CI leg).