### PR TITLE
docs: s3 store credentials are optional (ambient AWS identity)

### DIFF
--- a/src/how-to/configure-storage.md
+++ b/src/how-to/configure-storage.md
@@ -80,6 +80,13 @@ Store credentials separately in `.secrets/`:
 └── stores.main.secret_key
 ```
 
+!!! note "Ambient credentials"
+    `access_key` and `secret_key` are **optional**. Omit both to let the AWS
+    default credential chain resolve an ambient identity — an EC2 instance
+    profile, EKS/IRSA service-account role, ECS task role, or a workstation with
+    `AWS_PROFILE`/SSO — the same way the `gcs` and `azure` stores resolve theirs.
+    Provide both only for static keys. (Supplying just one is rejected.)
+
 Paths will be:
 
 - Hash: `s3://my-bucket/my-project/production/_hash/{schema}/{hash}`
@@ -196,8 +203,8 @@ print(dj.config.stores.keys())
 | `stores.<name>.bucket` | S3/GCS | Bucket name |
 | `stores.<name>.endpoint` | S3 | S3 endpoint URL |
 | `stores.<name>.secure` | No | Use HTTPS (default: true) |
-| `stores.<name>.access_key` | S3 | Access key ID (store in `.secrets/`) |
-| `stores.<name>.secret_key` | S3 | Secret access key (store in `.secrets/`) |
+| `stores.<name>.access_key` | No | Access key ID (store in `.secrets/`). Omit both keys to use ambient AWS credentials |
+| `stores.<name>.secret_key` | No | Secret access key (store in `.secrets/`). Omit both keys to use ambient AWS credentials |
 | `stores.<name>.subfolding` | No | Hash-addressed hierarchy: `[2, 2]` for 2-level nesting (default: no subfolding) |
 | `stores.<name>.partition_pattern` | No | Schema-addressed path partitioning: `"subject_id/session_date"` (default: no partitioning) |
 | `stores.<name>.token_length` | No | Random token length for schema-addressed filenames (default: `8`) |

--- a/src/how-to/manage-secrets.md
+++ b/src/how-to/manage-secrets.md
@@ -165,6 +165,13 @@ AKIAIOSFODNN7EXAMPLE
 wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ```
 
+!!! tip "No static keys? Use an ambient identity"
+    On infrastructure with an AWS identity already attached — an EC2 instance
+    profile, EKS/IRSA service-account role, ECS task role, or SSO — omit
+    `access_key` and `secret_key` entirely. The AWS default credential chain
+    resolves the identity (and refreshes it for long-running jobs), so no static
+    keys need to be minted or stored. Set both only for static credentials.
+
 #### Alternative: Environment Variables
 
 !!! version-added "New in 2.2.4"


### PR DESCRIPTION
Documentation follow-up to datajoint-python #1538 (allow s3 stores without static credentials).

`access_key` / `secret_key` are no longer required for `protocol: s3`. Omitting both resolves an ambient AWS identity (EC2 instance profile, EKS/IRSA role, ECS task role, SSO) via the default credential chain — matching how `gcs`/`azure` already behave.

### Changes
- **`configure-storage.md`** — the Configuration Options table listed `access_key`/`secret_key` as **Required: S3**, which is now inaccurate; changed to **No** with a note that omitting both uses ambient credentials. Added an "Ambient credentials" admonition to the S3 Store section.
- **`manage-secrets.md`** — added a tip to the S3 credentials section: on infrastructure with an attached AWS identity, omit both keys so nothing static is minted or stored; the chain also refreshes for long-running jobs. Set both only for static keys; supplying exactly one is rejected.

No behavior claims beyond what #1538 ships.
