### PR TITLE
docs(#1512): specify FK-column indexing on PostgreSQL

### DIFF
--- a/src/explanation/referential-integrity.md
+++ b/src/explanation/referential-integrity.md
@@ -105,13 +105,16 @@ quietly rewritten.
 
 ### 5. Indexing the foreign-key columns
 
-On MySQL/InnoDB the engine automatically creates a secondary index on the
-child's foreign-key columns as part of enforcing the constraint — you never
+The child's foreign-key columns are always indexed, on both backends — you never
 declare it. Such an index accelerates the delete check (finding a parent's
 children), the join (matching child keys to parent keys), and the insert check
-(confirming the parent exists). PostgreSQL does *not* index foreign-key columns
-automatically; when the delete or join cost on a large child table matters,
-declare an explicit `index(...)` on those columns.
+(confirming the parent exists). On MySQL/InnoDB the engine creates the index
+implicitly as part of enforcing the constraint. PostgreSQL does *not* index
+foreign-key columns automatically, so DataJoint emits the index itself — skipping
+it only when those columns are already covered (a left-prefix of the primary key
+or of a declared index). Either way, the mental model holds: the database indexes
+foreign-key columns. See the
+[table-declaration spec](../reference/specs/table-declaration.md#26-foreign-key-indexes).
 
 ## The dual role: integrity and workflow
 

--- a/src/reference/specs/database-backends.md
+++ b/src/reference/specs/database-backends.md
@@ -90,6 +90,11 @@ The following features work identically across all backends:
 | JSON operators | `->`, `->>` | `->`, `->>` |
 | BLOB storage | `LONGBLOB` | `BYTEA` |
 | Boolean type | `TINYINT(1)` | `BOOLEAN` |
+| Foreign-key column index | Implicit (InnoDB) | Emitted by DataJoint (coverage-aware) |
+
+DataJoint guarantees foreign-key columns are indexed on both backends; the
+difference above is only *who* creates the index. See
+[Foreign-Key Indexes](table-declaration.md#26-foreign-key-indexes).
 
 ### String Quoting
 

--- a/src/reference/specs/table-declaration.md
+++ b/src/reference/specs/table-declaration.md
@@ -130,6 +130,26 @@ Internally, singleton tables use a hidden `_singleton` attribute of type `bool` 
 - Excluded from `fetch()` results
 - Excluded from join matching
 
+### 2.6 Foreign-Key Indexes
+
+DataJoint guarantees that a foreign key's referencing (child) columns are
+indexed, so foreign-key joins, cascade deletes, and the parent-existence check
+are index-supported on every backend.
+
+- On **MySQL/InnoDB** the index is created implicitly as part of enforcing the
+  constraint; DataJoint declares nothing.
+- On **PostgreSQL**, which does not index foreign-key columns automatically,
+  DataJoint emits the index itself.
+
+The emitted index is **coverage-aware**: it is skipped when the foreign-key
+columns are already a left-prefix of an existing index — the table's primary key,
+a declared `index(...)`/`unique index(...)`, or a wider foreign-key index — since
+that index already serves the lookups. So a *leading* primary foreign key adds no
+index, while a *secondary* foreign key or one in a *non-leading* position of a
+composite primary key gets its own. A `unique` foreign key always carries its
+`UNIQUE INDEX` on both backends. (Index lifecycle on foreign-key drop / `alter()`
+is out of scope of declaration; see the schema-changes specification.)
+
 ---
 
 ## 3. Attribute Definition


### PR DESCRIPTION
Documents the behavior added in datajoint/datajoint-python#1526 (closes #1512), and flips the now-obsolete guidance from #227.

## Changes

- **`reference/specs/table-declaration.md` §2.6 (new) — Foreign-Key Indexes.** Normative statement of the guarantee: FK columns are indexed on both backends — implicit on MySQL/InnoDB, emitted by DataJoint on PostgreSQL — and the emitted index is **coverage-aware** (skipped when the columns are already a left-prefix of the PK, a declared index, or a wider FK index). Notes that lifecycle on FK drop / `alter()` is out of declaration scope.
- **`reference/specs/database-backends.md` §Backend-Specific Behavior.** Adds a "Foreign-key column index" row (Implicit / Emitted by DataJoint) with a pointer to the declaration spec — the difference is only *who* creates the index.
- **`explanation/referential-integrity.md` §5.** **Flips** the guidance added in #227: it previously told users to declare an explicit `index(...)` on PostgreSQL; that index is now created by the framework, so the mental model "the database indexes foreign-key columns" holds on both backends.

## Why now (not the spec-reshape)

§5's old text becomes actively wrong the moment #1526 merges (it tells users to hand-declare an index the framework now creates), so this shouldn't wait for the larger diagram-operations spec reshape.