### PR TITLE
chore: ignore mkdocs-jupyter build cache in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ src/llms-full.txt
 site/llms-full.txt
 dj_local_conf.json
 __pycache__/
+.cache/


### PR DESCRIPTION
'mkdocs serve' and 'docker compose up' (MODE=LIVE/BUILD) write build
artifacts to '.cache/mkdocs-jupyter/'. This directory isn't tracked or
committed, but it wasn't previously listed in .gitignore, so it shows up
as untracked clutter in 'git status' for anyone running the docs locally.

This PR adds '.cache/' to .gitignore. No functional change to the build
or site output — purely a local-development quality-of-life fix to prevent accidental 'git add-A' noise.