### PR TITLE
docs: fix tutorials/installation accuracy, move author tooling to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Contributions welcome! See [contribution guidelines](https://docs.datajoint.com/
 
 **Quick fixes:** Fork, edit markdown in `src/`, submit PR.
 
-**Tutorial notebooks:** Re-execute after changes:
+**Single notebook:** Re-execute one notebook in place:
 ```bash
 docker compose exec docs jupyter nbconvert --to notebook --execute --inplace \
     /main/src/tutorials/YOUR_NOTEBOOK.ipynb
@@ -93,6 +93,19 @@ banner doesn't match `extra.datajoint_version`:
 ```bash
 python scripts/check_notebook_versions.py
 ```
+
+Notes on the execution environment:
+
+- **Credentials.** The Compose databases use the password `tutorial` —
+  `root` for MySQL (`MYSQL_ROOT_PASSWORD`) and `postgres` for PostgreSQL (`POSTGRES_USER` /
+  `POSTGRES_PASSWORD`), both set in `docker-compose.yaml`. `MODE=EXECUTE*` supplies them to the
+  notebooks automatically; you only need them to connect to a Compose database from outside it.
+- **Graphviz.** `dj.Diagram`'s notebook display calls the Graphviz `dot` binary, which the docs
+  image installs. This is why committed diagram outputs always render, and why the same cell
+  fails on a host without Graphviz — see
+  [Installation → Troubleshooting](https://docs.datajoint.com/how-to/installation/#djdiagram-raises-filenotfounderror).
+- **DataJoint version.** `pip_requirements.txt` installs `datajoint@master`, so regenerated
+  outputs track the development branch rather than the last release.
 
 ## Related
 

--- a/src/how-to/installation.md
+++ b/src/how-to/installation.md
@@ -2,6 +2,13 @@
 
 Install DataJoint Python and set up your environment.
 
+## Requirements
+
+- Python 3.10+
+- MySQL 8.0.13+ or PostgreSQL 15+
+- Network access to database server
+- Linux, macOS, or Windows (see [Platform support](#platform-support))
+
 ## Install DataJoint 2.0+
 
 ```bash
@@ -11,7 +18,7 @@ pip install datajoint
 **With optional dependencies:**
 
 ```bash
-# For diagram visualization (matplotlib, ipython)
+# For Diagram.draw(), which renders diagrams into a matplotlib figure
 pip install datajoint[viz]
 
 # For polars DataFrame support
@@ -56,6 +63,10 @@ print(dj.__version__)
 
 DataJoint connects to either MySQL or PostgreSQL. MySQL has been supported since the original release; PostgreSQL support was added in **2.1**, and the `database.name` setting for selecting a non-default PostgreSQL database was added in **2.2.1**. See [Configure Database Connection](configure-database.md#postgresql-backend) for the full configuration reference.
 
+### DataJoint.com (Recommended)
+
+[DataJoint.com](https://datajoint.com) provides fully managed infrastructure for scientific data pipelines—cloud or on-premises—with comprehensive support, automatic backups, object storage, and team collaboration features.
+
 ### Local Development (Docker)
 
 ```bash
@@ -76,10 +87,6 @@ docker run -d \
   postgres:15
 ```
 
-### DataJoint.com (Recommended)
-
-[DataJoint.com](https://datajoint.com) provides fully managed infrastructure for scientific data pipelines—cloud or on-premises—with comprehensive support, automatic backups, object storage, and team collaboration features.
-
 ### Self-Managed Cloud Databases
 
 - **Amazon RDS** — MySQL, Aurora MySQL, PostgreSQL, or Aurora PostgreSQL
@@ -88,12 +95,101 @@ docker run -d \
 
 See [Configure Database Connection](configure-database.md) for connection setup.
 
-## Requirements
+## Your First Pipeline
 
-- Python 3.10+
-- MySQL 8.0.13+ or PostgreSQL 15+
-- Network access to database server
-- Linux, macOS, or Windows (see [Platform support](#platform-support))
+With DataJoint installed and a database reachable, this is the shortest end-to-end path: point
+DataJoint at your database, declare a few tables, insert a row, and run a computation.
+
+Configure your project (see [Configuration](../reference/configuration.md) for the full
+reference):
+
+```bash
+# Non-sensitive settings
+echo '{"database": {"host": "localhost", "port": 3306}}' > datajoint.json
+
+# Credentials, kept out of the project files
+mkdir -p .secrets
+echo "<your-username>" > .secrets/database.user
+echo "<your-password>" > .secrets/database.password
+chmod 600 .secrets/*
+```
+
+Define and populate a simple pipeline:
+
+```python
+import datajoint as dj
+
+schema = dj.Schema('my_pipeline')
+
+@schema
+class Subject(dj.Manual):
+    definition = """
+    subject_id : int32
+    ---
+    name : varchar(100)
+    date_of_birth : date
+    """
+
+@schema
+class Session(dj.Manual):
+    definition = """
+    -> Subject
+    session_idx : int16
+    ---
+    session_date : date
+    """
+
+@schema
+class SessionAnalysis(dj.Computed):
+    definition = """
+    -> Session
+    ---
+    result : float64
+    """
+
+    def make(self, key):
+        # Compute result for this session
+        self.insert1({**key, 'result': 42.0})
+
+# Insert data
+Subject.insert1({'subject_id': 1, 'name': 'M001', 'date_of_birth': '2026-01-15'})
+Session.insert1({'subject_id': 1, 'session_idx': 1, 'session_date': '2026-01-06'})
+
+# Run computations
+SessionAnalysis.populate()
+```
+
+`Subject` and `Session` are entered by hand; `SessionAnalysis` derives from `Session` and fills
+itself when you call `populate()`. That dependency — declared with `->` — is the whole of the
+[Relational Workflow Model](../explanation/relational-workflow-model.md) in miniature.
+
+## Running the Tutorial Notebooks
+
+The [tutorials](../tutorials/index.md) are published with their outputs, so you can read them
+straight through. To run them yourself, add Jupyter to the environment above and get a copy of
+the notebooks — each tutorial page has a download link, or clone the documentation repository
+for all of them at once:
+
+```bash
+pip install jupyterlab
+
+git clone https://github.com/datajoint/datajoint-docs.git
+jupyter lab datajoint-docs/src/tutorials/
+```
+
+Configuration works exactly as in the example above: DataJoint searches upward from the
+notebook's directory for `datajoint.json` and reads credentials from the `.secrets/` directory
+beside it. The repository ships a `datajoint.json` at its root pointing at `localhost:3306` —
+edit it to match your own server, and add your own `.secrets/`. Each tutorial creates its own
+schema, so they do not collide with each other or with your existing databases.
+
+Two dependencies are worth installing up front:
+
+- **Graphviz**, for the `dj.Diagram` cells — see
+  [Troubleshooting](#djdiagram-raises-filenotfounderror) below.
+- **An object store**, for the tutorials that use `<blob@>`, `<npy@>`, or `<attach@>` types. The
+  committed `datajoint.json` writes to a local directory, which needs no extra services; see
+  [Configure Storage](configure-storage.md) to point it elsewhere.
 
 ## Platform support
 
@@ -140,3 +236,18 @@ GRANT ALL PRIVILEGES ON `your_schema%`.* TO 'username'@'%';
 -- PostgreSQL
 GRANT ALL PRIVILEGES ON DATABASE my_db TO username;
 ```
+
+### `dj.Diagram` raises `FileNotFoundError`
+
+Install Graphviz:
+
+```bash
+brew install graphviz                 # macOS
+sudo apt-get install graphviz         # Debian/Ubuntu
+conda install -c conda-forge graphviz # conda, any platform
+```
+
+Diagrams render through `pydot` — installed with DataJoint — which calls the Graphviz `dot`
+executable. Graphviz is a system package, so `pip` cannot supply it. On Windows, install
+from [graphviz.org/download](https://graphviz.org/download/) and put its `bin` directory on
+your `PATH`. Verify with `dot -V`.

--- a/src/index.md
+++ b/src/index.md
@@ -25,7 +25,7 @@
 
     ---
 
-    Build your first pipeline with hands-on Jupyter notebooks
+    Learn DataJoint through complete, worked Jupyter-notebook pipelines
 
     [:octicons-arrow-right-24: Start learning](tutorials/index.md)
 
@@ -65,4 +65,4 @@
 
 ---
 
-**New to DataJoint?** Start with the [:octicons-arrow-right-24: Quick Start tutorial](tutorials/index.md).
+**New to DataJoint?** Visit [:octicons-arrow-right-24: Installation](how-to/installation.md) to install DataJoint and run your first pipeline, then work through the [:octicons-arrow-right-24: Tutorials](tutorials/index.md).

--- a/src/reference/specs/diagram.md
+++ b/src/reference/specs/diagram.md
@@ -491,13 +491,18 @@ combined = dj.Diagram.from_sequence([schema1, schema2, schema3])
 
 Operational methods (`cascade`, `restrict`, `counts`, `prune`) use `networkx`, which is always installed as a core dependency.
 
-Diagram **visualization** requires optional dependencies:
+Diagram **visualization** additionally requires:
 
-```bash
-pip install matplotlib pygraphviz
-```
+- **Graphviz** — the `dot` executable. The default notebook display, `_repr_svg_()`, goes through
+  `make_svg()` → `make_dot()` → pydot → `dot`, so this is the path nearly all usage hits. `pydot`
+  ships with DataJoint, but Graphviz itself is a system package that `pip` cannot install
+  (`brew install graphviz`, `sudo apt-get install graphviz`). Without it, rendering raises
+  `FileNotFoundError` — see
+  [Installation → Troubleshooting](../../how-to/installation.md#djdiagram-raises-filenotfounderror).
+- **matplotlib** — only for `Diagram.draw()`, a separate `make_image()` path that most usage never
+  touches: `pip install datajoint[viz]`.
 
-If visualization dependencies are missing, `dj.Diagram` displays a warning and provides a stub class. Operational methods remain available regardless.
+Operational methods remain available regardless.
 
 ---
 

--- a/src/tutorials/index.md
+++ b/src/tutorials/index.md
@@ -2,76 +2,15 @@
 
 Learn DataJoint by building real pipelines.
 
-These tutorials guide you through building data pipelines step by step. Each tutorial
-is a Jupyter notebook that you can run interactively. Start with the basics and
-progress to domain-specific and advanced topics.
+These tutorials guide you through building data pipelines step by step. Each tutorial is a
+Jupyter notebook, published here with its code and its executed outputs, so you can follow the
+whole pipeline without leaving the page. Start with the basics and progress to domain-specific
+and advanced topics.
 
-## Quick Start
-
-Install DataJoint:
-
-```bash
-pip install datajoint
-```
-
-Configure database credentials in your project (see [Configuration](../reference/configuration.md)):
-
-```bash
-# Create datajoint.json for non-sensitive settings
-echo '{"database": {"host": "localhost", "port": 3306}}' > datajoint.json
-
-# Create secrets directory for credentials
-mkdir -p .secrets
-echo "root" > .secrets/database.user
-echo "password" > .secrets/database.password
-```
-
-Define and populate a simple pipeline:
-
-```python
-import datajoint as dj
-
-schema = dj.Schema('my_pipeline')
-
-@schema
-class Subject(dj.Manual):
-    definition = """
-    subject_id : int32
-    ---
-    name : varchar(100)
-    date_of_birth : date
-    """
-
-@schema
-class Session(dj.Manual):
-    definition = """
-    -> Subject
-    session_idx : int16
-    ---
-    session_date : date
-    """
-
-@schema
-class SessionAnalysis(dj.Computed):
-    definition = """
-    -> Session
-    ---
-    result : float64
-    """
-
-    def make(self, key):
-        # Compute result for this session
-        self.insert1({**key, 'result': 42.0})
-
-# Insert data
-Subject.insert1({'subject_id': 1, 'name': 'M001', 'date_of_birth': '2026-01-15'})
-Session.insert1({'subject_id': 1, 'session_idx': 1, 'session_date': '2026-01-06'})
-
-# Run computations
-SessionAnalysis.populate()
-```
-
-Continue learning with the structured tutorials below.
+**Want to run them yourself?** Every notebook can be downloaded and executed against your own
+MySQL or PostgreSQL database. [Installation](../how-to/installation.md) covers the setup:
+DataJoint, a database, Jupyter, and
+[getting the notebooks](../how-to/installation.md#running-the-tutorial-notebooks).
 
 ## Learning Paths
 
@@ -198,19 +137,3 @@ Extending DataJoint for specialized use cases:
 - [JSON Data Type](advanced/json-type.ipynb) — Semi-structured data in tables
 - [Distributed Computing](advanced/distributed.ipynb) — Multi-process and cluster workflows
 - [Custom Codecs](advanced/custom-codecs.ipynb) — Extending the type system
-
-## Running the Tutorials
-
-```bash
-# Clone the repository
-git clone https://github.com/datajoint/datajoint-docs.git
-cd datajoint-docs
-
-# Start the tutorial environment
-docker compose up -d
-
-# Launch Jupyter
-jupyter lab src/tutorials/
-```
-
-All tutorials use a local MySQL database that resets between sessions.


### PR DESCRIPTION
## What

Fixes the accuracy of the Tutorials and Installation pages, makes Installation the general
setup path a reader follows to run DataJoint — and the tutorial notebooks — on their own
infrastructure, and moves author regeneration tooling to the repository README.

Rebased onto `main` (`df7282e5`) and re-authored as three commits, one concern each.

## Why

The original version of this PR was built on a premise @dimitri-yatsenko corrected in review: it
treated "readers cannot execute the notebooks" as the problem and shipped a documentation-specific
runner to solve it. The actual model is that readers run the tutorials **on their own
infrastructure**, by following general setup instructions — and our Docker / `MODE=EXECUTE*`
stack exists to *generate* the published outputs, which makes it contributor tooling. So the
bundled runner is gone, and Installation now carries the setup that enables self-running.

The underlying accuracy problems the PR found are unchanged and still worth fixing:

### Credentials

The Tutorials page wrote `password` into `.secrets/database.password` while `docker-compose.yaml`
sets `MYSQL_ROOT_PASSWORD: tutorial`. Followed exactly, the first cell calling `dj.Schema()` fails
with `OperationalError: (1045, "Access denied for user 'root'")`. Those credentials belong to our
Compose stack, so they now live in the README with the rest of the author tooling; the reader-facing
snippet in Installation uses placeholders.

### Undocumented Graphviz dependency for `dj.Diagram`

`dj.Diagram(schema)` — cell 12 of the first tutorial, and 22 files across `tutorials/` and
`how-to/` — raises `FileNotFoundError` on any machine without Graphviz. The only mention outside
the docs image was one line in the diagram spec reading `pip install matplotlib pygraphviz`. The
notebook display path is `_repr_svg_()` → `make_svg()` → `make_dot()` → **pydot** (a core
dependency) → the Graphviz `dot` binary; `pip` cannot supply `dot` either way, and matplotlib
serves only the separate `Diagram.draw()` / `make_image()` path. The docs image installs Graphviz
via `apk`, so committed outputs always show clean diagrams regardless of what a reader can render
locally.

### Setup instructions were incomplete and out of order

The page opened with a Quick Start that read as step one of a Docker flow but was actually a
standalone bring-your-own-database walkthrough. The real setup sat at the bottom and omitted half
of what it needed: `docker compose up -d` starts only the databases, `jupyter lab` runs on the
host, and no local Python or Jupyter install was mentioned anywhere.

## Changes

**`how-to/installation.md`** — now the general setup path.

- Requirements to the top; it describes DataJoint generally rather than the hosted options it was
  buried under. DataJoint.com above Local Development, matching its "Recommended" label.
- **Your First Pipeline** — the `Subject`/`Session`/`SessionAnalysis` snippet restored from the old
  Tutorials Quick Start, with placeholder credentials. The simplest end-to-end path against a
  reader's own database, independent of any tutorial infrastructure.
- **Running the Tutorial Notebooks** — Jupyter, where to get the notebooks (per-page download or a
  clone), and how DataJoint resolves `datajoint.json` and `.secrets/` from a notebook's directory.
  Infrastructure-neutral: nothing here depends on our Compose stack.
- Graphviz added as a **troubleshooting symptom** rather than a prerequisite — DataJoint imports,
  connects, defines, inserts, queries, and computes without it.
- Corrected the `datajoint[viz]` comment, which advertised "diagram visualization" but installs
  matplotlib + ipython.

**`tutorials/index.md`** — back to navigational. Quick Start moved to Installation; the
reader-facing "Running the Tutorials" section removed. The intro states that notebooks are
published with their executed outputs, and links readers who want hands-on to the general setup.

**`reference/specs/diagram.md`** — replaced the `pygraphviz` instruction, named the `_repr_svg_`
render path per @dimitri-yatsenko's note so it is unambiguous which path most usage hits, and
dropped the claim that missing dependencies yield a warning and a stub class.

**`README.md`** — the `MODE=EXECUTE*` instructions already lived under Notebook execution policy;
they gain the environment facts the docs body had been carrying: the Compose credentials
(`root`/`tutorial` for MySQL, `postgres`/`tutorial` for PostgreSQL), why the image supplies
Graphviz, and that `pip_requirements.txt` tracks `datajoint@master`.

**`src/index.md`** — the Tutorials card promised "hands-on Jupyter notebooks", which reads as a
runner we ship rather than notebooks a reader runs on their own database. This is the wording that
prompted this PR's original framing, so it is fixed here. The footer link also named a Quick Start
section that no longer exists on the page it pointed to.

## Not in this PR

- **The `dj.Instance` credential placeholder** in `01-first-pipeline.ipynb`. #256 regenerates that
  notebook wholesale, so per review it is held back rather than dropped — it lands as a one-line
  follow-up once #256 merges.
- **The `jupyter` Compose service**, `jupyter_work` volume, and the `jupyterlab` requirement.
  Removed entirely. `docker-compose.yaml`, `pip_requirements.txt`, and `.gitignore` are now
  byte-identical to `main`.

## Verification

`MODE="BUILD" docker compose up --build` exits 0. Both new cross-references resolve
(`installation.md#running-the-tutorial-notebooks`, `installation.md#djdiagram-raises-filenotfounderror`);
the remaining anchor notices are pre-existing and in untouched files, and the stderr warnings are
MkDocs' own deprecation message.

The restored minimal example was run end to end in the docs image against a scratch MySQL:
DataJoint 2.3.3.dev12 connected, `populate()` returned
`[{'subject_id': 1, 'session_idx': 1, 'result': 42.0}]`.

Correction to my original description: it said the render raises `DataJointError`. A missing `dot`
binary surfaces as `FileNotFoundError` — the docs were right and the description was wrong.
