### PR TITLE
docs: remove redundant cd pairing in Docker installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ This repository contains the source for the DataJoint documentation, organized u
 ```bash
 # Clone repositories
 git clone https://github.com/datajoint/datajoint-docs.git
-cd datajoint-docs
-cd ..
 git clone https://github.com/datajoint/datajoint-python.git
 cd datajoint-docs
 


### PR DESCRIPTION
The Docker setup snippet in README.md has a `cd datajoint-docs` immediately
followed by `cd ..`, which cancels out and leaves the reader in the same
directory they started in. It's a no-op that adds a confusing extra step
with no effect.

This PR removes those two lines. The remaining instructions are unchanged
and still leave the user inside `datajoint-docs/` before running
`docker compose up`, which is what the bind mount in docker-compose.yaml
(`../datajoint-python`) depends on.