### PR TITLE
docs(migration): migrate 0.x directly to the latest 2.x (currently 2.3)

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -99,7 +99,7 @@ nav:
           - Manage Large Data: how-to/manage-large-data.md
           - Clean Up Storage: how-to/garbage-collection.md
       - Maintenance:
-          - Migrate to 2.0: how-to/migrate-to-v20.md
+          - Migrate to 2.x: how-to/migrate-to-v20.md
           - Alter Tables: how-to/alter-tables.md
           - Backup and Restore: how-to/backup-restore.md
       - Testing:

--- a/src/how-to/migrate-to-v20.md
+++ b/src/how-to/migrate-to-v20.md
@@ -1,9 +1,26 @@
-# Migrate to DataJoint 2.0
+# Migrate to DataJoint 2.x
 
-Upgrade existing pipelines from legacy DataJoint (pre-2.0) to DataJoint 2.0+.
+Upgrade existing pipelines from legacy DataJoint (the pre-2.0 `0.x` series)
+directly to the latest DataJoint 2.x — currently **2.3**.
 
 > **This guide is optimized for AI coding assistants.** Point your AI agent at this
 > document and it will execute the migration with your oversight.
+
+!!! tip "Which version do I migrate to?"
+
+    Migrate **straight to the latest 2.x release** (currently 2.3) — there is no
+    need to step through 2.0 → 2.1 → 2.2 → 2.3. A single upgrade takes a `0.x`
+    pipeline all the way to 2.3.
+
+    Everything this guide calls "2.0" is the **migration surface** — the type
+    system, explicit codecs, and unified `stores` introduced in 2.0. Later
+    releases build on it without adding migration steps: **2.1** added the
+    PostgreSQL backend and configurable diagram layout, **2.2** added the jobs
+    layer and diagram operations, and **2.3** added the upstream/provenance API.
+    Installing the latest release gives you all of them.
+
+    Complete the migration while on **2.3 or earlier**: the `datajoint.migrate`
+    helper is scheduled for removal in 2.4/2.5.
 
 !!! warning "Temporary module"
 


### PR DESCRIPTION
The migration guide framed the destination only as "2.0", which understated it. This clarifies **which versions you migrate to**.

### Changes
- **Intro + title** — now "Migrate to DataJoint 2.x": a legacy (`0.x`) pipeline migrates **directly to the latest 2.x release (currently 2.3)** in a single upgrade; there's no need to step through 2.0 → 2.1 → 2.2 → 2.3. (Nav label updated to match.)
- **New "Which version do I migrate to?" tip** — explains that everything the guide calls "2.0" is the *migration surface* (type system, explicit codecs, unified `stores`), and that 2.1 (PostgreSQL backend), 2.2 (jobs layer, diagram ops), and 2.3 (upstream/provenance API) build on it with **no extra migration steps**. Installing the latest release gives you all of them. Reiterates completing the migration while on 2.3 or earlier (the `datajoint.migrate` helper is removed in 2.4/2.5).

Body "2.0" references are left as-is where they correctly describe the 2.0 feature baseline. No broken anchors (verified nothing links to the old H1 slug).
