### PR TITLE
docs: name a table's grain (level of detail) alongside schema dimension

### DIFF
--- a/src/explanation/entity-integrity.md
+++ b/src/explanation/entity-integrity.md
@@ -223,6 +223,30 @@ The rule applies whether the table has only new attributes or also inherits
 attributes through foreign keys. A new primary-key attribute means a new
 dimension.
 
+### Grain
+
+A dimension is a *single* axis of variation; a table's **grain** is the *whole
+combination* of axes at which each row is recorded or computed — its full primary
+key. Grain is the answer to this guide's leading question, *"what is one row of
+this table?"*
+
+> **The grain of a table is the level of detail at which its data is recorded or
+> computed: what one row represents, given by the combination of dimensions in its
+> primary key.**
+
+- `Session`, keyed `(subject_id, session_idx)`, has grain **(subject × session)** —
+  one row per session of a subject.
+- Adding a dimension makes the grain **finer**: a part table that adds `blob_idx`
+  (`Detection.Blob` below) has grain **(… × blob)** — one row per blob of a
+  detection.
+- A computed table's grain is the combination of dimensions at which its `make()`
+  produces rows — its
+  [`key_source`](../reference/specs/autopopulate.md). *A computation operates at
+  its grain.*
+
+"Grain" is the established term in dimensional modeling for what a single row
+represents; DataJoint generalizes it from recorded fact rows to *computed* rows.
+
 ### Tables that introduce dimensions
 
 ```python

--- a/src/reference/specs/autopopulate.md
+++ b/src/reference/specs/autopopulate.md
@@ -82,6 +82,8 @@ class Analysis(dj.Computed):
 
 The `key_source` property defines which entries should exist in the table—the complete set of primary keys that `make()` should be called with.
 
+This set is the table's **grain**—the combination of dimensions at which the computation is done. `make()` runs once per key, so a computed table operates at the grain of its `key_source`.
+
 ### 2.2 Automatic Key Source
 
 By default, DataJoint automatically calculates `key_source` as the join of all tables referenced by foreign keys in the primary key:

--- a/src/reference/specs/query-algebra.md
+++ b/src/reference/specs/query-algebra.md
@@ -407,6 +407,8 @@ result = A.aggr(B, ..., exclude_nonmatching=True) # Only rows with matches
 
 **B must contain all primary key attributes of A.** This enables grouping B's rows by A's primary key.
 
+Geometrically, aggregation **reduces the grain**: it projects the finer grain of `B` onto the coarser grain of `A` it contains, folding each group of B-rows into summary values. Requiring `B` to contain all of A's primary key is exactly what makes every B-row fall into one A-group. Note that `.proj` does *not* reduce the grain—it always retains the primary key (§3.2)—so aggregation, not projection, is the grain-reducing operator.
+
 ### 5.4 Aggregate Functions
 
 ```python


### PR DESCRIPTION
Adopts **grain** as the word for a table's overall level of detail — *what one row represents*, i.e. its full primary key, the combination of schema dimensions. The docs already name the single *axis* ("schema dimension"); this names the *combination*, which today gets described the long way each time. Purely additive vocabulary — no change to behavior, the type system, or any existing term.

## Changes

- **`explanation/entity-integrity.md`** — new **Grain** subsection right after the dimension definition: dimension = one axis; grain = the whole combination (full primary key) = the answer to "what is one row of this table?". Includes the `Session` → (subject × session) and `Detection.Blob` → (… × blob) examples and the dimensional-modeling (Kimball) precedent.
- **`reference/specs/autopopulate.md` §2.1** — one line: a computed table's grain is its `key_source`; `make()` runs once per key, so a computation operates at its grain.
- **`reference/specs/query-algebra.md` §5.3** — a brief geometric note: `.aggr` reduces the grain (projects the finer grain of `B` onto the coarser grain of `A` it contains — why "B must contain all primary key attributes of A"); `.proj` retains the primary key, so aggregation, not projection, is the grain-reducing operator.

Closes #240