### PR TITLE
docs(data-integrity): domain integrity extends to OAS + codec types

### DIFF
--- a/src/explanation/data-integrity.md
+++ b/src/explanation/data-integrity.md
@@ -75,9 +75,24 @@ each column: `int32`, `int64`, `float32`, `float64`, `decimal(p, s)`,
 `varchar(N)`, `char(N)`, `date`, `datetime`, `uuid`, and `enum(...)` for
 closed categorical sets. Choosing `sex : enum('M', 'F', 'U')` instead of a
 free-text field means an invalid category can never be stored, and
-`decimal(5, 2)` fixes both magnitude and precision. The type system is
-extensible: custom codecs attach domain rules to structured and object-backed
-attributes as well.
+`decimal(5, 2)` fixes both magnitude and precision.
+
+The type system is **extensible**, and this is where DataJoint carries domain
+integrity beyond the scalar SQL types. Through
+[Object-Augmented Schemas](data-pipelines.md#object-augmented-schemas) and the
+[codec system](../how-to/create-custom-codec.md), an attribute can hold a
+domain-specific datatype — a calcium-imaging movie, a spike-sorting result, a
+fitted model — whose contents live in object storage but are addressed and
+governed by the schema. A [codec](../reference/specs/codec-api.md) *defines* that
+datatype: it can run **arbitrary validation checks** when a value is encoded —
+rejecting anything outside the domain's valid set, exactly as `enum` does for a
+category — and it exposes **typed access methods** for reading the value back.
+Crucially, the object write is bound to the **same database transaction** as the
+row that references it, so an object-backed attribute obeys the same discipline
+as any scalar column: the row and its object commit together or not at all, and
+a failed check or write rolls the whole insert back. Domain integrity therefore
+holds uniformly — from `int32` and `enum` to arbitrary structured and
+object-backed types — under one consistency guarantee.
 
 ### 2. Completeness
 

--- a/src/explanation/data-integrity.md
+++ b/src/explanation/data-integrity.md
@@ -87,12 +87,16 @@ governed by the schema. A [codec](../reference/specs/codec-api.md) *defines* tha
 datatype: it can run **arbitrary validation checks** when a value is encoded —
 rejecting anything outside the domain's valid set, exactly as `enum` does for a
 category — and it exposes **typed access methods** for reading the value back.
-Crucially, the object write is bound to the **same database transaction** as the
-row that references it, so an object-backed attribute obeys the same discipline
-as any scalar column: the row and its object commit together or not at all, and
-a failed check or write rolls the whole insert back. Domain integrity therefore
-holds uniformly — from `int32` and `enum` to arbitrary structured and
-object-backed types — under one consistency guarantee.
+The check runs at encode time, *before* anything is written, so an invalid
+value is rejected up front and the row that would reference it is never
+committed — the same guarantee scalar columns give, extended to object-backed
+types. The stored object is integrated with the row's lifecycle rather than
+being an opaque side file: it is addressed by the schema and reclaimed by
+[garbage collection](referential-integrity.md) when no row references it
+(object stores are not transactional participants, so a failed insert leaves at
+most an unreferenced object, never a bad value in the table).
+Domain integrity therefore holds uniformly — from `int32` and `enum` to
+arbitrary structured and object-backed types.
 
 ### 2. Completeness
 

--- a/src/explanation/data-integrity.md
+++ b/src/explanation/data-integrity.md
@@ -92,7 +92,7 @@ value is rejected up front and the row that would reference it is never
 committed — the same guarantee scalar columns give, extended to object-backed
 types. The stored object is integrated with the row's lifecycle rather than
 being an opaque side file: it is addressed by the schema and reclaimed by
-[garbage collection](referential-integrity.md) when no row references it
+[garbage collection](../how-to/garbage-collection.md) when no row references it
 (object stores are not transactional participants, so a failed insert leaves at
 most an unreferenced object, never a bad value in the table).
 Domain integrity therefore holds uniformly — from `int32` and `enum` to


### PR DESCRIPTION
Expands the **Domain integrity** section of [Data Integrity](https://docs.datajoint.com/explanation/data-integrity/) to cover what was only gestured at ("custom codecs attach domain rules … as well").

The added paragraph explains that Object-Augmented Schemas + the codec system carry domain integrity **beyond scalar SQL types**:
- A **codec defines a domain-specific datatype** (a movie, a sorting result, a fitted model) whose contents live in object storage but are addressed and governed by the schema.
- It can run **arbitrary validation checks** on encode (rejecting out-of-domain values, as `enum` does for a category) and expose **typed access methods** on decode.
- Object stores are **not transactional participants**: the codec validates and encodes *before* anything is written, the **row commit is the atomic act** that makes an object referenced, and a failed check aborts the insert with nothing written; unreferenced objects are removed by garbage collection.

Net: domain integrity holds uniformly from `int32`/`enum` to arbitrary structured and object-backed types, under one consistency guarantee. Links to the OAS explanation, the custom-codec how-to, and the codec API spec.