### PR TITLE
docs: correct config precedence and the `.secrets/` file format

### DIFF
--- a/src/how-to/configure-database.md
+++ b/src/how-to/configure-database.md
@@ -30,14 +30,17 @@ This file should be committed to version control.
 
 ## Secrets Directory (`.secrets/`)
 
-Store credentials in `.secrets/datajoint.json`:
+Store credentials as one plain-text file per setting:
 
-```json
-{
-  "database.user": "myuser",
-  "database.password": "mypassword"
-}
+```bash
+mkdir -p .secrets
+echo "myuser"     > .secrets/database.user
+echo "mypassword" > .secrets/database.password
+chmod 600 .secrets/*
 ```
+
+Only `database.user`, `database.password`, and `stores.<name>.<attr>` are read from this
+directory — see [Manage Secrets](manage-secrets.md#option-1-secrets-directory-recommended-for-development).
 
 **Important:** Add `.secrets/` to your `.gitignore`:
 
@@ -60,7 +63,7 @@ Environment variables take precedence over config files.
 ## Configuration Settings
 
 | Setting | Environment | Default | Description |
-|---------|-------------|---------|-------------|
+| --------- | ------------- | --------- | ------------- |
 | `database.host` | `DJ_HOST` | `localhost` | Database server hostname |
 | `database.port` | `DJ_PORT` | Auto | Database server port (3306 for MySQL, 5432 for PostgreSQL) |
 | `database.user` | `DJ_USER` | — | Database username |
@@ -104,8 +107,8 @@ with dj.config.override(database={'host': 'test-server'}):
 
 1. Programmatic settings (highest priority)
 2. Environment variables
-3. `.secrets/datajoint.json`
-4. `datajoint.json`
+3. `datajoint.json`
+4. `.secrets/`
 5. Default values (lowest priority)
 
 ## TLS Configuration
@@ -304,4 +307,3 @@ staging = dj.Instance(host="staging.example.com", user="dev", password="...")
 ```
 
 See [Use Isolated Instances](use-instances.md/) for a complete guide.
-

--- a/src/how-to/configure-storage.md
+++ b/src/how-to/configure-storage.md
@@ -26,8 +26,8 @@ Multiple stores can be configured for different data types or storage tiers. One
 DataJoint loads configuration in priority order:
 
 1. **Environment variables** (highest priority)
-2. **Secrets directory** (`.secrets/`)
-3. **Config file** (`datajoint.json`)
+2. **Config file** (`datajoint.json`)
+3. **Secrets directory** (`.secrets/`)
 4. **Defaults** (lowest priority)
 
 ## Single Store Configuration
@@ -196,7 +196,7 @@ print(dj.config.stores.keys())
 ## Configuration Options
 
 | Option | Required | Description |
-|--------|----------|-------------|
+| -------- | ---------- | ------------- |
 | `stores.default` | Yes | Name of the default store |
 | `stores.<name>.protocol` | Yes | `file`, `s3`, `gcs`, or `azure` |
 | `stores.<name>.location` | Yes | Base path or prefix (includes project context) |
@@ -248,7 +248,7 @@ Schema-addressed storage (`<object@>`, `<npy@>`) does not use subfolding—it us
 ### Filesystem Recommendations
 
 | Filesystem | Subfolding Needed | Notes |
-|------------|-------------------|-------|
+| ------------ | ------------------- | ------- |
 | ext3 | Yes | Limited directory indexing |
 | FAT32/exFAT | Yes | Linear directory scans |
 | NFS | Yes | Network latency amplifies directory lookups |

--- a/src/how-to/deploy-production.md
+++ b/src/how-to/deploy-production.md
@@ -7,7 +7,7 @@ Configure DataJoint for production environments with controlled schema changes a
 Development and production environments have different requirements:
 
 | Concern | Development | Production |
-|---------|-------------|------------|
+| --------- | ------------- | ------------ |
 | Schema changes | Automatic table creation | Controlled, explicit changes only |
 | Naming | Ad-hoc schema names | Consistent project prefixes |
 | Configuration | Local settings | Environment-based |
@@ -50,7 +50,7 @@ Or in `datajoint.json`:
 With `create_tables=False`:
 
 | Action | Development (True) | Production (False) |
-|--------|-------------------|-------------------|
+| -------- | ------------------- | ------------------- |
 | Access existing table | Works | Works |
 | Access missing table | Creates it | **Raises error** |
 | Explicit `Schema(create_tables=True)` | Creates | Creates (override) |
@@ -167,8 +167,8 @@ Use different configurations for development, staging, and production.
 DataJoint loads settings in priority order:
 
 1. **Environment variables** (highest priority)
-2. **Secrets directory** (`.secrets/`)
-3. **Config file** (`datajoint.json`)
+2. **Config file** (`datajoint.json`)
+3. **Secrets directory** (`.secrets/`)
 4. **Defaults** (lowest priority)
 
 ### Development Setup
@@ -331,7 +331,7 @@ if __name__ == '__main__':
 ## Summary
 
 | Setting | Development | Production |
-|---------|-------------|------------|
+| --------- | ------------- | ------------ |
 | `database.create_tables` | `true` | `false` |
 | `database.database_prefix` | `""` or `dev_` | `prod_` |
 | `safemode` | `true` | `false` (automated) |

--- a/src/how-to/manage-secrets.md
+++ b/src/how-to/manage-secrets.md
@@ -7,7 +7,7 @@ Secure configuration management for database credentials, storage access keys, a
 DataJoint separates configuration into sensitive and non-sensitive components:
 
 | Component | Location | Purpose | Version Control |
-|-----------|----------|---------|-----------------|
+| ----------- | ---------- | --------- | ----------------- |
 | **Non-sensitive** | `datajoint.json` | Project settings, defaults | ✅ Commit to git |
 | **Sensitive** | `.secrets/` directory | Credentials, API keys | ❌ Never commit |
 | **Dynamic** | Environment variables | CI/CD, production | ⚠️ Context-dependent |
@@ -19,7 +19,7 @@ DataJoint loads configuration in this priority order (highest to lowest):
 1. **Programmatic settings** — `dj.config['key'] = value`
 2. **Environment variables** — `DJ_HOST`, `DJ_USER`, `DJ_STORES`, etc.
 3. **Project configuration** — `datajoint.json`
-4. **Secrets directory** — `.secrets/stores.<name>.<attr>` (fills attributes the file/env didn't already set)
+4. **Secrets directory** — `.secrets/database.user`, `.secrets/database.password`, `.secrets/stores.<name>.<attr>` (each fills a value the file and env didn't already set)
 5. **Default values** — Built-in defaults
 
 Higher priority sources override lower ones. Set `DJ_IGNORE_CONFIG_FILE=true` *(new in 2.2.4)* to skip both `datajoint.json` and the secrets directory entirely — see [Env-var-only deployments](#env-var-only-deployments) below.
@@ -33,7 +33,8 @@ project/
 ├── datajoint.json               # Non-sensitive settings (commit)
 ├── .gitignore                   # Must include .secrets/
 ├── .secrets/
-│   ├── datajoint.json           # Database credentials
+│   ├── database.user            # Database credentials, one value per file
+│   ├── database.password
 │   ├── stores.main.access_key   # S3/cloud storage credentials
 │   ├── stores.main.secret_key
 │   ├── stores.archive.access_key
@@ -56,13 +57,13 @@ project/
 
 ### Option 1: Secrets Directory (Recommended for Development)
 
-Create `.secrets/datajoint.json`:
+Each secret is a separate plain-text file named for the setting it carries:
 
-```json
-{
-  "database.user": "myuser",
-  "database.password": "mypassword"
-}
+```bash
+mkdir -p .secrets
+echo "myuser"     > .secrets/database.user
+echo "mypassword" > .secrets/database.password
+chmod 600 .secrets/*
 ```
 
 Non-sensitive database settings go in `datajoint.json`:
@@ -122,7 +123,7 @@ Local or network-mounted file systems don't require credentials:
 
 ### S3/MinIO Storage (With Credentials)
 
-#### Config in `datajoint.json` (non-sensitive):
+#### Config in `datajoint.json` (non-sensitive)
 
 ```json
 {
@@ -144,7 +145,7 @@ Local or network-mounted file systems don't require credentials:
 }
 ```
 
-#### Credentials in `.secrets/` directory:
+#### Credentials in `.secrets/` directory
 
 Create separate files for each store's credentials:
 
@@ -202,7 +203,7 @@ If `DJ_STORES` contains invalid JSON, DataJoint raises `ValueError` at config-lo
 ### Database Connections
 
 | Setting | Environment Variable | Description |
-|---------|---------------------|-------------|
+| --------- | --------------------- | ------------- |
 | `database.host` | `DJ_HOST` | Database hostname |
 | `database.port` | `DJ_PORT` | Database port (default: 3306) |
 | `database.user` | `DJ_USER` | Database username |
@@ -256,16 +257,12 @@ chmod 700 .secrets  # Owner-only access
 # 2. Create .gitignore
 echo ".secrets/" >> .gitignore
 
-# 3. Store credentials in .secrets/
-cat > .secrets/datajoint.json <<EOF
-{
-  "database.user": "dev_user",
-  "database.password": "dev_password"
-}
-EOF
+# 3. Store credentials in .secrets/, one value per file
+echo "dev_user"     > .secrets/database.user
+echo "dev_password" > .secrets/database.password
 
 # 4. Set restrictive permissions
-chmod 600 .secrets/datajoint.json
+chmod 600 .secrets/*
 ```
 
 ### Production Environment
@@ -370,7 +367,7 @@ import datajoint as dj
 
 # Config loaded automatically from:
 # 1. datajoint.json (project settings)
-# 2. .secrets/datajoint.json (credentials)
+# 2. .secrets/database.user and .secrets/database.password (credentials)
 conn = dj.conn()
 ```
 
@@ -400,6 +397,10 @@ project/
 ```
 
 **Load by environment:**
+
+These per-environment JSON files are read by the snippet below, not by DataJoint's own
+secrets loader, so they can hold any settings and use any filenames. Assigning through
+`dj.config[...]` is a programmatic override, which outranks every other source.
 
 ```python
 import os
@@ -482,7 +483,7 @@ conn = dj.conn(reset=True)
 git history; until rotation completes, the leaked secret is still valid.
 
 - Database users (`database.user` / `database.password`): change the password
-  on the server, then update your local `.secrets/datajoint.json`.
+  on the server, then update your local `.secrets/database.password`.
 - Object-store credentials (`stores.<name>.access_key` / `secret_key`, or the
   equivalent in your cloud provider): issue new keys and revoke the old ones.
 - Any third-party tokens that appeared in the same file.
@@ -493,9 +494,9 @@ git history; until rotation completes, the leaked secret is still valid.
 clones don't leak it further:
 
 ```bash
-# Remove file from history
+# Remove the leaked file from history (repeat per file, or pass several paths)
 git filter-branch --force --index-filter \
-  "git rm --cached --ignore-unmatch .secrets/datajoint.json" \
+  "git rm --cached --ignore-unmatch .secrets/database.password" \
   --prune-empty --tag-name-filter cat -- --all
 
 # Force push (coordinate with team!)
@@ -505,7 +506,7 @@ git push origin --force --all
 **Step 3 — Verify removal:**
 
 ```bash
-git log --all --full-history -- .secrets/datajoint.json
+git log --all --full-history -- .secrets/database.password
 ```
 
 ## Configuration Templates
@@ -520,12 +521,10 @@ git log --all --full-history -- .secrets/datajoint.json
 }
 ```
 
-```json
-// .secrets/datajoint.json
-{
-  "database.user": "root",
-  "database.password": "simple"
-}
+```
+// .secrets/ directory
+.secrets/database.user                  # root
+.secrets/database.password              # simple
 ```
 
 ### Production with S3 Storage
@@ -551,7 +550,8 @@ git log --all --full-history -- .secrets/datajoint.json
 
 ```
 // .secrets/ directory
-.secrets/datajoint.json                 # Database credentials
+.secrets/database.user                  # Database username
+.secrets/database.password              # Database password
 .secrets/stores.main.access_key         # S3 access key
 .secrets/stores.main.secret_key         # S3 secret key
 ```

--- a/src/how-to/migrate-to-v20.md
+++ b/src/how-to/migrate-to-v20.md
@@ -14,7 +14,7 @@ Upgrade existing pipelines from legacy DataJoint (pre-2.0) to DataJoint 2.0+.
 ### System Requirements
 
 | Component | Legacy (pre-2.0) | DataJoint 2.0+ |
-|-----------|-----------------|---------------|
+| ----------- | ----------------- | --------------- |
 | **Python** | 3.8+ | **3.10+** |
 | **MySQL** | 5.7+ | **8.0+** |
 | **Character encoding** | (varies) | **UTF-8 (utf8mb4)** |
@@ -83,7 +83,7 @@ Tests provide immediate ROI during migration and ongoing value for development.
 DataJoint 2.0 introduces a unified type system with three tiers:
 
 | Tier | Description | Examples | Migration |
-|------|-------------|----------|-----------|
+| ------ | ------------- | ---------- | ----------- |
 | **Native** | Raw MySQL types | `int unsigned`, `tinyint` | Auto-converted to core types |
 | **Core** | Standardized portable types | `int64`, `float64`, `varchar(100)`, `json` | Phase I |
 | **Codec** | Serialization to blob or storage | `<blob>`, `<blob@store>`, `<npy@>` | Phase I-III |
@@ -97,7 +97,7 @@ DataJoint 2.0 makes serialization **explicit** with codecs. In pre-2.0, `longblo
 #### Migration: Legacy → 2.0
 
 | pre-2.0 (Implicit) | 2.0 (Explicit) | Storage | Migration |
-|-------------------|----------------|---------|-----------|
+| ------------------- | ---------------- | --------- | ----------- |
 | `longblob` | `<blob>` | In-table | Phase I code, Phase III data |
 | `mediumblob` | `<blob>` | In-table | Phase I code, Phase III data |
 | `blob`, `tinyblob` | `<blob>` | In-table | Phase I code, Phase III data |
@@ -142,7 +142,7 @@ COMMENT ':<blob@store>:large array in object storage'
 In pre-2.0, `longblob` columns automatically deserialized Python objects using DataJoint's binary serialization format. DataJoint 2.0 identifies blob columns by checking for `:<blob>:` in the column comment. **Without this marker, blob columns are treated as raw binary data and will NOT be deserialized.**
 
 | Column Comment | DataJoint 2.0 Behavior |
-|----------------|----------------------|
+| ---------------- | ---------------------- |
 | `:<blob>:neural data` | ✓ Deserializes to Python/NumPy objects |
 | `neural data` (no marker) | ✗ Returns raw bytes (no deserialization) |
 
@@ -237,7 +237,7 @@ DataJoint 2.0 replaces `external.*` with unified `stores.*` configuration:
 ### Query API Changes
 
 | pre-2.0 | 2.0 | Phase |
-|--------|-----|-------|
+| -------- | ----- | ------- |
 | `table.fetch()` | `table.to_arrays()` or `table.to_dicts()` | I |
 | `table.fetch(..., format="frame")` | `table.to_pandas(...)` | I |
 | `table.fetch1()` | `table.fetch1()` (unchanged) | — |
@@ -259,7 +259,7 @@ DataJoint 2.0 replaces `external.*` with unified `stores.*` configuration:
 ## Migration Overview
 
 | Phase | Goal | Code Changes | Schema/Store Changes | Production Impact |
-|-------|------|--------------|----------------------|-------------------|
+| ------- | ------ | -------------- | ---------------------- | ------------------- |
 | **I** | Branch & code migration | All API updates, type syntax, **all codecs** (in-table and in-store) | Empty `_v2` schemas + test stores | **None** |
 | **II** | Test compatibility | — | Populate `_v2` schemas with sample data, test equivalence | **None** |
 | **III** | Migrate production data | — | Multiple migration options | **Varies** |
@@ -690,7 +690,7 @@ Now configure database connection and stores.
 
 DataJoint 2.0 uses:
 
-- **`.secrets/datajoint.json`** for credentials (gitignored)
+- **`.secrets/database.user`** and **`.secrets/database.password`** for credentials (gitignored)
 - **`datajoint.json`** for non-sensitive settings (checked in)
 - **`stores.*`** instead of `external.*`
 
@@ -707,18 +707,18 @@ echo ".secrets/" >> .gitignore
 python -c "import datajoint as dj; dj.config.save_template()"
 ```
 
-**Edit `.secrets/datajoint.json`:**
-```json
-{
-  "database.host": "your-database-host",
-  "database.user": "your-username",
-  "database.password": "your-password"
-}
+**Fill in the credential files under `.secrets/`** — one value per file:
+```bash
+echo "your-username" > .secrets/database.user
+echo "your-password" > .secrets/database.password
 ```
 
-**Edit `datajoint.json`:**
+**Edit `datajoint.json`**:
 ```json
 {
+  "database": {
+    "host": "your-database-host"
+  },
   "loglevel": "INFO",
   "safemode": true,
   "display.limit": 12,
@@ -1077,7 +1077,7 @@ Convert ALL types and codecs in Phase I:
 **Integer and Float Types:**
 
 | pre-2.0 | 2.0 | Category |
-|--------|-----|----------|
+| -------- | ----- | ---------- |
 | `int unsigned` | `int64` | Core type |
 | `int` | `int32` | Core type |
 | `smallint unsigned` | `int32` | Core type |
@@ -1113,7 +1113,7 @@ precision, so converting to `decimal(M,D)` is the recommended move.
 **String, Date, and Structured Types:**
 
 | pre-2.0 | 2.0 | Notes |
-|--------|-----|-------|
+| -------- | ----- | ------- |
 | `varchar(N)`, `char(N)` | Unchanged | Core types |
 | `date` | Unchanged | Core type |
 | `enum('a', 'b')` | Unchanged | Core type |
@@ -1129,7 +1129,7 @@ precision, so converting to `decimal(M,D)` is the recommended move.
 **Codecs:**
 
 | pre-2.0 | 2.0 | Category |
-|--------|-----|----------|
+| -------- | ----- | ---------- |
 | `longblob` | `<blob>` | Codec (in-table) |
 | `attach` | `<attach>` | Codec (in-table) |
 | `blob@store` | `<blob@store>` | Codec (in-store) |

--- a/src/reference/configuration.md
+++ b/src/reference/configuration.md
@@ -9,14 +9,14 @@ DataJoint configuration options and settings.
 Configuration is loaded in priority order:
 
 1. **Environment variables** (highest priority)
-2. **Secrets directory** (`.secrets/`)
-3. **Config file** (`datajoint.json`)
+2. **Config file** (`datajoint.json`)
+3. **Secrets directory** (`.secrets/`)
 4. **Defaults** (lowest priority)
 
 ## Database Settings
 
 | Setting | Environment | Default | Description |
-|---------|-------------|---------|-------------|
+| --------- | ------------- | --------- | ------------- |
 | `database.backend` | `DJ_BACKEND` | `mysql` | Database backend: `mysql` or `postgresql` *(new in 2.1)* |
 | `database.host` | `DJ_HOST` | `localhost` | Database server hostname |
 | `database.port` | `DJ_PORT` | `3306`/`5432` | Database server port (auto-detects from backend) |
@@ -53,7 +53,7 @@ DataJoint uses two default settings to reflect the architectural distinction bet
 **Common settings (all protocols):**
 
 | Setting | Required | Description |
-|---------|----------|-------------|
+| --------- | ---------- | ------------- |
 | `stores.<name>.protocol` | Yes | Storage protocol: `file`, `s3`, `gcs`, `azure` |
 | `stores.<name>.location` | Yes | Base path or prefix (includes project context) |
 | `stores.<name>.hash_prefix` | No | Path prefix for hash-addressed section (default: `"_hash"`) |
@@ -90,7 +90,7 @@ Prefixes must be mutually exclusive (no prefix can be a parent/child of another)
 **S3-specific settings:**
 
 | Setting | Required | Description |
-|---------|----------|-------------|
+| --------- | ---------- | ------------- |
 | `stores.<name>.endpoint` | Yes | S3 endpoint URL (e.g., `s3.amazonaws.com`) |
 | `stores.<name>.bucket` | Yes | Bucket name |
 | `stores.<name>.access_key` | Yes | S3 access key ID |
@@ -100,7 +100,7 @@ Prefixes must be mutually exclusive (no prefix can be a parent/child of another)
 **GCS-specific settings:**
 
 | Setting | Required | Description |
-|---------|----------|-------------|
+| --------- | ---------- | ------------- |
 | `stores.<name>.bucket` | Yes | GCS bucket name |
 | `stores.<name>.token` | Yes | Authentication token path |
 | `stores.<name>.project` | No | GCS project ID |
@@ -108,7 +108,7 @@ Prefixes must be mutually exclusive (no prefix can be a parent/child of another)
 **Azure-specific settings:**
 
 | Setting | Required | Description |
-|---------|----------|-------------|
+| --------- | ---------- | ------------- |
 | `stores.<name>.container` | Yes | Azure container name |
 | `stores.<name>.account_name` | Yes | Storage account name |
 | `stores.<name>.account_key` | Yes | Storage account key |
@@ -154,7 +154,7 @@ If table lacks partition attributes, it follows normal path structure.
 ## Jobs Settings
 
 | Setting | Default | Description |
-|---------|---------|-------------|
+| --------- | --------- | ------------- |
 | `jobs.auto_refresh` | `True` | Auto-refresh job queue on populate |
 | `jobs.keep_completed` | `False` | Retain success records in jobs table |
 | `jobs.stale_timeout` | `3600` | Seconds before stale job cleanup |
@@ -166,7 +166,7 @@ If table lacks partition attributes, it follows normal path structure.
 ## Display Settings
 
 | Setting | Environment | Default | Description |
-|---------|-------------|---------|-------------|
+| --------- | ------------- | --------- | ------------- |
 | `display.limit` | — | `12` | Max rows to display |
 | `display.width` | — | `14` | Column width |
 | `display.show_tuple_count` | — | `True` | Show row count in output |
@@ -175,7 +175,7 @@ If table lacks partition attributes, it follows normal path structure.
 ## Top-Level Settings
 
 | Setting | Environment | Default | Description |
-|---------|-------------|---------|-------------|
+| --------- | ------------- | --------- | ------------- |
 | `loglevel` | `DJ_LOG_LEVEL` | `INFO` | Log level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |
 | `safemode` | — | `True` | Require confirmation for destructive operations |
 | `enable_python_native_blobs` | — | `True` | Allow Python-native blob serialization |
@@ -326,7 +326,7 @@ schema = inst.Schema("my_schema")
 ### Parameters
 
 | Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
+| ----------- | ------ | --------- | ------------- |
 | `host` | str | — | Database hostname (required) |
 | `user` | str | — | Database username (required) |
 | `password` | str | — | Database password (required) |
@@ -337,7 +337,7 @@ schema = inst.Schema("my_schema")
 ### Attributes and Methods
 
 | Member | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `inst.config` | This Instance's Config object |
 | `inst.connection` | This Instance's Connection object |
 | `inst.Schema(name)` | Create a Schema bound to this Instance |


### PR DESCRIPTION
## What

Corrects two configuration errors in the docs: the precedence order between
`datajoint.json` and `.secrets/`, which four pages had inverted, and the `.secrets/`
credential format, which the docs recommended in a shape DataJoint never reads.

## Why

Both were found by following the documented setup and watching it fail, then checking the
loader in `datajoint-python` 2.3 rather than trusting any prose.

### Precedence between `datajoint.json` and `.secrets/` was inverted

Four pages said the secrets directory outranks the config file. It is the reverse: two
separate mechanisms in `settings.py` make the file win.

- `_update_from_flat_dict` skips a file value when its environment variable is set, logging
  *"Skipping {key} from file (env var {var} takes precedence)"*.
- `_load_secrets` assigns only when the target is still unset (`and self.database.user is
  None`), and for stores `if attr not in self.stores[store_name]` — carrying the comment
  *"Only set if not already present (config / env vars win)"*.

Confirmed by running the loader against fixtures with the same key in all three sources:

| Setup | Result |
| --- | --- |
| `datajoint.json` user vs `.secrets/database.user` | the file value |
| both, plus `DJ_USER` | the env value |
| user absent from the file | the `.secrets/` value |

So the order is: programmatic, environment variables, `datajoint.json`, `.secrets/`,
defaults. This matters in the common local-development case — a stale `user` left in a
committed `datajoint.json` silently overrides the one in `.secrets/`, which the old
ordering said should win.

`manage-secrets.md` and `specs/object-store-configuration.md` already had it right.

### `.secrets/datajoint.json` is never read

`manage-secrets.md` recommended it as "Option 1: Secrets Directory (Recommended for
Development)", and three pages repeated the shape. The secrets directory is read file by
file: only `database.user`, `database.password`, and `stores.<name>.<attr>` are recognized.
A JSON file there contributes nothing — `dj.config.database.user` and `.password` both come
back `None` — so the recommended setup left credentials unset and produced the very
access-denied error it was meant to prevent. Nothing warns; the file is simply ignored.

`migrate-to-v20.md` was therefore incorrect, instructing migrators to put `database.host` into
the secrets directory, which does not read that key at all.

## Changes

**Precedence lists corrected** — `reference/configuration.md`,
`how-to/configure-storage.md`, `how-to/deploy-production.md`, and
`how-to/configure-database.md`, now all consistent with `manage-secrets.md`.

**`.secrets/` format corrected to one plain-text file per setting:**

- **`manage-secrets.md`** — Option 1, the directory-structure tree, the
  Security-Best-Practices block, both configuration templates, and the leaked-credential
  section, whose rotation step and `git filter-branch` example both named the file that
  cannot hold credentials.
- **`configure-database.md`** — the secrets-directory section, plus a pointer to the
  supported key names.
- **`migrate-to-v20.md`** — credential files written per key; `database.host` moved into the
  `datajoint.json` example where it is actually read.

**Left as-is:** the Multi-Environment pattern in `manage-secrets.md` keeps its
`.secrets/datajoint.{env}.json` files. That snippet reads them itself and assigns through
`dj.config[...]`, so it works regardless of the loader — now stated explicitly so it does
not read as contradicting the corrected format.

## Notes

`mkdocs build` is clean — no content warnings, and no new link notices on the six edited
pages.

The module docstring in `datajoint-python`'s `settings.py` states the inverted precedence
and contradicts its own implementation twenty lines below it. That is the likely origin of
the error in these pages and wants a separate upstream fix.
