### PR TITLE
Define the term as 'schema dimension' (shortened to 'dimension')

### DIFF
--- a/src/explanation/entity-integrity.md
+++ b/src/explanation/entity-integrity.md
@@ -213,7 +213,8 @@ in a single statement.
 
 ## Schema dimensions
 
-A **dimension** is an independent axis of variation in the data. The rule:
+A **schema dimension** — often shortened to *dimension* — is an independent axis of
+variation in the data. The rule:
 
 > **Any table that introduces a new primary-key attribute introduces a new
 > dimension.**

--- a/src/how-to/read-diagrams.ipynb
+++ b/src/how-to/read-diagrams.ipynb
@@ -389,20 +389,7 @@
    "cell_type": "markdown",
    "id": "cell-dim-md",
    "metadata": {},
-   "source": [
-    "## Dimensions and Underlined Names\n",
-    "\n",
-    "A **dimension** is a new entity type introduced by a table that defines new primary key attributes. Each underlined table introduces exactly **one** dimension—even if it has multiple new PK attributes, together they identify one new entity type.\n",
-    "\n",
-    "| Visual | Meaning |\n",
-    "|--------|--------|\n",
-    "| **Underlined** | Introduces a new dimension (new entity type) |\n",
-    "| Not underlined | Exists in the space defined by dimensions from referenced tables |\n",
-    "\n",
-    "**Key rules:**\n",
-    "- Computed tables **never** introduce dimensions (always non-underlined)\n",
-    "- Part tables **can** introduce dimensions (may be underlined)"
-   ]
+   "source": "## Dimensions and Underlined Names\n\nA **schema dimension** (often shortened to *dimension*) is a new entity type introduced by a table that defines new primary key attributes. Each underlined table introduces exactly **one** dimension—even if it has multiple new PK attributes, together they identify one new entity type.\n\n| Visual | Meaning |\n|--------|--------|\n| **Underlined** | Introduces a new dimension (new entity type) |\n| Not underlined | Exists in the space defined by dimensions from referenced tables |\n\n**Key rules:**\n- Computed tables **never** introduce dimensions (always non-underlined)\n- Part tables **can** introduce dimensions (may be underlined)"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Promotes **schema dimension** to the *defined* term, then shortens to *dimension* in-context.

## Why
`dimension` is overloaded — data-warehouse *dimension tables*, OLAP cubes, and *array/tensor dimensions* (the type-system and npy pages already use "dimension" for array axes). Qualifying it as **schema dimension** on definition disambiguates cleanly. This isn't a new coinage: the Entity Integrity page **already** titles the section `## Schema dimensions` and says "lineage through schema dimensions" — this just makes the *defined term* consistent with that.

## Changes (definitional homes only)
- **Entity Integrity → §Schema dimensions:** `A **dimension** is…` → `A **schema dimension** — often shortened to *dimension* — is…`
- **Read Diagrams → §Dimensions and Underlined Names:** the same promotion on the definition sentence.
- Everything else keeps the short form **dimension** (define once, shorten in-context) — so **all headings and anchors are unchanged**.

## Notes
- Overlaps only lightly with the WIP diagram PR #234 (scoped to diagram *operations* — cascade/trace); different sections, low conflict.
- `llms-full.txt` regenerates from source (not hand-edited here).
- The Read Diagrams cell `source` was normalized to a single JSON string by the notebook editor (valid nbformat, identical rendering).